### PR TITLE
fix(genkit_openai): handle media parts rehydrated as base Part

### DIFF
--- a/packages/genkit_openai/lib/src/converters.dart
+++ b/packages/genkit_openai/lib/src/converters.dart
@@ -100,7 +100,7 @@ abstract final class GenkitConverter {
       return sdk.ContentPart.text(part.text!);
     }
     if (part.isMedia) {
-      final media = (part as MediaPart).media;
+      final media = part.mediaPart!.media;
       if (media.url.startsWith('data:')) {
         // Parse data URI: data:<mediaType>;base64,<data>
         final commaIdx = media.url.indexOf(',');

--- a/packages/genkit_openai/test/openai_plugin_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_test.dart
@@ -187,6 +187,28 @@ void main() {
       final result = GenkitConverter.toOpenAIContentPart(part, null);
       expect(result, isA<ContentPart>());
     });
+
+    test('converts media part rehydrated from Message.content as base Part', () {
+      final msg = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'data:image/png;base64,iVBORw0KGgoAAAANS',
+              contentType: 'image/png',
+            ),
+          ),
+        ],
+      );
+
+      final part = msg.content.single;
+      expect(part, isA<Part>());
+      expect(part, isNot(isA<MediaPart>()));
+      expect(part.isMedia, isTrue);
+
+      final result = GenkitConverter.toOpenAIContentPart(part, null);
+      expect(result, isA<ContentPart>());
+    });
   });
 
   group('GenkitConverter.toOpenAITool', () {


### PR DESCRIPTION
## Summary
- avoid casting `Part` directly to `MediaPart` in the OpenAI converter
- rehydrate media parts through `part.mediaPart` to match Genkit `Message.content` behavior
- add a regression test covering media parts read back from `Message.content`

## Context
`Message.content` currently rehydrates entries as base `Part` values. The existing OpenAI converter used `(part as MediaPart)` after `part.isMedia`, which crashes for image inputs even though the payload is valid.

## Testing
- dart analyze packages/genkit_openai
- dart test packages/genkit_openai/test/openai_plugin_test.dart
