### PR TITLE
fix: let list() throw on API errors to preserve retry, graceful init() for custom models

### DIFF
--- a/packages/genkit/lib/src/core/registry.dart
+++ b/packages/genkit/lib/src/core/registry.dart
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:logging/logging.dart';
+
 import '../ai/generate_middleware.dart';
 import './action.dart';
 import './plugin.dart';
+
+final _logger = Logger('genkit.registry');
 
 class Registry {
   final Map<String, Action> _actions = {};
@@ -130,7 +134,11 @@ class Registry {
           }
         }
       } catch (e, st) {
-        print('Failed to list actions from plugin ${plugin.name}: $e $st');
+        _logger.warning(
+          'Failed to list actions from plugin ${plugin.name}',
+          e,
+          st,
+        );
       }
     }
     return allActions.values.toList();

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -72,9 +72,11 @@ class AnthropicPluginImpl extends GenkitPlugin {
           )
           .toList();
     } catch (e, s) {
-      // Fallback or empty if listing fails/not supported as expected
-      print('Failed to list Anthropic models: $e\n$s');
-      return [];
+      throw GenkitException(
+        'Error listing models from Anthropic: $e',
+        underlyingException: e,
+        stackTrace: s,
+      );
     }
   }
 

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -14,10 +14,13 @@
 
 import 'package:genkit/plugin.dart';
 import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
 import 'package:openai_dart/openai_dart.dart' as sdk;
 import 'package:schemantic/schemantic.dart';
 
 import '../genkit_openai.dart';
+
+final _logger = Logger('genkit_openai');
 
 /// Returns true when the output config indicates JSON-structured output
 /// (format is 'json' or contentType is 'application/json').
@@ -76,10 +79,12 @@ class OpenAIPlugin extends GenkitPlugin {
           final info = _getModelInfo(modelId);
           actions.add(_createModel(modelId, info));
         }
-      } catch (e) {
-        throw GenkitException(
-          'Error fetching available models from OpenAI: $e',
-          underlyingException: e,
+      } catch (e, s) {
+        _logger.warning(
+          'Failed to fetch available models from OpenAI. '
+          'Only custom models will be available.',
+          e,
+          s,
         );
       }
     }
@@ -271,12 +276,9 @@ class OpenAIPlugin extends GenkitPlugin {
       }
 
       return modelMetadataList;
-    } catch (e, stackTrace) {
-      throw GenkitException(
-        'Error listing models from OpenAI: $e',
-        underlyingException: e,
-        stackTrace: stackTrace,
-      );
+    } catch (e, s) {
+      _logger.warning('Failed to list models from OpenAI', e, s);
+      return [];
     }
   }
 

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -276,9 +276,12 @@ class OpenAIPlugin extends GenkitPlugin {
       }
 
       return modelMetadataList;
-    } catch (e, s) {
-      _logger.warning('Failed to list models from OpenAI', e, s);
-      return [];
+    } catch (e, stackTrace) {
+      throw GenkitException(
+        'Error listing models from OpenAI: $e',
+        underlyingException: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/packages/genkit_openai/pubspec.yaml
+++ b/packages/genkit_openai/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   genkit: ^0.12.0
   http: ^1.6.0
   json_schema_builder: ^0.1.3
+  logging: ^1.3.0
   meta: ^1.17.0
   openai_dart: ^2.0.0
   schemantic: ^0.1.1

--- a/packages/genkit_openai/test/openai_plugin_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_test.dart
@@ -400,7 +400,10 @@ void main() {
       final plugin = openAI(
         apiKey: 'test-key',
         models: [CustomModelDefinition(name: 'my-custom')],
-        httpClient: _throwingClient(Exception('connection refused')),
+        httpClient: _modelsClient(
+          body: '{"error":{"message":"Forbidden"}}',
+          statusCode: 403,
+        ),
       );
       // Should not throw
       final actions = await plugin.init();
@@ -457,7 +460,10 @@ void main() {
     test('API failure degrades gracefully', () async {
       final plugin = openAI(
         apiKey: 'test-key',
-        httpClient: _throwingClient(Exception('DNS resolution failed')),
+        httpClient: _modelsClient(
+          body: '{"error":{"message":"Forbidden"}}',
+          statusCode: 403,
+        ),
       );
       // Should not throw
       final metadata = await plugin.list();
@@ -485,10 +491,9 @@ MockClient _modelsClient({required String body, int statusCode = 200}) {
   );
 }
 
-/// Creates a [MockClient] that throws [error] on any request.
+/// Creates a [MockClient] that throws on any request.
 ///
-/// Uses plain [Exception] (not [http.ClientException]) so that
-/// openai_dart's retry wrapper rethrows immediately.
+/// Used as a sentinel to verify no HTTP calls are made.
 MockClient _throwingClient(Exception error) {
   return MockClient((_) => throw error);
 }

--- a/packages/genkit_openai/test/openai_plugin_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_test.dart
@@ -457,7 +457,7 @@ void main() {
       expect(names, contains('openai/codestral'));
     });
 
-    test('API failure degrades gracefully', () async {
+    test('API failure throws to allow retry', () async {
       final plugin = openAI(
         apiKey: 'test-key',
         httpClient: _modelsClient(
@@ -465,12 +465,10 @@ void main() {
           statusCode: 403,
         ),
       );
-      // Should not throw
-      final metadata = await plugin.list();
-      expect(metadata, isEmpty);
+      expect(plugin.list(), throwsA(isA<GenkitException>()));
     });
 
-    test('401 error degrades gracefully', () async {
+    test('401 error throws to allow retry', () async {
       final plugin = openAI(
         apiKey: 'bad-key',
         httpClient: _modelsClient(
@@ -478,17 +476,14 @@ void main() {
           statusCode: 401,
         ),
       );
-      final metadata = await plugin.list();
-      expect(metadata, isEmpty);
+      expect(plugin.list(), throwsA(isA<GenkitException>()));
     });
   });
 }
 
 /// Creates a [MockClient] that returns a canned response for `/models`.
 MockClient _modelsClient({required String body, int statusCode = 200}) {
-  return MockClient(
-    (_) async => http.Response(body, statusCode),
-  );
+  return MockClient((_) async => http.Response(body, statusCode));
 }
 
 /// Creates a [MockClient] that throws on any request.

--- a/packages/genkit_openai/test/openai_plugin_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_test.dart
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:genkit/genkit.dart' hide Tool;
 import 'package:genkit_openai/genkit_openai.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:openai_dart/openai_dart.dart'
     show AssistantMessage, ContentPart, SystemMessage, ToolMessage, UserMessage;
 import 'package:test/test.dart';
@@ -348,4 +352,158 @@ void main() {
       expect(def.info?.label, 'Custom Model');
     });
   });
+
+  group('init()', () {
+    test('registers models from API when baseUrl is null', () async {
+      final plugin = openAI(
+        apiKey: 'test-key',
+        httpClient: _modelsClient(
+          body: _modelsResponse(['gpt-4o', 'gpt-4o-mini', 'dall-e-3']),
+        ),
+      );
+      final actions = await plugin.init();
+      final names = actions.map((a) => a.name).toList();
+      expect(names, contains('openai/gpt-4o'));
+      expect(names, contains('openai/gpt-4o-mini'));
+      // dall-e-3 is an image model, should be filtered out
+      expect(names, isNot(contains('openai/dall-e-3')));
+    });
+
+    test('skips API call when baseUrl is set', () async {
+      // Throwing client proves no HTTP call is made
+      final plugin = openAI(
+        apiKey: 'test-key',
+        baseUrl: 'https://custom.api.example.com/v1',
+        httpClient: _throwingClient(Exception('should not be called')),
+      );
+      final actions = await plugin.init();
+      expect(actions, isEmpty);
+    });
+
+    test('registers custom models when baseUrl is set', () async {
+      final plugin = openAI(
+        apiKey: 'test-key',
+        baseUrl: 'https://custom.api.example.com/v1',
+        models: [
+          CustomModelDefinition(name: 'my-model'),
+          CustomModelDefinition(name: 'my-other-model'),
+        ],
+        httpClient: _throwingClient(Exception('should not be called')),
+      );
+      final actions = await plugin.init();
+      final names = actions.map((a) => a.name).toList();
+      expect(names, contains('openai/my-model'));
+      expect(names, contains('openai/my-other-model'));
+    });
+
+    test('API failure degrades gracefully, custom models survive', () async {
+      final plugin = openAI(
+        apiKey: 'test-key',
+        models: [CustomModelDefinition(name: 'my-custom')],
+        httpClient: _throwingClient(Exception('connection refused')),
+      );
+      // Should not throw
+      final actions = await plugin.init();
+      final names = actions.map((a) => a.name).toList();
+      expect(names, contains('openai/my-custom'));
+    });
+
+    test('401 error degrades gracefully', () async {
+      final plugin = openAI(
+        apiKey: 'bad-key',
+        models: [CustomModelDefinition(name: 'my-custom')],
+        httpClient: _modelsClient(
+          body: '{"error":{"message":"Invalid API key"}}',
+          statusCode: 401,
+        ),
+      );
+      final actions = await plugin.init();
+      final names = actions.map((a) => a.name).toList();
+      expect(names, contains('openai/my-custom'));
+    });
+  });
+
+  group('list()', () {
+    test('returns model metadata when baseUrl is null', () async {
+      final plugin = openAI(
+        apiKey: 'test-key',
+        httpClient: _modelsClient(
+          body: _modelsResponse(['gpt-4o', 'gpt-4o-mini', 'dall-e-3']),
+        ),
+      );
+      final metadata = await plugin.list();
+      final names = metadata.map((m) => m.name).toList();
+      expect(names, contains('openai/gpt-4o'));
+      expect(names, contains('openai/gpt-4o-mini'));
+      // dall-e-3 is an image model, should be filtered out
+      expect(names, isNot(contains('openai/dall-e-3')));
+    });
+
+    test('discovers models from custom baseUrl', () async {
+      final plugin = openAI(
+        apiKey: 'test-key',
+        baseUrl: 'https://ollama.local/v1',
+        httpClient: _modelsClient(
+          body: _modelsResponse(['llama3', 'codestral']),
+        ),
+      );
+      final metadata = await plugin.list();
+      final names = metadata.map((m) => m.name).toList();
+      // Both are 'unknown' type which is included
+      expect(names, contains('openai/llama3'));
+      expect(names, contains('openai/codestral'));
+    });
+
+    test('API failure degrades gracefully', () async {
+      final plugin = openAI(
+        apiKey: 'test-key',
+        httpClient: _throwingClient(Exception('DNS resolution failed')),
+      );
+      // Should not throw
+      final metadata = await plugin.list();
+      expect(metadata, isEmpty);
+    });
+
+    test('401 error degrades gracefully', () async {
+      final plugin = openAI(
+        apiKey: 'bad-key',
+        httpClient: _modelsClient(
+          body: '{"error":{"message":"Invalid API key"}}',
+          statusCode: 401,
+        ),
+      );
+      final metadata = await plugin.list();
+      expect(metadata, isEmpty);
+    });
+  });
+}
+
+/// Creates a [MockClient] that returns a canned response for `/models`.
+MockClient _modelsClient({required String body, int statusCode = 200}) {
+  return MockClient(
+    (_) async => http.Response(body, statusCode),
+  );
+}
+
+/// Creates a [MockClient] that throws [error] on any request.
+///
+/// Uses plain [Exception] (not [http.ClientException]) so that
+/// openai_dart's retry wrapper rethrows immediately.
+MockClient _throwingClient(Exception error) {
+  return MockClient((_) => throw error);
+}
+
+/// Returns a valid OpenAI `/v1/models` JSON response body.
+String _modelsResponse(List<String> modelIds) {
+  final models = modelIds
+      .map(
+        (id) => {
+          'id': id,
+          'object': 'model',
+          'created': 1700000000,
+          'owned_by': 'test',
+        },
+      )
+      .toList();
+  return jsonEncode({'object': 'list', 'data': models});
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #225** (`pj/openai-httpClient`) — must be merged first.

## Summary
- `init()` now degrades gracefully on API errors (DNS failure, timeouts, invalid key) instead of throwing `GenkitException` — custom models are always registered
- `list()` continues to throw on API errors so the registry's `_ListActionsCachingPluginAdapter` can clear the cache and retry on subsequent calls
- Registry's `listActions()` uses `_logger.warning()` instead of `print()` to avoid scary console output
- Same `list()` fix applied to the Anthropic plugin

Closes #229

## Details

When a user configures the OpenAI plugin with a custom `baseUrl`, `list()` throws on API errors. The `Registry.listActions()` catch block already handles this non-fatally, but it used `print()` with the full stack trace, producing alarming console output: _"Failed to list actions from plugin openai: Error listing models from OpenAI: ClientException with SocketException"_.

**Three things fixed:**

1. **`init()` throws before registering custom models** — When `baseUrl == null` and the API is unreachable, `init()` previously threw at the API call before reaching the custom model loop. Now it catches the error and continues, so custom models are always registered. `resolve()` handles on-demand creation for API models.

2. **Registry uses `print()` for plugin errors** — Replaced with `_logger.warning()` via `package:logging` (already a dependency) so the error goes through proper log levels instead of raw stdout. This is the actual fix for the "scary error" reported in #229.

3. **Anthropic plugin's `list()` returns `[]` on error** — Same bug: returning `[]` causes the `_ListActionsCachingPluginAdapter` to cache the empty result permanently, preventing retry. Changed to throw `GenkitException` (consistent with the OpenAI plugin).

**Design: `list()` must throw, not return `[]`** — The `_ListActionsCachingPluginAdapter` caches successful results and clears the cache on errors to allow retry. Returning `[]` makes the adapter think the call succeeded, permanently caching an empty result even if the API recovers later.

| Scenario | Before | After |
|----------|--------|-------|
| Custom baseUrl, endpoint unreachable | `list()` throws, `print()` dumps scary error | `list()` throws, `_logger.warning()` (proper log level) |
| Default host, API unreachable | `init()` throws, custom models lost | `init()` catches error, registers custom models |
| Invalid API key (401) | Both throw with scary print | `init()` degrades, `list()` throws with proper logging |
| API recovers after initial failure | `list()` retried via cache adapter | **Same behavior preserved** |

## Test Plan
- [x] `dart analyze` — zero warnings across genkit, genkit_openai, genkit_anthropic
- [x] `dart test packages/genkit/test/core/registry_test.dart` — all 16 tests pass (including `list actions retry on failure`)
- [x] `dart test packages/genkit_openai/test/openai_plugin_test.dart` — all 37 tests pass
- [x] `list()` error tests updated to verify throws (not empty list)
- [x] `init()` error tests verify custom models survive API failures
