### PR TITLE
fix(genkit): ensure _repairJson only appends ': null' for object keys

### DIFF
--- a/packages/genkit/lib/src/extract.dart
+++ b/packages/genkit/lib/src/extract.dart
@@ -183,9 +183,11 @@ String _repairJson(String json) {
   }
 
   // 2. Fix partial keys (e.g. {"key" -> {"key": null)
-  final tailStringPattern = RegExp(r'([{,])\s*("(?:[^"\\]|\\.)*")\s*$');
-  if (tailStringPattern.hasMatch(repaired)) {
-    repaired += ': null';
+  if (stack.isNotEmpty && stack.last == '}') {
+    final tailStringPattern = RegExp(r'([{,])\s*("(?:[^"\\]|\\.)*")\s*$');
+    if (tailStringPattern.hasMatch(repaired)) {
+      repaired += ': null';
+    }
   }
 
   // 3. Handle trailing comma or colon

--- a/packages/genkit/test/extract_test.dart
+++ b/packages/genkit/test/extract_test.dart
@@ -222,5 +222,19 @@ void main() {
         equals([1, 2]),
       );
     });
+
+    test('handles incomplete string inside an array', () {
+      expect(
+        extractJson(
+          '["1/4 cup lemon juice", "1/4 cup olive oil", "1/4 cup nutritional yeast (optional, for cheesy',
+          allowPartial: true,
+        ),
+        equals([
+          "1/4 cup lemon juice",
+          "1/4 cup olive oil",
+          "1/4 cup nutritional yeast (optional, for cheesy",
+        ]),
+      );
+    });
   });
 }


### PR DESCRIPTION
Check the stack balance before assuming an unterminated string is a key. This prevents incorrectly transforming partial arrays like `["item` into invalid JSON like `["item": null]`.