### PR TITLE
refactor: internal Dart style tweaks

### DIFF
--- a/packages/schemantic/lib/schemantic.dart
+++ b/packages/schemantic/lib/schemantic.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:convert';
+
 import 'package:json_schema_builder/json_schema_builder.dart' as jsb;
 
 export 'package:json_schema_builder/json_schema_builder.dart'
@@ -23,8 +24,8 @@ export 'package:schemantic/src/flatten.dart' show SchemaFlatten;
 
 /// Annotation to mark a class as a schema definition.
 ///
-/// This annotation triggers the generation of a counterpart `Schema.g.dart` file
-/// with a concrete implementation of the schema class and a type utility.
+/// This annotation triggers the generation of a counterpart `Schema.g.dart`
+/// file with a concrete implementation of the schema class and a type utility.
 class Schematic {
   /// A description of the schema, to be included in the generated JSON Schema.
   final String? description;
@@ -40,13 +41,16 @@ class AnyOf {
 
 /// Annotation to customize valid JSON fields.
 ///
-/// Use this annotation (or a subclass like [StringField], [IntegerField]) on a getter
-/// to specify a custom JSON key name, description, and other schema constraints.
+/// Use this annotation (or a subclass like [StringField], [IntegerField]) on a
+/// getter
+/// to specify a custom JSON key name, description, and other schema
+/// constraints.
 class Field {
   /// The key name to use in the JSON map.
   final String? name;
 
-  /// A description of the field, which will be included in the generated JSON Schema.
+  /// A description of the field, which will be included in the generated JSON
+  /// Schema.
   final String? description;
 
   /// The default value for the field.
@@ -96,7 +100,6 @@ class IntegerField extends Field {
 }
 
 /// Annotation for Number (double) fields with specific schema constraints.
-/// Annotation for Number (double) fields with specific schema constraints.
 class DoubleField extends Field {
   final num? minimum;
   final num? maximum;
@@ -116,7 +119,8 @@ class DoubleField extends Field {
   }) : super(defaultValue: defaultValue);
 }
 
-/// Metadata associated with a [SchemanticType], primarily used for schema generation.
+/// Metadata associated with a [SchemanticType], primarily used for schema
+/// generation.
 class JsonSchemaMetadata {
   /// The name of the type in the schema (e.g. for $defs).
   final String? name;
@@ -145,11 +149,10 @@ abstract class SchemanticType<T> {
   /// Throws if the JSON data does not match the expected structure.
   T parse(Object? json);
 
-  // ignore: avoid_renaming_method_parameters
   /// Returns the [jsb.Schema] for this type.
   ///
-  /// If [useRefs] is true, the schema will use `$ref` to reference dependent types
-  /// in a global `$defs` section. This is required for recursive schemas.
+  /// If [useRefs] is true, the schema will use `$ref` to reference dependent
+  /// types in a global `$defs` section. This is required for recursive schemas.
   jsb.Schema jsonSchema({bool useRefs = false}) {
     if (!useRefs) {
       if (schemaMetadata == null) return jsb.Schema.any();

--- a/packages/schemantic/lib/src/flatten.dart
+++ b/packages/schemantic/lib/src/flatten.dart
@@ -16,16 +16,18 @@ import 'package:json_schema_builder/json_schema_builder.dart' as jsb;
 
 extension SchemaFlatten on jsb.Schema {
   /// Flattens a JSON schema by dereferencing all `$ref`s and removing `$defs`.
+  ///
+  /// Throws [FormatException] if recursive references are detected.
   jsb.Schema flatten() {
-    final flatMap = flattenSchemaMap(value);
+    final flatMap = _flatten(value);
     return jsb.Schema.fromMap(flatMap);
   }
 }
 
-/// Flattens a JSON schema map by dereferencing all `$ref`s and removing `$defs`.
+/// Flattens a JSON schema by dereferencing all `$ref`s and removing `$defs`.
 ///
 /// Throws [FormatException] if recursive references are detected.
-Map<String, dynamic> flattenSchemaMap(Map<String, dynamic> schema) {
+Map<String, dynamic> _flatten(Map<String, dynamic> schema) {
   // 1. Identify definitions
   final defs = <String, Map<String, dynamic>>{};
   // Check for both $defs (modern) and definitions (legacy)

--- a/packages/schemantic/lib/src/schema_generator.dart
+++ b/packages/schemantic/lib/src/schema_generator.dart
@@ -397,7 +397,8 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
       (m) => m
         ..name = mainGetter.name
         ..docs.add(
-          '// Possible return values are ${types.map((e) => e.toTypeValue()).map((e) => '`$e`').join(', ')}',
+          '// Possible return values are '
+          '${types.map((e) => e.toTypeValue()).map((e) => '`$e`').join(', ')}',
         )
         ..type = MethodType.getter
         ..returns = refer('Object?')
@@ -505,14 +506,20 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
           final nestedBaseName = _resolveBaseName(itemType.element!.name!);
           if (itemIsNullable) {
             getterBody =
-                "return (_json['$jsonFieldName'] as List?)?.map((e) => e == null ? null : $nestedBaseName(e as Map<String, dynamic>)).toList();";
+                "return (_json['$jsonFieldName'] as List?)"
+                "?.map((e) => e == null ? null : "
+                "$nestedBaseName(e as Map<String, dynamic>)).toList();";
           } else {
             getterBody =
-                "return (_json['$jsonFieldName'] as List?)?.map((e) => $nestedBaseName.fromJson(e as Map<String, dynamic>)).toList();";
+                "return (_json['$jsonFieldName'] as List?)"
+                "?.map((e) => "
+                "$nestedBaseName.fromJson(e as Map<String, dynamic>))"
+                ".toList();";
           }
         } else {
           getterBody =
-              "return (_json['$jsonFieldName'] as List?)?.cast<$itemTypeName>();";
+              "return (_json['$jsonFieldName'] as List?)"
+              "?.cast<$itemTypeName>();";
         }
       } else if (returnType.isDartCoreMap) {
         final keyTypeName = (returnType as InterfaceType).typeArguments[0]
@@ -525,22 +532,32 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
           final nestedBaseName = _resolveBaseName(valueType.element!.name!);
           if (valueIsNullable) {
             getterBody =
-                "return (_json['$jsonFieldName'] as Map?)?.map<$keyTypeName, $nestedBaseName?>((k, v) => MapEntry(k as $keyTypeName, v == null ? null : $nestedBaseName.fromJson(v as Map<String, dynamic>)));";
+                "return (_json['$jsonFieldName'] as Map?)"
+                "?.map<$keyTypeName, $nestedBaseName?>((k, v) => "
+                "MapEntry(k as $keyTypeName, v == null ? null : "
+                "$nestedBaseName.fromJson(v as Map<String, dynamic>)));";
           } else {
             getterBody =
-                "return (_json['$jsonFieldName'] as Map?)?.map<$keyTypeName, $nestedBaseName>((k, v) => MapEntry(k as $keyTypeName, $nestedBaseName.fromJson(v as Map<String, dynamic>)));";
+                "return (_json['$jsonFieldName'] as Map?)"
+                "?.map<$keyTypeName, $nestedBaseName>((k, v) => "
+                "MapEntry(k as $keyTypeName, "
+                "$nestedBaseName.fromJson(v as Map<String, dynamic>)));";
           }
         } else {
           getterBody =
-              "return (_json['$jsonFieldName'] as Map?)?.cast<$keyTypeName, $valueTypeName>();";
+              "return (_json['$jsonFieldName'] as Map?)"
+              "?.cast<$keyTypeName, $valueTypeName>();";
         }
       } else if (returnType.isSchema) {
         final nestedBaseName = _resolveBaseName(returnType.element!.name!);
         getterBody =
-            "return _json['$jsonFieldName'] == null ? null : $nestedBaseName.fromJson(_json['$jsonFieldName'] as Map<String, dynamic>);";
+            "return _json['$jsonFieldName'] == null ? null : "
+            "$nestedBaseName.fromJson(_json['$jsonFieldName'] "
+            "as Map<String, dynamic>);";
       } else if (nonNullableTypeName == 'DateTime') {
         getterBody =
-            "return _json['$jsonFieldName'] == null ? null : DateTime.parse(_json['$jsonFieldName'] as String);";
+            "return _json['$jsonFieldName'] == null ? null : "
+            "DateTime.parse(_json['$jsonFieldName'] as String);";
       }
     } else if (returnType.element is EnumElement) {
       final enumName = returnType.getDisplayString().replaceAll('?', '');
@@ -554,10 +571,14 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
         final nestedBaseName = _resolveBaseName(itemType.element!.name!);
         if (itemIsNullable) {
           getterBody =
-              "return (_json['$jsonFieldName'] as List).map((e) => e == null ? null : $nestedBaseName.fromJson(e as Map<String, dynamic>)).toList();";
+              "return (_json['$jsonFieldName'] as List).map((e) => e == null ? "
+              "null : $nestedBaseName.fromJson(e as Map<String, dynamic>))"
+              ".toList();";
         } else {
           getterBody =
-              "return (_json['$jsonFieldName'] as List).map((e) => $nestedBaseName.fromJson(e as Map<String, dynamic>)).toList();";
+              "return (_json['$jsonFieldName'] as List)"
+              ".map((e) => $nestedBaseName.fromJson(e as Map<String, dynamic>))"
+              ".toList();";
         }
       } else {
         getterBody =
@@ -574,21 +595,29 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
         final nestedBaseName = _resolveBaseName(valueType.element!.name!);
         if (valueIsNullable) {
           getterBody =
-              "return (_json['$jsonFieldName'] as Map).map<$keyTypeName, $nestedBaseName?>((k, v) => MapEntry(k as $keyTypeName, v == null ? null : $nestedBaseName.fromJson(v as Map<String, dynamic>)));";
+              "return (_json['$jsonFieldName'] as Map)"
+              ".map<$keyTypeName, $nestedBaseName?>((k, v) => "
+              "MapEntry(k as $keyTypeName, v == null ? null : "
+              "$nestedBaseName.fromJson(v as Map<String, dynamic>)));";
         } else {
           getterBody =
-              "return (_json['$jsonFieldName'] as Map).map<$keyTypeName, $nestedBaseName>((k, v) => MapEntry(k as $keyTypeName, $nestedBaseName.fromJson(v as Map<String, dynamic>)));";
+              "return (_json['$jsonFieldName'] as Map)"
+              ".map<$keyTypeName, $nestedBaseName>((k, v) => "
+              "MapEntry(k as $keyTypeName, "
+              "$nestedBaseName.fromJson(v as Map<String, dynamic>)));";
         }
       } else {
         getterBody =
-            "return (_json['$jsonFieldName'] as Map).cast<$keyTypeName, $valueTypeName>();";
+            "return (_json['$jsonFieldName'] as Map)"
+            ".cast<$keyTypeName, $valueTypeName>();";
       }
     } else if (nonNullableTypeName == 'DateTime') {
       getterBody = "return DateTime.parse(_json['$jsonFieldName'] as String);";
     } else if (returnType.isSchema) {
       final nestedBaseName = _resolveBaseName(returnType.element!.name!);
       getterBody =
-          "return $nestedBaseName.fromJson(_json['$jsonFieldName'] as Map<String, dynamic>);";
+          "return $nestedBaseName.fromJson("
+          "_json['$jsonFieldName'] as Map<String, dynamic>);";
     }
 
     return Method(
@@ -626,7 +655,8 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
         }
       }
       setterBody =
-          "if (value == null) { _json.remove('$jsonFieldName'); } else { _json['$jsonFieldName'] = $valueExpression; }";
+          "if (value == null) { _json.remove('$jsonFieldName'); } "
+          "else { _json['$jsonFieldName'] = $valueExpression; }";
     } else if (paramType.element is EnumElement) {
       setterBody = "_json['$jsonFieldName'] = value.name;";
     } else if (paramType.isDartCoreList) {
@@ -679,12 +709,14 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
             .where((name) => name != null);
 
         var parseBody =
-            'final Map<String, dynamic> jsonMap = json as Map<String, dynamic>;';
+            'final Map<String, dynamic> jsonMap = '
+            'json as Map<String, dynamic>;';
         for (final subtype in subtypes) {
           // This parse logic implies that we need to check validity.
           // Validate JSON structure using the schema before parsing.
           parseBody +=
-              'if (${subtype}Type.jsonSchema(useRefs: true).validate(jsonMap)) { return $subtype.fromJson(jsonMap); }';
+              'if (${subtype}Type.jsonSchema(useRefs: true).validate(jsonMap)) '
+              '{ return $subtype.fromJson(jsonMap); }';
         }
         parseBody += 'throw Exception("Invalid JSON for $baseName");';
 
@@ -835,9 +867,10 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
           .toList()
           .cast<Expression>();
 
-      // Wrapping anyOf in an object if we have a description, or just use anyOf.
-      // json_schema_builder's Schema.anyOf doesn't seem to support description directly in constructor usually?
-      // We'll use Schema.fromMap for full control if description is present, or just Schema.anyOf.
+      // Wrapping anyOf in an object if we have a description, or just use
+      // anyOf. json_schema_builder's Schema.anyOf doesn't seem to support
+      // description directly in constructor usually? We'll use Schema.fromMap
+      // for full control if description is present, or just Schema.anyOf.
       if (descriptionExpr != null) {
         // Schema that is both anyOf and has description.
         // In JSON Schema: { "description": "...", "anyOf": [...] }
@@ -1023,7 +1056,8 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
         }
       } else if (type.isSchema) {
         final nestedBaseName = _resolveBaseName(type.element!.name!);
-        // If we are building the "definition" for the metadata, we want to use refs for children.
+        // If we are building the "definition" for the metadata, we want to use
+        // refs for children.
         if (useRefs) {
           final refMap = <Object, Object>{
             literalString(r'\$ref'): CodeExpression(
@@ -1034,18 +1068,21 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
           // It will be added in the allOf wrapper below.
           schemaExpression = refer('Schema.fromMap').call([literalMap(refMap)]);
         } else {
-          // For metadata generation, we can emit a direct call to the nested type's jsonSchema.
+          // For metadata generation, we can emit a direct call to the nested
+          // type's jsonSchema.
           schemaExpression = refer(
             '$nestedBaseName.\$schema.jsonSchema',
           ).call([]);
         }
 
         if (properties.isNotEmpty) {
-          // If there are extra properties (like description or default), we need to wrap the ref/schema.
+          // If there are extra properties (like description or default), we
+          // need to wrap the ref/schema.
           // Wrap the schema in allOf to allow adding extra properties.
           if (useRefs) {
             // we already have schemaExpression as a ref.
-            // Always wrap if we have properties (because we can't put them on the ref)
+            // Always wrap if we have properties (because we can't put them on
+            // the ref)
             final allOfList = [
               refer('Schema.fromMap').call([
                 literalMap({
@@ -1120,7 +1157,8 @@ class SchemaGenerator extends GeneratorForAnnotation<Schematic> {
       throw InvalidGenerationSourceError(
         '@DoubleField can only be used on num, double, or int types.',
         todo:
-            'Change the field type to num/double or use a different annotation.',
+            'Change the field type to a number type '
+            'or use a different annotation.',
       );
     }
   }


### PR DESCRIPTION
- Reflow String literals and comments to keep lines under 80 characters.
- Make the implementation of flatten private. (https://dart.dev/effective-dart/design#prefer-making-declarations-private)
- Keep `dart:` imports separate. (https://dart.dev/effective-dart/style#ordering)
- Remove a doubled doc.
