### PR TITLE
feat: add additionalProperties support to @Schema and implement strict object validation

### DIFF
--- a/packages/genkit/lib/src/ai/middleware/retry.g.dart
+++ b/packages/genkit/lib/src/ai/middleware/retry.g.dart
@@ -205,7 +205,6 @@ base class _RetryOptionsTypeFactory extends SchemanticType<RetryOptions> {
             'retryModel': $Schema.boolean(),
             'retryTools': $Schema.boolean(),
           },
-          required: [],
         )
         .value,
     dependencies: [],

--- a/packages/genkit/lib/src/types.g.dart
+++ b/packages/genkit/lib/src/types.g.dart
@@ -388,7 +388,7 @@ base class _PartTypeFactory extends SchemanticType<Part> {
   @override
   JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
     name: 'Part',
-    definition: $Schema.object(properties: {}, required: []).value,
+    definition: $Schema.object(properties: {}).value,
     dependencies: [],
   );
 }
@@ -901,7 +901,6 @@ base class _DataPartTypeFactory extends SchemanticType<DataPart> {
             'metadata': $Schema.object(additionalProperties: $Schema.any()),
             'custom': $Schema.object(additionalProperties: $Schema.any()),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -1342,7 +1341,6 @@ base class _BaseDataPointTypeFactory extends SchemanticType<BaseDataPoint> {
             'testCaseId': $Schema.string(),
             'traceIds': $Schema.list(items: $Schema.string()),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -1694,7 +1692,6 @@ base class _ScoreTypeFactory extends SchemanticType<Score> {
             'error': $Schema.string(),
             'details': $Schema.object(additionalProperties: $Schema.any()),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -2078,7 +2075,6 @@ base class _ModelInfoTypeFactory extends SchemanticType<ModelInfo> {
             'supports': $Schema.object(additionalProperties: $Schema.any()),
             'stage': $Schema.string(),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -2832,7 +2828,6 @@ base class _GenerateResponseTypeFactory
               items: $Schema.fromMap({'\$ref': r'#/$defs/Candidate'}),
             ),
           },
-          required: [],
         )
         .value,
     dependencies: [
@@ -3266,7 +3261,6 @@ base class _GenerationUsageTypeFactory extends SchemanticType<GenerationUsage> {
             'thoughtsTokens': $Schema.number(),
             'cachedContentTokens': $Schema.number(),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -3508,7 +3502,6 @@ base class _OutputConfigTypeFactory extends SchemanticType<OutputConfig> {
             'constrained': $Schema.boolean(),
             'contentType': $Schema.string(),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -3958,7 +3951,6 @@ base class _GenerateResumeOptionsTypeFactory
             ),
             'metadata': $Schema.object(additionalProperties: $Schema.any()),
           },
-          required: [],
         )
         .value,
     dependencies: [ToolResponsePart.$schema, ToolRequestPart.$schema],
@@ -4105,7 +4097,6 @@ base class _GenerateActionOutputConfigTypeFactory
             'constrained': $Schema.boolean(),
             'defaultInstructions': $Schema.boolean(),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -4478,10 +4469,7 @@ base class _ReflectionConfigureParamsTypeFactory
   JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
     name: 'ReflectionConfigureParams',
     definition: $Schema
-        .object(
-          properties: {'telemetryServerUrl': $Schema.string()},
-          required: [],
-        )
+        .object(properties: {'telemetryServerUrl': $Schema.string()})
         .value,
     dependencies: [],
   );

--- a/packages/genkit/test/extension_type_test.dart
+++ b/packages/genkit/test/extension_type_test.dart
@@ -201,7 +201,6 @@ void main() {
             Ingredient.$schema.jsonSchema(),
           ),
         },
-        required: [],
       );
 
       expect(NullableFields.$schema.jsonSchema(), expectedSchema.value);

--- a/packages/genkit/test/extension_type_test.g.dart
+++ b/packages/genkit/test/extension_type_test.g.dart
@@ -426,7 +426,6 @@ base class _NullableFieldsTypeFactory extends SchemanticType<NullableFields> {
               '\$ref': r'#/$defs/Ingredient',
             }),
           },
-          required: [],
         )
         .value,
     dependencies: [Ingredient.$schema],

--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.g.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.g.dart
@@ -334,7 +334,6 @@ base class _GeminiOptionsTypeFactory extends SchemanticType<GeminiOptions> {
             'responseLogprobs': $Schema.boolean(),
             'logprobs': $Schema.integer(),
           },
-          required: [],
         )
         .value,
     dependencies: [ThinkingConfig.$schema, FunctionCallingConfig.$schema],
@@ -410,7 +409,6 @@ base class _FunctionCallingConfigTypeFactory
             ),
             'allowedFunctionNames': $Schema.list(items: $Schema.string()),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -486,7 +484,6 @@ base class _ThinkingConfigTypeFactory extends SchemanticType<ThinkingConfig> {
             'thinkingBudget': $Schema.integer(),
             'includeThoughts': $Schema.boolean(),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -543,7 +540,7 @@ base class _PrebuiltVoiceConfigTypeFactory
   JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
     name: 'PrebuiltVoiceConfig',
     definition: $Schema
-        .object(properties: {'voiceName': $Schema.string()}, required: [])
+        .object(properties: {'voiceName': $Schema.string()})
         .value,
     dependencies: [],
   );
@@ -607,7 +604,6 @@ base class _VoiceConfigTypeFactory extends SchemanticType<VoiceConfig> {
               '\$ref': r'#/$defs/PrebuiltVoiceConfig',
             }),
           },
-          required: [],
         )
         .value,
     dependencies: [PrebuiltVoiceConfig.$schema],
@@ -669,7 +665,6 @@ base class _SpeechConfigTypeFactory extends SchemanticType<SpeechConfig> {
           properties: {
             'voiceConfig': $Schema.fromMap({'\$ref': r'#/$defs/VoiceConfig'}),
           },
-          required: [],
         )
         .value,
     dependencies: [VoiceConfig.$schema],
@@ -856,7 +851,6 @@ base class _LiveGenerationConfigTypeFactory
             'presencePenalty': $Schema.number(),
             'frequencyPenalty': $Schema.number(),
           },
-          required: [],
         )
         .value,
     dependencies: [SpeechConfig.$schema],

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -400,7 +400,6 @@ base class _GeminiOptionsTypeFactory extends SchemanticType<GeminiOptions> {
             'seed': $Schema.integer(),
             'speechConfig': $Schema.fromMap({'\$ref': r'#/$defs/SpeechConfig'}),
           },
-          required: [],
         )
         .value,
     dependencies: [
@@ -496,7 +495,6 @@ base class _SafetySettingsTypeFactory extends SchemanticType<SafetySettings> {
               ],
             ),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -602,7 +600,6 @@ base class _ThinkingConfigTypeFactory extends SchemanticType<ThinkingConfig> {
               enumValues: ['MINIMAL', 'LOW', 'MEDIUM', 'HIGH'],
             ),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -678,7 +675,6 @@ base class _FunctionCallingConfigTypeFactory
             ),
             'allowedFunctionNames': $Schema.list(items: $Schema.string()),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -736,7 +732,6 @@ base class _FileSearchTypeFactory extends SchemanticType<FileSearch> {
           properties: {
             'fileSearchStoreNames': $Schema.list(items: $Schema.string()),
           },
-          required: [],
         )
         .value,
     dependencies: [],
@@ -1123,7 +1118,6 @@ base class _GeminiTtsOptionsTypeFactory
             'seed': $Schema.integer(),
             'speechConfig': $Schema.fromMap({'\$ref': r'#/$defs/SpeechConfig'}),
           },
-          required: [],
         )
         .value,
     dependencies: [
@@ -1217,7 +1211,6 @@ base class _SpeechConfigTypeFactory extends SchemanticType<SpeechConfig> {
               '\$ref': r'#/$defs/MultiSpeakerVoiceConfig',
             }),
           },
-          required: [],
           description: 'Speech generation config',
         )
         .value,
@@ -1425,7 +1418,6 @@ base class _VoiceConfigTypeFactory extends SchemanticType<VoiceConfig> {
               '\$ref': r'#/$defs/PrebuiltVoiceConfig',
             }),
           },
-          required: [],
           description: 'Configuration for the voice to use',
         )
         .value,
@@ -1490,7 +1482,6 @@ base class _PrebuiltVoiceConfigTypeFactory
                   'Name of the preset voice to use. Known values: Zephyr, Puck, Charon, Kore, Fenrir, Leda, Orus, Aoede, Callirrhoe, Autonoe, Enceladus, Iapetus, Umbriel, Algieba, Despina, Erinome, Algenib, Rasalgethi, Laomedeia, Achernar, Alnilam, Schedar, Gacrux, Pulcherrima, Achird, Zubenelgenubi, Vindemiatrix, Sadachbia, Sadaltager, Sulafat',
             ),
           },
-          required: [],
           description: 'Configuration for the prebuilt speaker to use',
         )
         .value,
@@ -1534,7 +1525,7 @@ base class _GoogleSearchTypeFactory extends SchemanticType<GoogleSearch> {
   @override
   JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
     name: 'GoogleSearch',
-    definition: $Schema.object(properties: {}, required: []).value,
+    definition: $Schema.object(properties: {}).value,
     dependencies: [],
   );
 }
@@ -1644,7 +1635,6 @@ base class _TextEmbedderOptionsTypeFactory
             ),
             'title': $Schema.string(),
           },
-          required: [],
         )
         .value,
     dependencies: [],

--- a/packages/genkit_openai/lib/genkit_openai.g.dart
+++ b/packages/genkit_openai/lib/genkit_openai.g.dart
@@ -230,7 +230,6 @@ base class _OpenAIOptionsTypeFactory extends SchemanticType<OpenAIOptions> {
               enumValues: ['auto', 'low', 'high'],
             ),
           },
-          required: [],
         )
         .value,
     dependencies: [],

--- a/packages/schemantic/lib/schemantic.dart
+++ b/packages/schemantic/lib/schemantic.dart
@@ -31,7 +31,10 @@ final class Schema {
   /// A description of the schema, to be included in the generated JSON Schema.
   final String? description;
 
-  const Schema({this.description});
+  /// Whether to allow additional properties on the schema object.
+  final bool? additionalProperties;
+
+  const Schema({this.description, this.additionalProperties});
 }
 
 final class AnyOf {

--- a/packages/schemantic/lib/src/schema_generator.dart
+++ b/packages/schemantic/lib/src/schema_generator.dart
@@ -942,9 +942,7 @@ final class SchemaGenerator extends GeneratorForAnnotation<Schema> {
       }
 
       if (additionalProperties != null) {
-        definitionExpression = refer(
-          '\$Schema.fromMap',
-        ).call([
+        definitionExpression = refer('\$Schema.fromMap').call([
           literalMap({
             'type': literalString('object'),
             ...namedArgs,
@@ -954,7 +952,6 @@ final class SchemaGenerator extends GeneratorForAnnotation<Schema> {
       } else {
         definitionExpression = refer('\$Schema.object').call([], namedArgs);
       }
-
     }
 
     return Method(

--- a/packages/schemantic/lib/src/schema_generator.dart
+++ b/packages/schemantic/lib/src/schema_generator.dart
@@ -927,14 +927,36 @@ final class SchemaGenerator extends GeneratorForAnnotation<Schema> {
         ).call([literalList(subtypes)]);
       }
     } else {
-      final namedArgs = <String, Expression>{
-        'properties': literalMap(properties),
-        'required': literalList(required.map(literalString)),
-      };
-      if (descriptionExpr != null) {
-        namedArgs['description'] = descriptionExpr;
+      final additionalProperties = annotation
+          .peek('additionalProperties')
+          ?.boolValue;
+
+      if (additionalProperties != null) {
+        final mapProps = <String, Expression>{
+          'type': literalString('object'),
+          'properties': literalMap(properties),
+        };
+        if (required.isNotEmpty) {
+          mapProps['required'] = literalList(required.map(literalString));
+        }
+        if (descriptionExpr != null) {
+          mapProps['description'] = descriptionExpr;
+        }
+        mapProps['additionalProperties'] = literalBool(additionalProperties);
+
+        definitionExpression = refer(
+          '\$Schema.fromMap',
+        ).call([literalMap(mapProps)]);
+      } else {
+        final namedArgs = <String, Expression>{
+          'properties': literalMap(properties),
+          'required': literalList(required.map(literalString)),
+        };
+        if (descriptionExpr != null) {
+          namedArgs['description'] = descriptionExpr;
+        }
+        definitionExpression = refer('\$Schema.object').call([], namedArgs);
       }
-      definitionExpression = refer('\$Schema.object').call([], namedArgs);
     }
 
     return Method(

--- a/packages/schemantic/lib/src/schema_generator.dart
+++ b/packages/schemantic/lib/src/schema_generator.dart
@@ -931,32 +931,30 @@ final class SchemaGenerator extends GeneratorForAnnotation<Schema> {
           .peek('additionalProperties')
           ?.boolValue;
 
-      if (additionalProperties != null) {
-        final mapProps = <String, Expression>{
-          'type': literalString('object'),
-          'properties': literalMap(properties),
-        };
-        if (required.isNotEmpty) {
-          mapProps['required'] = literalList(required.map(literalString));
-        }
-        if (descriptionExpr != null) {
-          mapProps['description'] = descriptionExpr;
-        }
-        mapProps['additionalProperties'] = literalBool(additionalProperties);
+      final namedArgs = <String, Expression>{
+        'properties': literalMap(properties),
+      };
+      if (required.isNotEmpty) {
+        namedArgs['required'] = literalList(required.map(literalString));
+      }
+      if (descriptionExpr != null) {
+        namedArgs['description'] = descriptionExpr;
+      }
 
+      if (additionalProperties != null) {
         definitionExpression = refer(
           '\$Schema.fromMap',
-        ).call([literalMap(mapProps)]);
+        ).call([
+          literalMap({
+            'type': literalString('object'),
+            ...namedArgs,
+            'additionalProperties': literalBool(additionalProperties),
+          }),
+        ]);
       } else {
-        final namedArgs = <String, Expression>{
-          'properties': literalMap(properties),
-          'required': literalList(required.map(literalString)),
-        };
-        if (descriptionExpr != null) {
-          namedArgs['description'] = descriptionExpr;
-        }
         definitionExpression = refer('\$Schema.object').call([], namedArgs);
       }
+
     }
 
     return Method(

--- a/packages/schemantic/test/integration_test.dart
+++ b/packages/schemantic/test/integration_test.dart
@@ -150,6 +150,11 @@ abstract class $OrderStatus {
   Color? get nullableColor;
 }
 
+@Schema(additionalProperties: false)
+abstract class $StrictUser {
+  String get name;
+}
+
 void main() {
   group('Integration Tests', () {
     test('User serialization and deserialization', () {
@@ -166,6 +171,22 @@ void main() {
       expect(parsed.name, 'Alice');
       expect(parsed.age, 30);
       expect(parsed.isAdmin, isTrue);
+    });
+
+    test('Strict user validation with unknown parameter', () async {
+      final json = {'name': 'Alice', 'extra': 'foo'};
+      final errors = await StrictUser.$schema.validate(json, useRefs: false);
+      expect(errors, isNotEmpty);
+      expect(
+        errors.any(
+          (e) => e.error == ValidationErrorType.additionalPropertyNotAllowed,
+        ),
+        isTrue,
+        reason: 'Should fail with additionalPropertyNotAllowed',
+      );
+
+      final schemaJson = StrictUser.$schema.jsonSchema(useRefs: false);
+      expect(schemaJson['additionalProperties'], isFalse);
     });
 
     test('User with null optional field', () {

--- a/packages/schemantic/test/integration_test.g.dart
+++ b/packages/schemantic/test/integration_test.g.dart
@@ -704,7 +704,6 @@ base class _PolyTypeFactory extends SchemanticType<Poly> {
               ],
             ),
           },
-          required: [],
         )
         .value,
     dependencies: [User.$schema],

--- a/packages/schemantic/test/integration_test.g.dart
+++ b/packages/schemantic/test/integration_test.g.dart
@@ -969,3 +969,55 @@ base class _OrderStatusTypeFactory extends SchemanticType<OrderStatus> {
     dependencies: [],
   );
 }
+
+base class StrictUser {
+  factory StrictUser.fromJson(Map<String, dynamic> json) => $schema.parse(json);
+
+  StrictUser._(this._json);
+
+  StrictUser({required String name}) {
+    _json = {'name': name};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static const SchemanticType<StrictUser> $schema = _StrictUserTypeFactory();
+
+  String get name {
+    return _json['name'] as String;
+  }
+
+  set name(String value) {
+    _json['name'] = value;
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _StrictUserTypeFactory extends SchemanticType<StrictUser> {
+  const _StrictUserTypeFactory();
+
+  @override
+  StrictUser parse(Object? json) {
+    return StrictUser._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'StrictUser',
+    definition: $Schema.fromMap({
+      'type': 'object',
+      'properties': {'name': $Schema.string()},
+      'required': ['name'],
+      'additionalProperties': false,
+    }).value,
+    dependencies: [],
+  );
+}

--- a/packages/schemantic/test/schemas/shared_test_schema.g.dart
+++ b/packages/schemantic/test/schemas/shared_test_schema.g.dart
@@ -108,7 +108,7 @@ base class _PartTypeFactory extends SchemanticType<Part> {
   @override
   JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
     name: 'Part',
-    definition: $Schema.object(properties: {}, required: []).value,
+    definition: $Schema.object(properties: {}).value,
     dependencies: [],
   );
 }


### PR DESCRIPTION
Introduces the `additionalProperties` field to the `Schema` annotation and updates the SchemaGenerator to support it.

Minor refactoring also eliminated generation of unnecessary empty `required` fields array