### PR TITLE
refactor!: Remove `SchemaHelpers` utility class

### DIFF
--- a/packages/schemantic/CHANGELOG.md
+++ b/packages/schemantic/CHANGELOG.md
@@ -8,7 +8,6 @@
  - **FIX**: enable and fix a couple of lints (#174).
  - **FIX**: be consistent with String quotes (#164).
  - **BREAKING** **FEAT**: move basic type functions to static creation method on SchemanticType (#154).
-- **BREAKING** **REFACTOR**: Remove `SchemaHelpers` utility class.
 
 ## 0.0.1-dev.17
 


### PR DESCRIPTION
Resolves a violation of
https://dart.dev/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members

Rewrite `buildSchema` and the related private utility methods as
extension methods in private extensions. The `buildSchema` function is
invoked publicly through `SchemanticType.jsonSchema()`, with identical
behavior if the caller passes `uesRefs: true`.
