### PR TITLE
feat(stream)!: Replace FlowStreamResponse with GenkitStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 0.8.0
+
+- **BREAKING CHANGE**: The `.stream()` method now returns a `GenkitStream` instead of a `FlowStreamResponse` record. `GenkitStream` is a `Stream` that also provides a `finalResult` property to access the flow's final, non-streamed response. This simplifies the API for handling streaming responses.
+
+  **Migration**:
+  Code that previously looked like this:
+  ```dart
+  final (:stream, :response) = myAction.stream(input: ...);
+  await for (final chunk in stream) {
+    // ...
+  }
+  final finalResult = await response;
+  ```
+
+  Should be updated to:
+  ```dart
+  final stream = myAction.stream(input: ...);
+  await for (final chunk in stream) {
+    // ...
+  }
+  final finalResult = stream.finalResult;
+  ```
+
 ## 0.7.0
 
 - **BREAKING CHANGE**: The package has been renamed from `package:genkit/genkit.dart` to `package:genkit/client.dart`. You will need to update your import statements.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ try {
 
 ## Calling Streaming Flows
 
-Use the `stream` method for flows that stream multiple chunks of data and then return a final response. It returns a `FlowStreamResponse` containing both the `stream` and the `response` future. The final response is optional (`Future<O?>`) because the stream may be cancelled before a final response is received, in which case the future will complete with `null`.
+Use the `stream` method for flows that stream multiple chunks of data and then return a final response. It returns a `GenkitStream` which is a `Stream` of chunks and also provides access to the `finalResult` of the flow. The `finalResult` is optional because the stream may be cancelled before a final response is received, in which case it will be `null`.
 
 ### Example: String Input, Streaming String Chunks, String Final Response
 
@@ -106,16 +106,16 @@ final streamAction = defineRemoteAction(
 );
 
 try {
-  final streamResponse = streamAction.stream(
+  final stream = streamAction.stream(
     input: 'Tell me a short story about a Dart developer.',
   );
 
   print('Streaming chunks:');
-  await for (final chunk in streamResponse.stream) {
+  await for (final chunk in stream) {
     print('Chunk: $chunk');
   }
 
-  final finalResult = await streamResponse.response;
+  final finalResult = stream.finalResult;
   if (finalResult != null) {
     print('\nFinal Response: $finalResult');
   } else {
@@ -148,14 +148,14 @@ final streamAction = defineRemoteAction(
 final input = MyInput(message: 'Stream this data', count: 5);
 
 try {
-  final streamResponse = streamAction.stream(input: input);
+  final stream = streamAction.stream(input: input);
 
   print('Streaming chunks:');
-  await for (final chunk in streamResponse.stream) {
+  await for (final chunk in stream) {
     print('Chunk: ${chunk.content}');
   }
 
-  final finalResult = await streamResponse.response;
+  final finalResult = stream.finalResult;
   if (finalResult != null) {
     print('\nFinal Response: ${finalResult.reply}');
   } else {
@@ -253,7 +253,7 @@ final generateFlow = defineRemoteAction(
   fromStreamChunk: (json) => GenerateResponseChunk.fromJson(json),
 );
 
-final (:stream, :response) = generateFlow.stream(
+final stream = generateFlow.stream(
   input: Message(role: Role.user, content: [TextPart(text: "hello")]),
 );
 
@@ -263,7 +263,7 @@ await for (final chunk in stream) {
   print('Chunk: ${chunk.text}');
 }
 
-final finalResult = await response;
+final finalResult = stream.finalResult;
 // The .text getter also works on the final response
 if (finalResult != null) {
   print('Final Response: ${finalResult.text}');

--- a/example/genkit_example.dart
+++ b/example/genkit_example.dart
@@ -16,7 +16,7 @@ void printServerInstructions() {
     '| \$ cd example/server                                             |\n'
     '| \$ npm i                                                         |\n'
     '| \$ npm start                                                     |\n'
-    '-------------------------------------------------------------------\n'
+    '-------------------------------------------------------------------\n',
   );
 }
 
@@ -59,8 +59,7 @@ Future<void> _runThrowingStreamingFlow() async {
     fromStreamChunk: (json) => json,
   );
   try {
-    final (:stream, :response) = streamyThrowy.stream(input: 5);
-
+    final stream = streamyThrowy.stream(input: 5);
     await for (final chunk in stream) {
       print('Chunk: $chunk');
     }
@@ -97,7 +96,7 @@ Future<void> _runStreamingFlow() async {
     fromResponse: (json) => StreamOutput.fromJson(json),
     fromStreamChunk: (json) => StreamOutput.fromJson(json),
   );
-  final (:stream, :response) = streamObjectsFlow.stream(
+  final stream = streamObjectsFlow.stream(
     input: StreamInput(prompt: 'What is Genkit?'),
   );
 
@@ -106,7 +105,7 @@ Future<void> _runStreamingFlow() async {
     print('Chunk: ${chunk.text}');
   }
   print('\nStream finished.');
-  final finalResult = await response;
+  final finalResult = stream.finalResult;
   print('Final Response: ${finalResult?.text}');
 }
 
@@ -118,7 +117,7 @@ Future<void> _runStreamingGenerateFlow() async {
     fromResponse: (json) => GenerateResponse.fromJson(json),
     fromStreamChunk: (json) => GenerateResponseChunk.fromJson(json),
   );
-  final (:stream, :response) = generateFlow.stream(
+  final stream = generateFlow.stream(
     input: [
       Message(
         role: Role.user,
@@ -140,7 +139,7 @@ Future<void> _runStreamingGenerateFlow() async {
     print('Chunk: ${chunk.text}');
   }
   print('\nStream finished.');
-  final finalResult = await response;
+  final finalResult = stream.finalResult;
   print('Final Response: ${finalResult?.text}');
 }
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -15,8 +15,7 @@
 /// Support for Genkit client operations in Dart.
 library;
 
-export 'src/client.dart' show RemoteAction, defineRemoteAction;
+export 'src/client.dart' show RemoteAction, defineRemoteAction, GenkitStream;
 export 'src/exception.dart' show GenkitException;
-export 'src/flow_response.dart' show FlowStreamResponse;
 export 'src/genkit_schemas.dart';
 export 'src/common.dart';

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -108,14 +108,14 @@ void main() {
           );
         });
 
-        final streamResponse = remoteAction.stream(input: input);
+        final stream = remoteAction.stream(input: input);
         final chunks = <String>[];
 
-        await for (final chunk in streamResponse.stream) {
+        await for (final chunk in stream) {
           chunks.add(chunk);
         }
 
-        final finalResponse = await streamResponse.response;
+        final finalResponse = stream.finalResult;
 
         expect(chunks, expectedChunks);
         expect(finalResponse, expectedResponse);


### PR DESCRIPTION
This commit introduces a breaking change to the streaming API to simplify its usage.

The `.stream()` method on a `RemoteAction` now returns a `GenkitStream` object directly, instead of a `FlowStreamResponse` record.

`GenkitStream` is a `Stream` subclass, so it can be used directly in `await for` loops. It also provides a `finalResult` property to access the flow's final, non-streamed response, replacing the previous `response` future from the record.

This change makes the API more intuitive and reduces boilerplate when handling streaming flows.

BREAKING CHANGE: The `.stream()` method now returns a `GenkitStream` instead of a `FlowStreamResponse` record (`({Future<O?> response, Stream<S> stream})`).

Migration:
- Replace `final (:stream, :response) = myAction.stream(...)` with `final stream = myAction.stream(...)`.
- Access the final result via `stream.finalResult` instead of `await response`.