### PR TITLE
genkit: clear generic parameter names

### DIFF
--- a/packages/genkit/lib/src/core/flow.dart
+++ b/packages/genkit/lib/src/core/flow.dart
@@ -14,7 +14,8 @@
 
 import 'action.dart';
 
-class Flow<I, O, S, Init> extends Action<I, O, S, Init> {
+class Flow<Input, Output, Chunk, Init>
+    extends Action<Input, Output, Chunk, Init> {
   Flow({
     required super.name,
     required super.fn,


### PR DESCRIPTION
E, K, V are fine when things are simple
