### PR TITLE
feat(google_genai): add Gemma model family support

### DIFF
--- a/packages/genkit_google_genai/lib/genkit_google_genai.dart
+++ b/packages/genkit_google_genai/lib/genkit_google_genai.dart
@@ -32,6 +32,10 @@ class GoogleGenAiPluginHandle {
     return modelRef('googleai/$name', customOptions: GeminiOptions.$schema);
   }
 
+  ModelRef<GemmaOptions> gemma(String name) {
+    return modelRef('googleai/$name', customOptions: GemmaOptions.$schema);
+  }
+
   EmbedderRef<TextEmbedderOptions> textEmbedding(String name) {
     return embedderRef(
       'googleai/$name',

--- a/packages/genkit_google_genai/lib/genkit_google_genai.dart
+++ b/packages/genkit_google_genai/lib/genkit_google_genai.dart
@@ -33,6 +33,10 @@ class GoogleGenAiPluginHandle {
     return modelRef('googleai/$name', customOptions: GeminiOptions.$schema);
   }
 
+  ModelRef<GemmaOptions> gemma(String name) {
+    return modelRef('googleai/$name', customOptions: GemmaOptions.$schema);
+  }
+
   EmbedderRef<TextEmbedderOptions> textEmbedding(String name) {
     return embedderRef(
       'googleai/$name',

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -49,10 +49,7 @@ final commonGemmaModelInfo = ModelInfo(
 );
 
 final gemma3ModelInfo = ModelInfo(
-  supports: {
-    ...?commonGemmaModelInfo.supports,
-    'systemRole': false,
-  },
+  supports: {...?commonGemmaModelInfo.supports, 'systemRole': false},
 );
 
 bool isGemmaModelName(String name) => name.startsWith('gemma-');

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -37,14 +37,42 @@ final commonModelInfo = ModelInfo(
   },
 );
 
+final commonGemmaModelInfo = ModelInfo(
+  supports: {
+    'multiturn': true,
+    'media': true,
+    'tools': true,
+    'toolChoice': true,
+    'systemRole': true,
+    'constrained': 'no-tools',
+  },
+);
+
+final gemma3ModelInfo = ModelInfo(
+  supports: {
+    ...?commonGemmaModelInfo.supports,
+    'systemRole': false,
+  },
+);
+
+bool isGemmaModelName(String name) => name.startsWith('gemma-');
+
+bool isGemma3ModelName(String name) =>
+    name.startsWith('gemma-3-') || name.startsWith('gemma-3n-');
+
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
 
-  Model createModel(String modelName, SchemanticType customOptions) {
+  Model createModel(
+    String modelName,
+    SchemanticType customOptions, {
+    ModelInfo? modelInfo,
+  }) {
+    final isGemma = customOptions == GemmaOptions.$schema;
     return Model(
       name: '$name/$modelName',
       customOptions: customOptions,
-      metadata: {'model': commonModelInfo.toJson()},
+      metadata: {'model': (modelInfo ?? commonModelInfo).toJson()},
       fn: (req, ctx) async {
         gcl.GenerationConfig generationConfig;
         List<gcl.SafetySetting>? safetySettings;
@@ -74,9 +102,17 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           );
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         } else {
-          final options = req.config == null
-              ? GeminiOptions()
-              : GeminiOptions.$schema.parse(req.config!);
+          final GeminiOptions options;
+          if (isGemma) {
+            final gemmaOptions = req.config == null
+                ? GemmaOptions()
+                : GemmaOptions.$schema.parse(req.config!);
+            options = _gemmaToGeminiOptions(gemmaOptions);
+          } else {
+            options = req.config == null
+                ? GeminiOptions()
+                : GeminiOptions.$schema.parse(req.config!);
+          }
           apiKey = options.apiKey;
           generationConfig = toGeminiSettings(
             options,
@@ -98,9 +134,12 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           final systemMessage = req.messages
               .where((m) => m.role == Role.system)
               .firstOrNull;
-          final messages = req.messages
+          final nonSystemMessages = req.messages
               .where((m) => m.role != Role.system)
               .toList();
+          final messages = isGemma
+              ? stripReasoningParts(nonSystemMessages)
+              : nonSystemMessages;
 
           final generateRequest = gcl.GenerateContentRequest(
             contents: toGeminiContent(messages),
@@ -189,6 +228,15 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
       return createEmbedder(name);
     }
     if (actionType == 'model') {
+      if (isGemmaModelName(name)) {
+        return createModel(
+          name,
+          GemmaOptions.$schema,
+          modelInfo: isGemma3ModelName(name)
+              ? gemma3ModelInfo
+              : commonGemmaModelInfo,
+        );
+      }
       if (name.contains('-tts')) {
         return createModel(name, GeminiTtsOptions.$schema);
       }
@@ -425,6 +473,51 @@ List<gcl.Content> toGeminiContent(List<Message> messages) {
         ),
       )
       .toList();
+}
+
+@visibleForTesting
+List<Message> stripReasoningParts(List<Message> messages) {
+  return messages
+      .map(
+        (m) => Message(
+          role: m.role,
+          content: m.content
+              .where(
+                (p) =>
+                    !p.isReasoning && p.metadata?['thoughtSignature'] == null,
+              )
+              .toList(),
+          metadata: m.metadata,
+        ),
+      )
+      .where((m) => m.content.isNotEmpty)
+      .toList();
+}
+
+GeminiOptions _gemmaToGeminiOptions(GemmaOptions o) {
+  return GeminiOptions(
+    apiKey: o.apiKey,
+    safetySettings: o.safetySettings,
+    codeExecution: o.codeExecution,
+    functionCallingConfig: o.functionCallingConfig,
+    thinkingConfig: o.thinkingConfig,
+    responseModalities: o.responseModalities,
+    googleSearch: o.googleSearch,
+    fileSearch: o.fileSearch,
+    temperature: o.temperature,
+    topP: o.topP,
+    topK: o.topK,
+    candidateCount: o.candidateCount,
+    stopSequences: o.stopSequences,
+    maxOutputTokens: o.maxOutputTokens,
+    responseMimeType: o.responseMimeType,
+    responseLogprobs: o.responseLogprobs,
+    logprobs: o.logprobs,
+    presencePenalty: o.presencePenalty,
+    frequencyPenalty: o.frequencyPenalty,
+    seed: o.seed,
+    speechConfig: o.speechConfig,
+  );
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -68,7 +68,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
     SchemanticType customOptions, {
     ModelInfo? modelInfo,
   }) {
-    final isGemma = customOptions == GemmaOptions.$schema;
+    final isGemma = isGemmaModelName(modelName);
     return Model(
       name: '$name/$modelName',
       customOptions: customOptions,

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -21,6 +21,7 @@ import 'package:schemantic/schemantic.dart';
 
 import 'aggregation.dart';
 import 'api_client.dart';
+import 'gemma.dart';
 import 'generated/generativelanguage.dart' as gcl;
 import 'model.dart';
 
@@ -36,26 +37,6 @@ final commonModelInfo = ModelInfo(
     'constrained': true,
   },
 );
-
-final commonGemmaModelInfo = ModelInfo(
-  supports: {
-    'multiturn': true,
-    'media': true,
-    'tools': true,
-    'toolChoice': true,
-    'systemRole': true,
-    'constrained': 'no-tools',
-  },
-);
-
-final gemma3ModelInfo = ModelInfo(
-  supports: {...?commonGemmaModelInfo.supports, 'systemRole': false},
-);
-
-bool isGemmaModelName(String name) => name.startsWith('gemma-');
-
-bool isGemma3ModelName(String name) =>
-    name.startsWith('gemma-3-') || name.startsWith('gemma-3n-');
 
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
@@ -104,7 +85,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             final gemmaOptions = req.config == null
                 ? GemmaOptions()
                 : GemmaOptions.$schema.parse(req.config!);
-            options = _gemmaToGeminiOptions(gemmaOptions);
+            options = gemmaToGeminiOptions(gemmaOptions);
           } else {
             options = req.config == null
                 ? GeminiOptions()
@@ -470,51 +451,6 @@ List<gcl.Content> toGeminiContent(List<Message> messages) {
         ),
       )
       .toList();
-}
-
-@visibleForTesting
-List<Message> stripReasoningParts(List<Message> messages) {
-  return messages
-      .map(
-        (m) => Message(
-          role: m.role,
-          content: m.content
-              .where(
-                (p) =>
-                    !p.isReasoning && p.metadata?['thoughtSignature'] == null,
-              )
-              .toList(),
-          metadata: m.metadata,
-        ),
-      )
-      .where((m) => m.content.isNotEmpty)
-      .toList();
-}
-
-GeminiOptions _gemmaToGeminiOptions(GemmaOptions o) {
-  return GeminiOptions(
-    apiKey: o.apiKey,
-    safetySettings: o.safetySettings,
-    codeExecution: o.codeExecution,
-    functionCallingConfig: o.functionCallingConfig,
-    thinkingConfig: o.thinkingConfig,
-    responseModalities: o.responseModalities,
-    googleSearch: o.googleSearch,
-    fileSearch: o.fileSearch,
-    temperature: o.temperature,
-    topP: o.topP,
-    topK: o.topK,
-    candidateCount: o.candidateCount,
-    stopSequences: o.stopSequences,
-    maxOutputTokens: o.maxOutputTokens,
-    responseMimeType: o.responseMimeType,
-    responseLogprobs: o.responseLogprobs,
-    logprobs: o.logprobs,
-    presencePenalty: o.presencePenalty,
-    frequencyPenalty: o.frequencyPenalty,
-    seed: o.seed,
-    speechConfig: o.speechConfig,
-  );
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -49,8 +49,8 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   /// capabilities for known models.
   Map<String, ModelInfo> get knownModels => const {};
 
-  /// Whether `gemma-*` model names resolve with Gemma-specific handling
-  /// (Gemma options schema, system-message folding, reasoning strip).
+  /// Whether `gemma-4-*` model names resolve with Gemma-specific handling
+  /// (Gemma options schema and reasoning strip).
   bool get servesGemmaModels => false;
 
   /// Returns the capability metadata for [modelName], falling back to
@@ -63,7 +63,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
     SchemanticType customOptions, {
     ModelInfo? modelInfo,
   }) {
-    final isGemma = servesGemmaModels && isGemmaModelName(modelName);
+    final isGemma = servesGemmaModels && isGemma4ModelName(modelName);
     return Model(
       name: '$name/$modelName',
       customOptions: customOptions,
@@ -128,11 +128,11 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
               .toList();
           var messages = nonSystemMessages;
           if (isGemma) {
-            if (systemMessage != null) {
-              messages = foldSystemMessage(systemMessage, messages);
-            }
             messages = stripReasoningParts(messages);
           }
+          final effectiveSystemMessage = isGemma && systemMessage != null
+              ? stripReasoningParts([systemMessage]).firstOrNull
+              : systemMessage;
 
           if (isGemma && messages.isEmpty) {
             throw GenkitException(
@@ -150,11 +150,16 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             safetySettings: safetySettings?.isEmpty ?? true
                 ? null
                 : safetySettings,
-            systemInstruction: systemMessage == null || isGemma
+            systemInstruction: effectiveSystemMessage == null
                 ? null
                 : gcl.Content(
-                    parts: systemMessage.content.map(toGeminiPart).toList(),
-                    role: 'system',
+                    parts: effectiveSystemMessage.content
+                        .map(toGeminiPart)
+                        .toList(),
+                    // The Gemini API accepts a dedicated `systemInstruction`
+                    // object whose role can be left unset. This is required
+                    // for Gemma 4; `role: system` is not a valid Content role.
+                    role: isGemma ? null : 'system',
                   ),
           );
 
@@ -229,7 +234,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
       return createEmbedder(name);
     }
     if (actionType == 'model') {
-      if (servesGemmaModels && isGemmaModelName(name)) {
+      if (servesGemmaModels && isGemma4ModelName(name)) {
         return createModel(
           name,
           GemmaOptions.$schema,

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -81,7 +81,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
     SchemanticType customOptions, {
     ModelInfo? modelInfo,
   }) {
-    final isGemma = customOptions == GemmaOptions.$schema;
+    final isGemma = isGemmaModelName(modelName);
     return Model(
       name: '$name/$modelName',
       customOptions: customOptions,

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -21,6 +21,7 @@ import 'package:schemantic/schemantic.dart';
 
 import 'aggregation.dart';
 import 'api_client.dart';
+import 'gemma.dart';
 import 'generated/generativelanguage.dart' as gcl;
 import 'model.dart';
 
@@ -36,26 +37,6 @@ final commonModelInfo = ModelInfo(
     'constrained': true,
   },
 );
-
-final commonGemmaModelInfo = ModelInfo(
-  supports: {
-    'multiturn': true,
-    'media': true,
-    'tools': true,
-    'toolChoice': true,
-    'systemRole': true,
-    'constrained': 'no-tools',
-  },
-);
-
-final gemma3ModelInfo = ModelInfo(
-  supports: {...?commonGemmaModelInfo.supports, 'systemRole': false},
-);
-
-bool isGemmaModelName(String name) => name.startsWith('gemma-');
-
-bool isGemma3ModelName(String name) =>
-    name.startsWith('gemma-3-') || name.startsWith('gemma-3n-');
 
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
@@ -118,7 +99,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             final gemmaOptions = req.config == null
                 ? GemmaOptions()
                 : GemmaOptions.$schema.parse(req.config!);
-            options = _gemmaToGeminiOptions(gemmaOptions);
+            options = gemmaToGeminiOptions(gemmaOptions);
           } else {
             options = req.config == null
                 ? GeminiOptions()
@@ -501,51 +482,6 @@ List<gcl.Content> toGeminiContent(List<Message> messages) {
         ),
       )
       .toList();
-}
-
-@visibleForTesting
-List<Message> stripReasoningParts(List<Message> messages) {
-  return messages
-      .map(
-        (m) => Message(
-          role: m.role,
-          content: m.content
-              .where(
-                (p) =>
-                    !p.isReasoning && p.metadata?['thoughtSignature'] == null,
-              )
-              .toList(),
-          metadata: m.metadata,
-        ),
-      )
-      .where((m) => m.content.isNotEmpty)
-      .toList();
-}
-
-GeminiOptions _gemmaToGeminiOptions(GemmaOptions o) {
-  return GeminiOptions(
-    apiKey: o.apiKey,
-    safetySettings: o.safetySettings,
-    codeExecution: o.codeExecution,
-    functionCallingConfig: o.functionCallingConfig,
-    thinkingConfig: o.thinkingConfig,
-    responseModalities: o.responseModalities,
-    googleSearch: o.googleSearch,
-    fileSearch: o.fileSearch,
-    temperature: o.temperature,
-    topP: o.topP,
-    topK: o.topK,
-    candidateCount: o.candidateCount,
-    stopSequences: o.stopSequences,
-    maxOutputTokens: o.maxOutputTokens,
-    responseMimeType: o.responseMimeType,
-    responseLogprobs: o.responseLogprobs,
-    logprobs: o.logprobs,
-    presencePenalty: o.presencePenalty,
-    frequencyPenalty: o.frequencyPenalty,
-    seed: o.seed,
-    speechConfig: o.speechConfig,
-  );
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -126,16 +126,18 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           final nonSystemMessages = req.messages
               .where((m) => m.role != Role.system)
               .toList();
-          var messages = isGemma
-              ? stripReasoningParts(nonSystemMessages)
-              : nonSystemMessages;
-          if (isGemma && systemMessage != null) {
-            messages = foldSystemMessage(systemMessage, messages);
+          var messages = nonSystemMessages;
+          if (isGemma) {
+            if (systemMessage != null) {
+              messages = foldSystemMessage(systemMessage, messages);
+            }
+            messages = stripReasoningParts(messages);
           }
 
           if (isGemma && messages.isEmpty) {
             throw GenkitException(
-              'No valid messages found for the model request.',
+              'Gemma request is empty: no message content remained after '
+              'reasoning parts were stripped from the history.',
               status: StatusCodes.INVALID_ARGUMENT,
             );
           }

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -37,6 +37,29 @@ final commonModelInfo = ModelInfo(
   },
 );
 
+final commonGemmaModelInfo = ModelInfo(
+  supports: {
+    'multiturn': true,
+    'media': true,
+    'tools': true,
+    'toolChoice': true,
+    'systemRole': true,
+    'constrained': 'no-tools',
+  },
+);
+
+final gemma3ModelInfo = ModelInfo(
+  supports: {
+    ...?commonGemmaModelInfo.supports,
+    'systemRole': false,
+  },
+);
+
+bool isGemmaModelName(String name) => name.startsWith('gemma-');
+
+bool isGemma3ModelName(String name) =>
+    name.startsWith('gemma-3-') || name.startsWith('gemma-3n-');
+
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
 
@@ -53,11 +76,16 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   ModelInfo modelInfoFor(String modelName) =>
       knownModels[modelName] ?? commonModelInfo;
 
-  Model createModel(String modelName, SchemanticType customOptions) {
+  Model createModel(
+    String modelName,
+    SchemanticType customOptions, {
+    ModelInfo? modelInfo,
+  }) {
+    final isGemma = customOptions == GemmaOptions.$schema;
     return Model(
       name: '$name/$modelName',
       customOptions: customOptions,
-      metadata: {'model': modelInfoFor(modelName).toJson()},
+      metadata: {'model': (modelInfo ?? modelInfoFor(modelName)).toJson()},
       fn: (req, ctx) async {
         gcl.GenerationConfig generationConfig;
         List<gcl.SafetySetting>? safetySettings;
@@ -88,9 +116,17 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           );
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         } else {
-          final options = req.config == null
-              ? GeminiOptions()
-              : GeminiOptions.$schema.parse(req.config!);
+          final GeminiOptions options;
+          if (isGemma) {
+            final gemmaOptions = req.config == null
+                ? GemmaOptions()
+                : GemmaOptions.$schema.parse(req.config!);
+            options = _gemmaToGeminiOptions(gemmaOptions);
+          } else {
+            options = req.config == null
+                ? GeminiOptions()
+                : GeminiOptions.$schema.parse(req.config!);
+          }
           apiKey = options.apiKey;
           generationConfig = toGeminiSettings(
             options,
@@ -113,9 +149,12 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           final systemMessage = req.messages
               .where((m) => m.role == Role.system)
               .firstOrNull;
-          final messages = req.messages
+          final nonSystemMessages = req.messages
               .where((m) => m.role != Role.system)
               .toList();
+          final messages = isGemma
+              ? stripReasoningParts(nonSystemMessages)
+              : nonSystemMessages;
 
           final generateRequest = gcl.GenerateContentRequest(
             contents: toGeminiContent(messages),
@@ -204,6 +243,15 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
       return createEmbedder(name);
     }
     if (actionType == 'model') {
+      if (isGemmaModelName(name)) {
+        return createModel(
+          name,
+          GemmaOptions.$schema,
+          modelInfo: isGemma3ModelName(name)
+              ? gemma3ModelInfo
+              : commonGemmaModelInfo,
+        );
+      }
       if (name.contains('-tts')) {
         return createModel(name, GeminiTtsOptions.$schema);
       }
@@ -456,6 +504,51 @@ List<gcl.Content> toGeminiContent(List<Message> messages) {
         ),
       )
       .toList();
+}
+
+@visibleForTesting
+List<Message> stripReasoningParts(List<Message> messages) {
+  return messages
+      .map(
+        (m) => Message(
+          role: m.role,
+          content: m.content
+              .where(
+                (p) =>
+                    !p.isReasoning && p.metadata?['thoughtSignature'] == null,
+              )
+              .toList(),
+          metadata: m.metadata,
+        ),
+      )
+      .where((m) => m.content.isNotEmpty)
+      .toList();
+}
+
+GeminiOptions _gemmaToGeminiOptions(GemmaOptions o) {
+  return GeminiOptions(
+    apiKey: o.apiKey,
+    safetySettings: o.safetySettings,
+    codeExecution: o.codeExecution,
+    functionCallingConfig: o.functionCallingConfig,
+    thinkingConfig: o.thinkingConfig,
+    responseModalities: o.responseModalities,
+    googleSearch: o.googleSearch,
+    fileSearch: o.fileSearch,
+    temperature: o.temperature,
+    topP: o.topP,
+    topK: o.topK,
+    candidateCount: o.candidateCount,
+    stopSequences: o.stopSequences,
+    maxOutputTokens: o.maxOutputTokens,
+    responseMimeType: o.responseMimeType,
+    responseLogprobs: o.responseLogprobs,
+    logprobs: o.logprobs,
+    presencePenalty: o.presencePenalty,
+    frequencyPenalty: o.frequencyPenalty,
+    seed: o.seed,
+    speechConfig: o.speechConfig,
+  );
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -94,17 +94,9 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           );
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         } else {
-          final GeminiOptions options;
-          if (isGemma) {
-            final gemmaOptions = req.config == null
-                ? GemmaOptions()
-                : GemmaOptions.$schema.parse(req.config!);
-            options = gemmaToGeminiOptions(gemmaOptions);
-          } else {
-            options = req.config == null
-                ? GeminiOptions()
-                : GeminiOptions.$schema.parse(req.config!);
-          }
+          final options = isGemma
+              ? gemmaToGeminiOptions(GemmaOptions.fromJson(req.config ?? {}))
+              : GeminiOptions.fromJson(req.config ?? {});
           apiKey = options.apiKey;
           generationConfig = toGeminiSettings(
             options,
@@ -133,6 +125,13 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           final messages = isGemma
               ? stripReasoningParts(nonSystemMessages)
               : nonSystemMessages;
+
+          if (isGemma && messages.isEmpty) {
+            throw GenkitException(
+              'No valid messages found for the model request.',
+              status: StatusCodes.INVALID_ARGUMENT,
+            );
+          }
 
           final generateRequest = gcl.GenerateContentRequest(
             contents: toGeminiContent(messages),

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -49,6 +49,10 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   /// capabilities for known models.
   Map<String, ModelInfo> get knownModels => const {};
 
+  /// Whether `gemma-*` model names resolve with Gemma-specific handling
+  /// (Gemma options schema, system-message folding, reasoning strip).
+  bool get servesGemmaModels => false;
+
   /// Returns the capability metadata for [modelName], falling back to
   /// [commonModelInfo] for names not in [knownModels].
   ModelInfo modelInfoFor(String modelName) =>
@@ -59,7 +63,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
     SchemanticType customOptions, {
     ModelInfo? modelInfo,
   }) {
-    final isGemma = isGemmaModelName(modelName);
+    final isGemma = servesGemmaModels && isGemmaModelName(modelName);
     return Model(
       name: '$name/$modelName',
       customOptions: customOptions,
@@ -122,9 +126,12 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           final nonSystemMessages = req.messages
               .where((m) => m.role != Role.system)
               .toList();
-          final messages = isGemma
+          var messages = isGemma
               ? stripReasoningParts(nonSystemMessages)
               : nonSystemMessages;
+          if (isGemma && systemMessage != null) {
+            messages = foldSystemMessage(systemMessage, messages);
+          }
 
           if (isGemma && messages.isEmpty) {
             throw GenkitException(
@@ -141,7 +148,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             safetySettings: safetySettings?.isEmpty ?? true
                 ? null
                 : safetySettings,
-            systemInstruction: systemMessage == null
+            systemInstruction: systemMessage == null || isGemma
                 ? null
                 : gcl.Content(
                     parts: systemMessage.content.map(toGeminiPart).toList(),
@@ -220,13 +227,11 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
       return createEmbedder(name);
     }
     if (actionType == 'model') {
-      if (isGemmaModelName(name)) {
+      if (servesGemmaModels && isGemmaModelName(name)) {
         return createModel(
           name,
           GemmaOptions.$schema,
-          modelInfo: isGemma3ModelName(name)
-              ? gemma3ModelInfo
-              : commonGemmaModelInfo,
+          modelInfo: gemmaModelInfo,
         );
       }
       if (name.contains('-tts')) {

--- a/packages/genkit_google_genai/lib/src/gemma.dart
+++ b/packages/genkit_google_genai/lib/src/gemma.dart
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+
+import 'model.dart';
+
+final commonGemmaModelInfo = ModelInfo(
+  supports: {
+    'multiturn': true,
+    'media': true,
+    'tools': true,
+    'toolChoice': true,
+    'systemRole': true,
+    'constrained': 'no-tools',
+  },
+);
+
+final gemma3ModelInfo = ModelInfo(
+  supports: {...?commonGemmaModelInfo.supports, 'systemRole': false},
+);
+
+bool isGemmaModelName(String name) => name.startsWith('gemma-');
+
+bool isGemma3ModelName(String name) =>
+    name.startsWith('gemma-3-') || name.startsWith('gemma-3n-');
+
+/// Strips parts that the Gemma API rejects in history: reasoning parts
+/// and any text/tool parts whose metadata carries a `thoughtSignature`.
+/// Messages that become empty after filtering are dropped.
+List<Message> stripReasoningParts(List<Message> messages) {
+  return messages
+      .map(
+        (m) => Message(
+          role: m.role,
+          content: m.content
+              .where(
+                (p) =>
+                    !p.isReasoning && p.metadata?['thoughtSignature'] == null,
+              )
+              .toList(),
+          metadata: m.metadata,
+        ),
+      )
+      .where((m) => m.content.isNotEmpty)
+      .toList();
+}
+
+/// Maps a [GemmaOptions] config to its [GeminiOptions] equivalent so the
+/// shared `toGeminiSettings`/`toGeminiTools`/etc. helpers can be reused.
+/// Every Gemma field has an identical Gemini twin; the only schema-level
+/// difference is the tighter `temperature` cap on Gemma.
+GeminiOptions gemmaToGeminiOptions(GemmaOptions o) {
+  return GeminiOptions(
+    apiKey: o.apiKey,
+    safetySettings: o.safetySettings,
+    codeExecution: o.codeExecution,
+    functionCallingConfig: o.functionCallingConfig,
+    thinkingConfig: o.thinkingConfig,
+    responseModalities: o.responseModalities,
+    googleSearch: o.googleSearch,
+    fileSearch: o.fileSearch,
+    temperature: o.temperature,
+    topP: o.topP,
+    topK: o.topK,
+    candidateCount: o.candidateCount,
+    stopSequences: o.stopSequences,
+    maxOutputTokens: o.maxOutputTokens,
+    responseMimeType: o.responseMimeType,
+    responseLogprobs: o.responseLogprobs,
+    logprobs: o.logprobs,
+    presencePenalty: o.presencePenalty,
+    frequencyPenalty: o.frequencyPenalty,
+    seed: o.seed,
+    speechConfig: o.speechConfig,
+  );
+}

--- a/packages/genkit_google_genai/lib/src/gemma.dart
+++ b/packages/genkit_google_genai/lib/src/gemma.dart
@@ -22,12 +22,12 @@ final gemmaModelInfo = ModelInfo(
     'media': true,
     'tools': true,
     'toolChoice': true,
-    'systemRole': false,
+    'systemRole': true,
     'constrained': 'no-tools',
   },
 );
 
-bool isGemmaModelName(String name) => name.startsWith('gemma-');
+bool isGemma4ModelName(String name) => name.startsWith('gemma-4-');
 
 /// Strips parts that the Gemma API rejects in history: reasoning parts
 /// and any text/tool parts whose metadata carries a `thoughtSignature`.
@@ -48,26 +48,6 @@ List<Message> stripReasoningParts(List<Message> messages) {
       )
       .where((m) => m.content.isNotEmpty)
       .toList();
-}
-
-/// Returns [messages] with [system]'s content prepended to the first user
-/// message. When no user message exists, a new user message carrying the
-/// system content is inserted at the front.
-List<Message> foldSystemMessage(Message system, List<Message> messages) {
-  final index = messages.indexWhere((m) => m.role == Role.user);
-  if (index == -1) {
-    return [Message(role: Role.user, content: system.content), ...messages];
-  }
-  final target = messages[index];
-  return [
-    ...messages.sublist(0, index),
-    Message(
-      role: Role.user,
-      content: [...system.content, ...target.content],
-      metadata: target.metadata,
-    ),
-    ...messages.sublist(index + 1),
-  ];
 }
 
 /// Maps a [GemmaOptions] config to its [GeminiOptions] equivalent.

--- a/packages/genkit_google_genai/lib/src/gemma.dart
+++ b/packages/genkit_google_genai/lib/src/gemma.dart
@@ -29,8 +29,8 @@ final gemmaModelInfo = ModelInfo(
 
 bool isGemma4ModelName(String name) => name.startsWith('gemma-4-');
 
-/// Strips parts that the Gemma API rejects in history: reasoning parts
-/// and any text/tool parts whose metadata carries a `thoughtSignature`.
+/// Strips what the Gemma API rejects in history: reasoning parts are
+/// dropped, and `thoughtSignature` metadata is removed from other parts.
 /// Messages that become empty after filtering are dropped.
 List<Message> stripReasoningParts(List<Message> messages) {
   return messages
@@ -38,16 +38,29 @@ List<Message> stripReasoningParts(List<Message> messages) {
         (m) => Message(
           role: m.role,
           content: m.content
-              .where(
-                (p) =>
-                    !p.isReasoning && p.metadata?['thoughtSignature'] == null,
-              )
+              .where((p) => !p.isReasoning)
+              .map(_withoutThoughtSignature)
               .toList(),
           metadata: m.metadata,
         ),
       )
       .where((m) => m.content.isNotEmpty)
       .toList();
+}
+
+Part _withoutThoughtSignature(Part p) {
+  final metadata = p.metadata;
+  if (metadata == null || !metadata.containsKey('thoughtSignature')) {
+    return p;
+  }
+  final stripped = {...metadata}..remove('thoughtSignature');
+  final json = {...p.toJson()};
+  if (stripped.isEmpty) {
+    json.remove('metadata');
+  } else {
+    json['metadata'] = stripped;
+  }
+  return Part.fromJson(json);
 }
 
 /// Maps a [GemmaOptions] config to its [GeminiOptions] equivalent.

--- a/packages/genkit_google_genai/lib/src/gemma.dart
+++ b/packages/genkit_google_genai/lib/src/gemma.dart
@@ -16,25 +16,18 @@ import 'package:genkit/plugin.dart';
 
 import 'model.dart';
 
-final commonGemmaModelInfo = ModelInfo(
+final gemmaModelInfo = ModelInfo(
   supports: {
     'multiturn': true,
     'media': true,
     'tools': true,
     'toolChoice': true,
-    'systemRole': true,
+    'systemRole': false,
     'constrained': 'no-tools',
   },
 );
 
-final gemma3ModelInfo = ModelInfo(
-  supports: {...?commonGemmaModelInfo.supports, 'systemRole': false},
-);
-
 bool isGemmaModelName(String name) => name.startsWith('gemma-');
-
-bool isGemma3ModelName(String name) =>
-    name.startsWith('gemma-3-') || name.startsWith('gemma-3n-');
 
 /// Strips parts that the Gemma API rejects in history: reasoning parts
 /// and any text/tool parts whose metadata carries a `thoughtSignature`.
@@ -57,11 +50,38 @@ List<Message> stripReasoningParts(List<Message> messages) {
       .toList();
 }
 
-/// Maps a [GemmaOptions] config to its [GeminiOptions] equivalent so the
-/// shared `toGeminiSettings`/`toGeminiTools`/etc. helpers can be reused.
-/// Every Gemma field has an identical Gemini twin; the only schema-level
-/// difference is the tighter `temperature` cap on Gemma.
+/// Returns [messages] with [system]'s content prepended to the first user
+/// message. When no user message exists, a new user message carrying the
+/// system content is inserted at the front.
+List<Message> foldSystemMessage(Message system, List<Message> messages) {
+  final index = messages.indexWhere((m) => m.role == Role.user);
+  if (index == -1) {
+    return [Message(role: Role.user, content: system.content), ...messages];
+  }
+  final target = messages[index];
+  return [
+    ...messages.sublist(0, index),
+    Message(
+      role: Role.user,
+      content: [...system.content, ...target.content],
+      metadata: target.metadata,
+    ),
+    ...messages.sublist(index + 1),
+  ];
+}
+
+/// Maps a [GemmaOptions] config to its [GeminiOptions] equivalent.
+///
+/// Throws a [GenkitException] with `INVALID_ARGUMENT` when `temperature` is
+/// outside the 0.0-1.0 range the Gemma API accepts.
 GeminiOptions gemmaToGeminiOptions(GemmaOptions o) {
+  final temperature = o.temperature;
+  if (temperature != null && (temperature < 0.0 || temperature > 1.0)) {
+    throw GenkitException(
+      'Gemma models accept temperature between 0.0 and 1.0, got $temperature.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
   return GeminiOptions(
     apiKey: o.apiKey,
     safetySettings: o.safetySettings,

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -54,12 +54,23 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
       final models = (modelsResponse.models ?? [])
           .where((model) {
             return model.name != null &&
-                model.name!.startsWith('models/gemini-');
+                (model.name!.startsWith('models/gemini-') ||
+                    model.name!.startsWith('models/gemma-'));
           })
           .map((model) {
-            final isTts = model.name!.contains('-tts');
+            final short = model.name!.split('/').last;
+            if (isGemmaModelName(short)) {
+              return modelMetadata(
+                '$name/$short',
+                customOptions: GemmaOptions.$schema,
+                modelInfo: isGemma3ModelName(short)
+                    ? gemma3ModelInfo
+                    : commonGemmaModelInfo,
+              );
+            }
+            final isTts = short.contains('-tts');
             return modelMetadata(
-              '$name/${model.name!.split('/').last}',
+              '$name/$short',
               customOptions: isTts
                   ? GeminiTtsOptions.$schema
                   : GeminiOptions.$schema,

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -17,6 +17,7 @@ import 'package:meta/meta.dart';
 
 import 'api_client.dart';
 import 'common_plugin.dart';
+import 'gemma.dart';
 import 'generated/generativelanguage.dart' as gcl;
 import 'model.dart';
 

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -70,11 +70,21 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
       final models = (modelsResponse.models ?? [])
           .where((model) {
             return model.name != null &&
-                model.name!.startsWith('models/gemini-');
+                (model.name!.startsWith('models/gemini-') ||
+                    model.name!.startsWith('models/gemma-'));
           })
           .map((model) {
-            final bareName = model.name!.split('/').last;
+final bareName = model.name!.split('/').last;
             discoveredNames.add(bareName);
+            if (isGemmaModelName(bareName)) {
+              return modelMetadata(
+                '$name/$bareName',
+                customOptions: GemmaOptions.$schema,
+                modelInfo: isGemma3ModelName(bareName)
+                    ? gemma3ModelInfo
+                    : commonGemmaModelInfo,
+              );
+            }
             final isTts = bareName.contains('-tts');
             return modelMetadata(
               '$name/$bareName',

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -38,7 +38,7 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
   String get name => 'googleai';
 
   @override
-final Map<String, ModelInfo> knownModels = knownGeminiModels;
+  final Map<String, ModelInfo> knownModels = knownGeminiModels;
 
   @override
   bool get servesGemmaModels => true;
@@ -84,7 +84,7 @@ final Map<String, ModelInfo> knownModels = knownGeminiModels;
               return modelMetadata(
                 '$name/$bareName',
                 customOptions: GemmaOptions.$schema,
-modelInfo: gemmaModelInfo,
+                modelInfo: gemmaModelInfo,
               );
             }
             final isTts = bareName.contains('-tts');

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -38,7 +38,10 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
   String get name => 'googleai';
 
   @override
-  final Map<String, ModelInfo> knownModels = knownGeminiModels;
+final Map<String, ModelInfo> knownModels = knownGeminiModels;
+
+  @override
+  bool get servesGemmaModels => true;
 
   @override
   Future<GenerativeLanguageBaseClient> getApiClient([
@@ -75,15 +78,13 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
                     model.name!.startsWith('models/gemma-'));
           })
           .map((model) {
-final bareName = model.name!.split('/').last;
+            final bareName = model.name!.split('/').last;
             discoveredNames.add(bareName);
             if (isGemmaModelName(bareName)) {
               return modelMetadata(
                 '$name/$bareName',
                 customOptions: GemmaOptions.$schema,
-                modelInfo: isGemma3ModelName(bareName)
-                    ? gemma3ModelInfo
-                    : commonGemmaModelInfo,
+modelInfo: gemmaModelInfo,
               );
             }
             final isTts = bareName.contains('-tts');

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -80,7 +80,7 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
           .map((model) {
             final bareName = model.name!.split('/').last;
             discoveredNames.add(bareName);
-            if (isGemmaModelName(bareName)) {
+            if (isGemma4ModelName(bareName)) {
               return modelMetadata(
                 '$name/$bareName',
                 customOptions: GemmaOptions.$schema,

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -18,6 +18,7 @@ import 'package:meta/meta.dart';
 
 import 'api_client.dart';
 import 'common_plugin.dart';
+import 'gemma.dart';
 import 'generated/generativelanguage.dart' as gcl;
 import 'known_models.dart';
 import 'model.dart';

--- a/packages/genkit_google_genai/lib/src/model.dart
+++ b/packages/genkit_google_genai/lib/src/model.dart
@@ -57,6 +57,42 @@ abstract class $GeminiOptions {
 }
 
 @Schema()
+abstract class $GemmaOptions {
+  String? get apiKey;
+
+  List<$SafetySettings>? get safetySettings;
+
+  bool? get codeExecution;
+  $FunctionCallingConfig? get functionCallingConfig;
+  $ThinkingConfig? get thinkingConfig;
+  List<String>? get responseModalities;
+
+  // Retrieval
+  $GoogleSearch? get googleSearch;
+  $FileSearch? get fileSearch;
+
+  @DoubleField(minimum: 0.0, maximum: 1.0)
+  double? get temperature;
+
+  @DoubleField(minimum: 0.0, maximum: 1.0)
+  double? get topP;
+
+  int? get topK;
+  int? get candidateCount;
+  List<String>? get stopSequences;
+  int? get maxOutputTokens;
+
+  String? get responseMimeType;
+  bool? get responseLogprobs;
+  int? get logprobs;
+  double? get presencePenalty;
+  double? get frequencyPenalty;
+  int? get seed;
+
+  $SpeechConfig? get speechConfig;
+}
+
+@Schema()
 abstract class $SafetySettings {
   @StringField(
     enumValues: [

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -413,6 +413,398 @@ base class _GeminiOptionsTypeFactory extends SchemanticType<GeminiOptions> {
   );
 }
 
+base class GemmaOptions {
+  factory GemmaOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  GemmaOptions._(this._json);
+
+  GemmaOptions({
+    String? apiKey,
+    List<SafetySettings>? safetySettings,
+    bool? codeExecution,
+    FunctionCallingConfig? functionCallingConfig,
+    ThinkingConfig? thinkingConfig,
+    List<String>? responseModalities,
+    GoogleSearch? googleSearch,
+    FileSearch? fileSearch,
+    double? temperature,
+    double? topP,
+    int? topK,
+    int? candidateCount,
+    List<String>? stopSequences,
+    int? maxOutputTokens,
+    String? responseMimeType,
+    bool? responseLogprobs,
+    int? logprobs,
+    double? presencePenalty,
+    double? frequencyPenalty,
+    int? seed,
+    SpeechConfig? speechConfig,
+  }) {
+    _json = {
+      'apiKey': ?apiKey,
+      'safetySettings': ?safetySettings?.map((e) => e.toJson()).toList(),
+      'codeExecution': ?codeExecution,
+      'functionCallingConfig': ?functionCallingConfig?.toJson(),
+      'thinkingConfig': ?thinkingConfig?.toJson(),
+      'responseModalities': ?responseModalities,
+      'googleSearch': ?googleSearch?.toJson(),
+      'fileSearch': ?fileSearch?.toJson(),
+      'temperature': ?temperature,
+      'topP': ?topP,
+      'topK': ?topK,
+      'candidateCount': ?candidateCount,
+      'stopSequences': ?stopSequences,
+      'maxOutputTokens': ?maxOutputTokens,
+      'responseMimeType': ?responseMimeType,
+      'responseLogprobs': ?responseLogprobs,
+      'logprobs': ?logprobs,
+      'presencePenalty': ?presencePenalty,
+      'frequencyPenalty': ?frequencyPenalty,
+      'seed': ?seed,
+      'speechConfig': ?speechConfig?.toJson(),
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static const SchemanticType<GemmaOptions> $schema =
+      _GemmaOptionsTypeFactory();
+
+  String? get apiKey {
+    return _json['apiKey'] as String?;
+  }
+
+  set apiKey(String? value) {
+    if (value == null) {
+      _json.remove('apiKey');
+    } else {
+      _json['apiKey'] = value;
+    }
+  }
+
+  List<SafetySettings>? get safetySettings {
+    return (_json['safetySettings'] as List?)
+        ?.map((e) => SafetySettings.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  set safetySettings(List<SafetySettings>? value) {
+    if (value == null) {
+      _json.remove('safetySettings');
+    } else {
+      _json['safetySettings'] = value.toList();
+    }
+  }
+
+  bool? get codeExecution {
+    return _json['codeExecution'] as bool?;
+  }
+
+  set codeExecution(bool? value) {
+    if (value == null) {
+      _json.remove('codeExecution');
+    } else {
+      _json['codeExecution'] = value;
+    }
+  }
+
+  FunctionCallingConfig? get functionCallingConfig {
+    return _json['functionCallingConfig'] == null
+        ? null
+        : FunctionCallingConfig.fromJson(
+            _json['functionCallingConfig'] as Map<String, dynamic>,
+          );
+  }
+
+  set functionCallingConfig(FunctionCallingConfig? value) {
+    if (value == null) {
+      _json.remove('functionCallingConfig');
+    } else {
+      _json['functionCallingConfig'] = value;
+    }
+  }
+
+  ThinkingConfig? get thinkingConfig {
+    return _json['thinkingConfig'] == null
+        ? null
+        : ThinkingConfig.fromJson(
+            _json['thinkingConfig'] as Map<String, dynamic>,
+          );
+  }
+
+  set thinkingConfig(ThinkingConfig? value) {
+    if (value == null) {
+      _json.remove('thinkingConfig');
+    } else {
+      _json['thinkingConfig'] = value;
+    }
+  }
+
+  List<String>? get responseModalities {
+    return (_json['responseModalities'] as List?)?.cast<String>();
+  }
+
+  set responseModalities(List<String>? value) {
+    if (value == null) {
+      _json.remove('responseModalities');
+    } else {
+      _json['responseModalities'] = value;
+    }
+  }
+
+  GoogleSearch? get googleSearch {
+    return _json['googleSearch'] == null
+        ? null
+        : GoogleSearch.fromJson(_json['googleSearch'] as Map<String, dynamic>);
+  }
+
+  set googleSearch(GoogleSearch? value) {
+    if (value == null) {
+      _json.remove('googleSearch');
+    } else {
+      _json['googleSearch'] = value;
+    }
+  }
+
+  FileSearch? get fileSearch {
+    return _json['fileSearch'] == null
+        ? null
+        : FileSearch.fromJson(_json['fileSearch'] as Map<String, dynamic>);
+  }
+
+  set fileSearch(FileSearch? value) {
+    if (value == null) {
+      _json.remove('fileSearch');
+    } else {
+      _json['fileSearch'] = value;
+    }
+  }
+
+  double? get temperature {
+    return (_json['temperature'] as num?)?.toDouble();
+  }
+
+  set temperature(double? value) {
+    if (value == null) {
+      _json.remove('temperature');
+    } else {
+      _json['temperature'] = value;
+    }
+  }
+
+  double? get topP {
+    return (_json['topP'] as num?)?.toDouble();
+  }
+
+  set topP(double? value) {
+    if (value == null) {
+      _json.remove('topP');
+    } else {
+      _json['topP'] = value;
+    }
+  }
+
+  int? get topK {
+    return _json['topK'] as int?;
+  }
+
+  set topK(int? value) {
+    if (value == null) {
+      _json.remove('topK');
+    } else {
+      _json['topK'] = value;
+    }
+  }
+
+  int? get candidateCount {
+    return _json['candidateCount'] as int?;
+  }
+
+  set candidateCount(int? value) {
+    if (value == null) {
+      _json.remove('candidateCount');
+    } else {
+      _json['candidateCount'] = value;
+    }
+  }
+
+  List<String>? get stopSequences {
+    return (_json['stopSequences'] as List?)?.cast<String>();
+  }
+
+  set stopSequences(List<String>? value) {
+    if (value == null) {
+      _json.remove('stopSequences');
+    } else {
+      _json['stopSequences'] = value;
+    }
+  }
+
+  int? get maxOutputTokens {
+    return _json['maxOutputTokens'] as int?;
+  }
+
+  set maxOutputTokens(int? value) {
+    if (value == null) {
+      _json.remove('maxOutputTokens');
+    } else {
+      _json['maxOutputTokens'] = value;
+    }
+  }
+
+  String? get responseMimeType {
+    return _json['responseMimeType'] as String?;
+  }
+
+  set responseMimeType(String? value) {
+    if (value == null) {
+      _json.remove('responseMimeType');
+    } else {
+      _json['responseMimeType'] = value;
+    }
+  }
+
+  bool? get responseLogprobs {
+    return _json['responseLogprobs'] as bool?;
+  }
+
+  set responseLogprobs(bool? value) {
+    if (value == null) {
+      _json.remove('responseLogprobs');
+    } else {
+      _json['responseLogprobs'] = value;
+    }
+  }
+
+  int? get logprobs {
+    return _json['logprobs'] as int?;
+  }
+
+  set logprobs(int? value) {
+    if (value == null) {
+      _json.remove('logprobs');
+    } else {
+      _json['logprobs'] = value;
+    }
+  }
+
+  double? get presencePenalty {
+    return (_json['presencePenalty'] as num?)?.toDouble();
+  }
+
+  set presencePenalty(double? value) {
+    if (value == null) {
+      _json.remove('presencePenalty');
+    } else {
+      _json['presencePenalty'] = value;
+    }
+  }
+
+  double? get frequencyPenalty {
+    return (_json['frequencyPenalty'] as num?)?.toDouble();
+  }
+
+  set frequencyPenalty(double? value) {
+    if (value == null) {
+      _json.remove('frequencyPenalty');
+    } else {
+      _json['frequencyPenalty'] = value;
+    }
+  }
+
+  int? get seed {
+    return _json['seed'] as int?;
+  }
+
+  set seed(int? value) {
+    if (value == null) {
+      _json.remove('seed');
+    } else {
+      _json['seed'] = value;
+    }
+  }
+
+  SpeechConfig? get speechConfig {
+    return _json['speechConfig'] == null
+        ? null
+        : SpeechConfig.fromJson(_json['speechConfig'] as Map<String, dynamic>);
+  }
+
+  set speechConfig(SpeechConfig? value) {
+    if (value == null) {
+      _json.remove('speechConfig');
+    } else {
+      _json['speechConfig'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _GemmaOptionsTypeFactory extends SchemanticType<GemmaOptions> {
+  const _GemmaOptionsTypeFactory();
+
+  @override
+  GemmaOptions parse(Object? json) {
+    return GemmaOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'GemmaOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'apiKey': $Schema.string(),
+            'safetySettings': $Schema.list(
+              items: $Schema.fromMap({'\$ref': r'#/$defs/SafetySettings'}),
+            ),
+            'codeExecution': $Schema.boolean(),
+            'functionCallingConfig': $Schema.fromMap({
+              '\$ref': r'#/$defs/FunctionCallingConfig',
+            }),
+            'thinkingConfig': $Schema.fromMap({
+              '\$ref': r'#/$defs/ThinkingConfig',
+            }),
+            'responseModalities': $Schema.list(items: $Schema.string()),
+            'googleSearch': $Schema.fromMap({'\$ref': r'#/$defs/GoogleSearch'}),
+            'fileSearch': $Schema.fromMap({'\$ref': r'#/$defs/FileSearch'}),
+            'temperature': $Schema.number(minimum: 0.0, maximum: 1.0),
+            'topP': $Schema.number(minimum: 0.0, maximum: 1.0),
+            'topK': $Schema.integer(),
+            'candidateCount': $Schema.integer(),
+            'stopSequences': $Schema.list(items: $Schema.string()),
+            'maxOutputTokens': $Schema.integer(),
+            'responseMimeType': $Schema.string(),
+            'responseLogprobs': $Schema.boolean(),
+            'logprobs': $Schema.integer(),
+            'presencePenalty': $Schema.number(),
+            'frequencyPenalty': $Schema.number(),
+            'seed': $Schema.integer(),
+            'speechConfig': $Schema.fromMap({'\$ref': r'#/$defs/SpeechConfig'}),
+          },
+        )
+        .value,
+    dependencies: [
+      SafetySettings.$schema,
+      FunctionCallingConfig.$schema,
+      ThinkingConfig.$schema,
+      GoogleSearch.$schema,
+      FileSearch.$schema,
+      SpeechConfig.$schema,
+    ],
+  );
+}
+
 base class SafetySettings {
   factory SafetySettings.fromJson(Map<String, dynamic> json) =>
       $schema.parse(json);

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -417,6 +417,7 @@ base class _GeminiOptionsTypeFactory extends SchemanticType<GeminiOptions> {
 }
 
 base class GemmaOptions {
+  /// Creates a [GemmaOptions] from a JSON map.
   factory GemmaOptions.fromJson(Map<String, dynamic> json) =>
       $schema.parse(json);
 
@@ -472,6 +473,7 @@ base class GemmaOptions {
 
   late final Map<String, dynamic> _json;
 
+  /// The JSON schema and type descriptor for [GemmaOptions].
   static const SchemanticType<GemmaOptions> $schema =
       _GemmaOptionsTypeFactory();
 
@@ -748,6 +750,7 @@ base class GemmaOptions {
     return _json.toString();
   }
 
+  /// Serializes this [GemmaOptions] to a JSON map.
   Map<String, dynamic> toJson() {
     return _json;
   }

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -416,6 +416,398 @@ base class _GeminiOptionsTypeFactory extends SchemanticType<GeminiOptions> {
   );
 }
 
+base class GemmaOptions {
+  factory GemmaOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  GemmaOptions._(this._json);
+
+  GemmaOptions({
+    String? apiKey,
+    List<SafetySettings>? safetySettings,
+    bool? codeExecution,
+    FunctionCallingConfig? functionCallingConfig,
+    ThinkingConfig? thinkingConfig,
+    List<String>? responseModalities,
+    GoogleSearch? googleSearch,
+    FileSearch? fileSearch,
+    double? temperature,
+    double? topP,
+    int? topK,
+    int? candidateCount,
+    List<String>? stopSequences,
+    int? maxOutputTokens,
+    String? responseMimeType,
+    bool? responseLogprobs,
+    int? logprobs,
+    double? presencePenalty,
+    double? frequencyPenalty,
+    int? seed,
+    SpeechConfig? speechConfig,
+  }) {
+    _json = {
+      'apiKey': ?apiKey,
+      'safetySettings': ?safetySettings?.map((e) => e.toJson()).toList(),
+      'codeExecution': ?codeExecution,
+      'functionCallingConfig': ?functionCallingConfig?.toJson(),
+      'thinkingConfig': ?thinkingConfig?.toJson(),
+      'responseModalities': ?responseModalities,
+      'googleSearch': ?googleSearch?.toJson(),
+      'fileSearch': ?fileSearch?.toJson(),
+      'temperature': ?temperature,
+      'topP': ?topP,
+      'topK': ?topK,
+      'candidateCount': ?candidateCount,
+      'stopSequences': ?stopSequences,
+      'maxOutputTokens': ?maxOutputTokens,
+      'responseMimeType': ?responseMimeType,
+      'responseLogprobs': ?responseLogprobs,
+      'logprobs': ?logprobs,
+      'presencePenalty': ?presencePenalty,
+      'frequencyPenalty': ?frequencyPenalty,
+      'seed': ?seed,
+      'speechConfig': ?speechConfig?.toJson(),
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static const SchemanticType<GemmaOptions> $schema =
+      _GemmaOptionsTypeFactory();
+
+  String? get apiKey {
+    return _json['apiKey'] as String?;
+  }
+
+  set apiKey(String? value) {
+    if (value == null) {
+      _json.remove('apiKey');
+    } else {
+      _json['apiKey'] = value;
+    }
+  }
+
+  List<SafetySettings>? get safetySettings {
+    return (_json['safetySettings'] as List?)
+        ?.map((e) => SafetySettings.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  set safetySettings(List<SafetySettings>? value) {
+    if (value == null) {
+      _json.remove('safetySettings');
+    } else {
+      _json['safetySettings'] = value.toList();
+    }
+  }
+
+  bool? get codeExecution {
+    return _json['codeExecution'] as bool?;
+  }
+
+  set codeExecution(bool? value) {
+    if (value == null) {
+      _json.remove('codeExecution');
+    } else {
+      _json['codeExecution'] = value;
+    }
+  }
+
+  FunctionCallingConfig? get functionCallingConfig {
+    return _json['functionCallingConfig'] == null
+        ? null
+        : FunctionCallingConfig.fromJson(
+            _json['functionCallingConfig'] as Map<String, dynamic>,
+          );
+  }
+
+  set functionCallingConfig(FunctionCallingConfig? value) {
+    if (value == null) {
+      _json.remove('functionCallingConfig');
+    } else {
+      _json['functionCallingConfig'] = value;
+    }
+  }
+
+  ThinkingConfig? get thinkingConfig {
+    return _json['thinkingConfig'] == null
+        ? null
+        : ThinkingConfig.fromJson(
+            _json['thinkingConfig'] as Map<String, dynamic>,
+          );
+  }
+
+  set thinkingConfig(ThinkingConfig? value) {
+    if (value == null) {
+      _json.remove('thinkingConfig');
+    } else {
+      _json['thinkingConfig'] = value;
+    }
+  }
+
+  List<String>? get responseModalities {
+    return (_json['responseModalities'] as List?)?.cast<String>();
+  }
+
+  set responseModalities(List<String>? value) {
+    if (value == null) {
+      _json.remove('responseModalities');
+    } else {
+      _json['responseModalities'] = value;
+    }
+  }
+
+  GoogleSearch? get googleSearch {
+    return _json['googleSearch'] == null
+        ? null
+        : GoogleSearch.fromJson(_json['googleSearch'] as Map<String, dynamic>);
+  }
+
+  set googleSearch(GoogleSearch? value) {
+    if (value == null) {
+      _json.remove('googleSearch');
+    } else {
+      _json['googleSearch'] = value;
+    }
+  }
+
+  FileSearch? get fileSearch {
+    return _json['fileSearch'] == null
+        ? null
+        : FileSearch.fromJson(_json['fileSearch'] as Map<String, dynamic>);
+  }
+
+  set fileSearch(FileSearch? value) {
+    if (value == null) {
+      _json.remove('fileSearch');
+    } else {
+      _json['fileSearch'] = value;
+    }
+  }
+
+  double? get temperature {
+    return (_json['temperature'] as num?)?.toDouble();
+  }
+
+  set temperature(double? value) {
+    if (value == null) {
+      _json.remove('temperature');
+    } else {
+      _json['temperature'] = value;
+    }
+  }
+
+  double? get topP {
+    return (_json['topP'] as num?)?.toDouble();
+  }
+
+  set topP(double? value) {
+    if (value == null) {
+      _json.remove('topP');
+    } else {
+      _json['topP'] = value;
+    }
+  }
+
+  int? get topK {
+    return _json['topK'] as int?;
+  }
+
+  set topK(int? value) {
+    if (value == null) {
+      _json.remove('topK');
+    } else {
+      _json['topK'] = value;
+    }
+  }
+
+  int? get candidateCount {
+    return _json['candidateCount'] as int?;
+  }
+
+  set candidateCount(int? value) {
+    if (value == null) {
+      _json.remove('candidateCount');
+    } else {
+      _json['candidateCount'] = value;
+    }
+  }
+
+  List<String>? get stopSequences {
+    return (_json['stopSequences'] as List?)?.cast<String>();
+  }
+
+  set stopSequences(List<String>? value) {
+    if (value == null) {
+      _json.remove('stopSequences');
+    } else {
+      _json['stopSequences'] = value;
+    }
+  }
+
+  int? get maxOutputTokens {
+    return _json['maxOutputTokens'] as int?;
+  }
+
+  set maxOutputTokens(int? value) {
+    if (value == null) {
+      _json.remove('maxOutputTokens');
+    } else {
+      _json['maxOutputTokens'] = value;
+    }
+  }
+
+  String? get responseMimeType {
+    return _json['responseMimeType'] as String?;
+  }
+
+  set responseMimeType(String? value) {
+    if (value == null) {
+      _json.remove('responseMimeType');
+    } else {
+      _json['responseMimeType'] = value;
+    }
+  }
+
+  bool? get responseLogprobs {
+    return _json['responseLogprobs'] as bool?;
+  }
+
+  set responseLogprobs(bool? value) {
+    if (value == null) {
+      _json.remove('responseLogprobs');
+    } else {
+      _json['responseLogprobs'] = value;
+    }
+  }
+
+  int? get logprobs {
+    return _json['logprobs'] as int?;
+  }
+
+  set logprobs(int? value) {
+    if (value == null) {
+      _json.remove('logprobs');
+    } else {
+      _json['logprobs'] = value;
+    }
+  }
+
+  double? get presencePenalty {
+    return (_json['presencePenalty'] as num?)?.toDouble();
+  }
+
+  set presencePenalty(double? value) {
+    if (value == null) {
+      _json.remove('presencePenalty');
+    } else {
+      _json['presencePenalty'] = value;
+    }
+  }
+
+  double? get frequencyPenalty {
+    return (_json['frequencyPenalty'] as num?)?.toDouble();
+  }
+
+  set frequencyPenalty(double? value) {
+    if (value == null) {
+      _json.remove('frequencyPenalty');
+    } else {
+      _json['frequencyPenalty'] = value;
+    }
+  }
+
+  int? get seed {
+    return _json['seed'] as int?;
+  }
+
+  set seed(int? value) {
+    if (value == null) {
+      _json.remove('seed');
+    } else {
+      _json['seed'] = value;
+    }
+  }
+
+  SpeechConfig? get speechConfig {
+    return _json['speechConfig'] == null
+        ? null
+        : SpeechConfig.fromJson(_json['speechConfig'] as Map<String, dynamic>);
+  }
+
+  set speechConfig(SpeechConfig? value) {
+    if (value == null) {
+      _json.remove('speechConfig');
+    } else {
+      _json['speechConfig'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _GemmaOptionsTypeFactory extends SchemanticType<GemmaOptions> {
+  const _GemmaOptionsTypeFactory();
+
+  @override
+  GemmaOptions parse(Object? json) {
+    return GemmaOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'GemmaOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'apiKey': $Schema.string(),
+            'safetySettings': $Schema.list(
+              items: $Schema.fromMap({'\$ref': r'#/$defs/SafetySettings'}),
+            ),
+            'codeExecution': $Schema.boolean(),
+            'functionCallingConfig': $Schema.fromMap({
+              '\$ref': r'#/$defs/FunctionCallingConfig',
+            }),
+            'thinkingConfig': $Schema.fromMap({
+              '\$ref': r'#/$defs/ThinkingConfig',
+            }),
+            'responseModalities': $Schema.list(items: $Schema.string()),
+            'googleSearch': $Schema.fromMap({'\$ref': r'#/$defs/GoogleSearch'}),
+            'fileSearch': $Schema.fromMap({'\$ref': r'#/$defs/FileSearch'}),
+            'temperature': $Schema.number(minimum: 0.0, maximum: 1.0),
+            'topP': $Schema.number(minimum: 0.0, maximum: 1.0),
+            'topK': $Schema.integer(),
+            'candidateCount': $Schema.integer(),
+            'stopSequences': $Schema.list(items: $Schema.string()),
+            'maxOutputTokens': $Schema.integer(),
+            'responseMimeType': $Schema.string(),
+            'responseLogprobs': $Schema.boolean(),
+            'logprobs': $Schema.integer(),
+            'presencePenalty': $Schema.number(),
+            'frequencyPenalty': $Schema.number(),
+            'seed': $Schema.integer(),
+            'speechConfig': $Schema.fromMap({'\$ref': r'#/$defs/SpeechConfig'}),
+          },
+        )
+        .value,
+    dependencies: [
+      SafetySettings.$schema,
+      FunctionCallingConfig.$schema,
+      ThinkingConfig.$schema,
+      GoogleSearch.$schema,
+      FileSearch.$schema,
+      SpeechConfig.$schema,
+    ],
+  );
+}
+
 base class SafetySettings {
   /// Creates a [SafetySettings] from a JSON map.
   factory SafetySettings.fromJson(Map<String, dynamic> json) =>

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -499,7 +499,7 @@ base class GemmaOptions {
     if (value == null) {
       _json.remove('safetySettings');
     } else {
-      _json['safetySettings'] = value.toList();
+      _json['safetySettings'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -527,7 +527,7 @@ base class GemmaOptions {
     if (value == null) {
       _json.remove('functionCallingConfig');
     } else {
-      _json['functionCallingConfig'] = value;
+      _json['functionCallingConfig'] = value.toJson();
     }
   }
 
@@ -543,7 +543,7 @@ base class GemmaOptions {
     if (value == null) {
       _json.remove('thinkingConfig');
     } else {
-      _json['thinkingConfig'] = value;
+      _json['thinkingConfig'] = value.toJson();
     }
   }
 
@@ -569,7 +569,7 @@ base class GemmaOptions {
     if (value == null) {
       _json.remove('googleSearch');
     } else {
-      _json['googleSearch'] = value;
+      _json['googleSearch'] = value.toJson();
     }
   }
 
@@ -583,7 +583,7 @@ base class GemmaOptions {
     if (value == null) {
       _json.remove('fileSearch');
     } else {
-      _json['fileSearch'] = value;
+      _json['fileSearch'] = value.toJson();
     }
   }
 
@@ -741,7 +741,7 @@ base class GemmaOptions {
     if (value == null) {
       _json.remove('speechConfig');
     } else {
-      _json['speechConfig'] = value;
+      _json['speechConfig'] = value.toJson();
     }
   }
 

--- a/packages/genkit_google_genai/test/gemma_test.dart
+++ b/packages/genkit_google_genai/test/gemma_test.dart
@@ -93,7 +93,10 @@ void main() {
           role: Role.model,
           content: [ReasoningPart(reasoning: 'only thought')],
         ),
-        Message(role: Role.user, content: [TextPart(text: 'hi')]),
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hi')],
+        ),
       ];
       final stripped = stripReasoningParts(messages);
       expect(stripped, hasLength(1));
@@ -102,7 +105,10 @@ void main() {
 
     test('leaves non-gemma-affected parts alone', () {
       final messages = [
-        Message(role: Role.user, content: [TextPart(text: 'hello')]),
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hello')],
+        ),
       ];
       final stripped = stripReasoningParts(messages);
       expect(stripped, hasLength(1));

--- a/packages/genkit_google_genai/test/gemma_test.dart
+++ b/packages/genkit_google_genai/test/gemma_test.dart
@@ -1,0 +1,152 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit/src/schema.dart' show toJsonSchema;
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_google_genai/src/common_plugin.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GemmaOptions schema', () {
+    test('round-trips temperature at cap', () {
+      final options = GemmaOptions.$schema.parse({'temperature': 1.0});
+      expect(options.temperature, 1.0);
+    });
+
+    test('JSON schema caps temperature at 1.0', () {
+      final schema = toJsonSchema(type: GemmaOptions.$schema);
+      final defs = schema[r'$defs'] as Map<String, dynamic>;
+      final gemma = defs['GemmaOptions'] as Map<String, dynamic>;
+      final props = gemma['properties'] as Map<String, dynamic>;
+      final temp = props['temperature'] as Map<String, dynamic>;
+      expect(temp['maximum'], 1.0);
+    });
+  });
+
+  group('model family predicates', () {
+    test('isGemmaModelName', () {
+      expect(isGemmaModelName('gemma-3-1b-it'), isTrue);
+      expect(isGemmaModelName('gemma-4-31b-it'), isTrue);
+      expect(isGemmaModelName('gemini-2.5-pro'), isFalse);
+      expect(isGemmaModelName('text-embedding-004'), isFalse);
+    });
+
+    test('isGemma3ModelName', () {
+      expect(isGemma3ModelName('gemma-3-1b-it'), isTrue);
+      expect(isGemma3ModelName('gemma-3-12b-it'), isTrue);
+      expect(isGemma3ModelName('gemma-3-27b-it'), isTrue);
+      expect(isGemma3ModelName('gemma-3-4b-it'), isTrue);
+      expect(isGemma3ModelName('gemma-3n-e4b-it'), isTrue);
+      expect(isGemma3ModelName('gemma-4-31b-it'), isFalse);
+      expect(isGemma3ModelName('gemini-2.5-pro'), isFalse);
+    });
+  });
+
+  group('stripReasoningParts', () {
+    test('drops reasoning parts', () {
+      final messages = [
+        Message(
+          role: Role.model,
+          content: [
+            ReasoningPart(reasoning: 'thinking...'),
+            TextPart(text: 'answer'),
+          ],
+        ),
+      ];
+      final stripped = stripReasoningParts(messages);
+      expect(stripped, hasLength(1));
+      expect(stripped.first.content, hasLength(1));
+      expect(stripped.first.content.first.text, 'answer');
+    });
+
+    test('drops parts whose metadata carries thoughtSignature', () {
+      final messages = [
+        Message(
+          role: Role.model,
+          content: [
+            TextPart(text: 'hidden', metadata: {'thoughtSignature': 'sig'}),
+            TextPart(text: 'visible'),
+          ],
+        ),
+      ];
+      final stripped = stripReasoningParts(messages);
+      expect(stripped.first.content, hasLength(1));
+      expect(stripped.first.content.first.text, 'visible');
+    });
+
+    test('drops messages that become empty', () {
+      final messages = [
+        Message(
+          role: Role.model,
+          content: [ReasoningPart(reasoning: 'only thought')],
+        ),
+        Message(role: Role.user, content: [TextPart(text: 'hi')]),
+      ];
+      final stripped = stripReasoningParts(messages);
+      expect(stripped, hasLength(1));
+      expect(stripped.first.role, Role.user);
+    });
+
+    test('leaves non-gemma-affected parts alone', () {
+      final messages = [
+        Message(role: Role.user, content: [TextPart(text: 'hello')]),
+      ];
+      final stripped = stripReasoningParts(messages);
+      expect(stripped, hasLength(1));
+      expect(stripped.first.content.first.text, 'hello');
+    });
+  });
+
+  group('plugin handle', () {
+    test('googleAI.gemma returns a ModelRef with GemmaOptions schema', () {
+      final ref = googleAI.gemma('gemma-3-1b-it');
+      expect(ref.name, 'googleai/gemma-3-1b-it');
+      expect(ref.customOptions, same(GemmaOptions.$schema));
+    });
+  });
+
+  group('GoogleGenAiPluginImpl.resolve for gemma models', () {
+    Map<String, dynamic>? supportsOf(String modelName) {
+      final plugin = GoogleGenAiPluginImpl();
+      final action = plugin.resolve('model', modelName);
+      expect(action, isNotNull);
+      expect(action!.name, 'googleai/$modelName');
+      final model = action.metadata['model'] as Map<String, dynamic>;
+      return model['supports'] as Map<String, dynamic>?;
+    }
+
+    test('gemma-3 models advertise systemRole: false', () {
+      for (final name in const [
+        'gemma-3-1b-it',
+        'gemma-3-4b-it',
+        'gemma-3-12b-it',
+        'gemma-3-27b-it',
+        'gemma-3n-e4b-it',
+      ]) {
+        expect(supportsOf(name)?['systemRole'], isFalse, reason: name);
+      }
+    });
+
+    test('gemma-4 models keep systemRole: true', () {
+      expect(supportsOf('gemma-4-31b-it')?['systemRole'], isTrue);
+      expect(supportsOf('gemma-4-26b-a4b-it')?['systemRole'], isTrue);
+    });
+
+    test('gemma models advertise constrained: no-tools', () {
+      expect(supportsOf('gemma-3-1b-it')?['constrained'], 'no-tools');
+    });
+  });
+}

--- a/packages/genkit_google_genai/test/gemma_test.dart
+++ b/packages/genkit_google_genai/test/gemma_test.dart
@@ -15,7 +15,7 @@
 import 'package:genkit/genkit.dart';
 import 'package:genkit/src/schema.dart' show toJsonSchema;
 import 'package:genkit_google_genai/genkit_google_genai.dart';
-import 'package:genkit_google_genai/src/common_plugin.dart';
+import 'package:genkit_google_genai/src/gemma.dart';
 import 'package:genkit_google_genai/src/google_api_client.dart';
 import 'package:test/test.dart';
 

--- a/packages/genkit_google_genai/test/gemma_test.dart
+++ b/packages/genkit_google_genai/test/gemma_test.dart
@@ -13,45 +13,116 @@
 // limitations under the License.
 
 import 'package:genkit/genkit.dart';
-import 'package:genkit/src/schema.dart' show toJsonSchema;
 import 'package:genkit_google_genai/genkit_google_genai.dart';
 import 'package:genkit_google_genai/src/gemma.dart';
 import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:schemantic/schemantic.dart';
 import 'package:test/test.dart';
+
+Map<String, dynamic> _propertiesOf(SchemanticType type) {
+  final schema = type.jsonSchema(useRefs: false);
+  return (schema['properties'] as Map).cast<String, dynamic>();
+}
+
+Object _sampleFor(String property, Map<String, dynamic> propertySchema) {
+  switch (propertySchema['type']) {
+    case 'string':
+      return 's';
+    case 'number':
+      return 0.5;
+    case 'integer':
+      return 1;
+    case 'boolean':
+      return true;
+    case 'array':
+      return <Object?>[];
+    case 'object':
+      return <String, Object?>{};
+  }
+  throw StateError('No sample value for $property: $propertySchema');
+}
 
 void main() {
   group('GemmaOptions schema', () {
-    test('round-trips temperature at cap', () {
-      final options = GemmaOptions.$schema.parse({'temperature': 1.0});
-      expect(options.temperature, 1.0);
+    test('JSON schema caps temperature at 1.0', () {
+      final temp =
+          _propertiesOf(GemmaOptions.$schema)['temperature']
+              as Map<String, dynamic>;
+      expect(temp['maximum'], 1.0);
     });
 
-    test('JSON schema caps temperature at 1.0', () {
-      final schema = toJsonSchema(type: GemmaOptions.$schema);
-      final defs = schema[r'$defs'] as Map<String, dynamic>;
-      final gemma = defs['GemmaOptions'] as Map<String, dynamic>;
-      final props = gemma['properties'] as Map<String, dynamic>;
-      final temp = props['temperature'] as Map<String, dynamic>;
-      expect(temp['maximum'], 1.0);
+    test('mirrors GeminiOptions property-for-property except the '
+        'temperature cap', () {
+      final geminiProps = _propertiesOf(GeminiOptions.$schema);
+      final gemmaProps = _propertiesOf(GemmaOptions.$schema);
+      expect(gemmaProps.keys.toSet(), geminiProps.keys.toSet());
+      for (final key in geminiProps.keys) {
+        if (key == 'temperature') continue;
+        expect(gemmaProps[key], geminiProps[key], reason: key);
+      }
+      final expectedTemperature = Map<String, dynamic>.of(
+        (geminiProps['temperature'] as Map).cast<String, dynamic>(),
+      )..['maximum'] = 1.0;
+      expect(gemmaProps['temperature'], expectedTemperature);
+    });
+  });
+
+  group('gemmaToGeminiOptions', () {
+    test('maps every GemmaOptions property', () {
+      final gemmaProps = _propertiesOf(GemmaOptions.$schema);
+      final sample = {
+        for (final entry in gemmaProps.entries)
+          entry.key: _sampleFor(
+            entry.key,
+            (entry.value as Map).cast<String, dynamic>(),
+          ),
+      };
+      final mapped = gemmaToGeminiOptions(GemmaOptions.fromJson(sample));
+      expect(mapped.toJson().keys.toSet(), sample.keys.toSet());
+    });
+
+    test('passes temperature at the cap through', () {
+      final mapped = gemmaToGeminiOptions(
+        GemmaOptions.fromJson({'temperature': 1.0}),
+      );
+      expect(mapped.temperature, 1.0);
+    });
+
+    test('rejects temperature above 1.0 with INVALID_ARGUMENT', () {
+      expect(
+        () => gemmaToGeminiOptions(GemmaOptions.fromJson({'temperature': 1.5})),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
+    test('rejects negative temperature with INVALID_ARGUMENT', () {
+      expect(
+        () =>
+            gemmaToGeminiOptions(GemmaOptions.fromJson({'temperature': -0.1})),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
     });
   });
 
   group('model family predicates', () {
     test('isGemmaModelName', () {
       expect(isGemmaModelName('gemma-3-1b-it'), isTrue);
+      expect(isGemmaModelName('gemma-3n-e4b-it'), isTrue);
       expect(isGemmaModelName('gemma-4-31b-it'), isTrue);
       expect(isGemmaModelName('gemini-2.5-pro'), isFalse);
       expect(isGemmaModelName('text-embedding-004'), isFalse);
-    });
-
-    test('isGemma3ModelName', () {
-      expect(isGemma3ModelName('gemma-3-1b-it'), isTrue);
-      expect(isGemma3ModelName('gemma-3-12b-it'), isTrue);
-      expect(isGemma3ModelName('gemma-3-27b-it'), isTrue);
-      expect(isGemma3ModelName('gemma-3-4b-it'), isTrue);
-      expect(isGemma3ModelName('gemma-3n-e4b-it'), isTrue);
-      expect(isGemma3ModelName('gemma-4-31b-it'), isFalse);
-      expect(isGemma3ModelName('gemini-2.5-pro'), isFalse);
     });
   });
 
@@ -116,6 +187,46 @@ void main() {
     });
   });
 
+  group('foldSystemMessage', () {
+    final system = Message(
+      role: Role.system,
+      content: [TextPart(text: 'be terse')],
+    );
+
+    test('prepends system content to the first user message', () {
+      final folded = foldSystemMessage(system, [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hello')],
+        ),
+        Message(
+          role: Role.model,
+          content: [TextPart(text: 'hi')],
+        ),
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'again')],
+        ),
+      ]);
+      expect(folded, hasLength(3));
+      expect(folded.first.role, Role.user);
+      expect(folded.first.content.map((p) => p.text), ['be terse', 'hello']);
+      expect(folded[2].content.single.text, 'again');
+    });
+
+    test('inserts a user message when none exists', () {
+      final folded = foldSystemMessage(system, [
+        Message(
+          role: Role.model,
+          content: [TextPart(text: 'hi')],
+        ),
+      ]);
+      expect(folded, hasLength(2));
+      expect(folded.first.role, Role.user);
+      expect(folded.first.content.single.text, 'be terse');
+    });
+  });
+
   group('plugin handle', () {
     test('googleAI.gemma returns a ModelRef with GemmaOptions schema', () {
       final ref = googleAI.gemma('gemma-3-1b-it');
@@ -134,21 +245,18 @@ void main() {
       return model['supports'] as Map<String, dynamic>?;
     }
 
-    test('gemma-3 models advertise systemRole: false', () {
+    test('gemma models advertise systemRole: false', () {
       for (final name in const [
         'gemma-3-1b-it',
         'gemma-3-4b-it',
         'gemma-3-12b-it',
         'gemma-3-27b-it',
         'gemma-3n-e4b-it',
+        'gemma-4-26b-a4b-it',
+        'gemma-4-31b-it',
       ]) {
         expect(supportsOf(name)?['systemRole'], isFalse, reason: name);
       }
-    });
-
-    test('gemma-4 models keep systemRole: true', () {
-      expect(supportsOf('gemma-4-31b-it')?['systemRole'], isTrue);
-      expect(supportsOf('gemma-4-26b-a4b-it')?['systemRole'], isTrue);
     });
 
     test('gemma models advertise constrained: no-tools', () {

--- a/packages/genkit_google_genai/test/gemma_test.dart
+++ b/packages/genkit_google_genai/test/gemma_test.dart
@@ -155,19 +155,56 @@ void main() {
       expect(stripped.first.content.first.text, 'answer');
     });
 
-    test('drops parts whose metadata carries thoughtSignature', () {
+    test('keeps signed parts, removing only their thoughtSignature', () {
+      final originalMetadata = {'thoughtSignature': 'sig', 'other': 'kept'};
       final messages = [
         Message(
           role: Role.model,
           content: [
-            TextPart(text: 'hidden', metadata: {'thoughtSignature': 'sig'}),
-            TextPart(text: 'visible'),
+            TextPart(text: 'signed', metadata: originalMetadata),
+            TextPart(text: 'plain'),
           ],
         ),
       ];
       final stripped = stripReasoningParts(messages);
-      expect(stripped.first.content, hasLength(1));
-      expect(stripped.first.content.first.text, 'visible');
+      expect(stripped.first.content, hasLength(2));
+      final signed = stripped.first.content.first;
+      expect(signed.text, 'signed');
+      expect(signed.metadata, {'other': 'kept'});
+      expect(stripped.first.content[1].text, 'plain');
+      expect(originalMetadata, {'thoughtSignature': 'sig', 'other': 'kept'});
+    });
+
+    test('drops metadata entirely when thoughtSignature was its only key', () {
+      final messages = [
+        Message(
+          role: Role.model,
+          content: [
+            TextPart(text: 'signed', metadata: {'thoughtSignature': 'sig'}),
+          ],
+        ),
+      ];
+      final stripped = stripReasoningParts(messages);
+      expect(stripped.first.content.single.text, 'signed');
+      expect(stripped.first.content.single.metadata, isNull);
+    });
+
+    test('keeps a signed tool request part, removing its thoughtSignature', () {
+      final messages = [
+        Message(
+          role: Role.model,
+          content: [
+            ToolRequestPart(
+              toolRequest: ToolRequest(name: 'lookup', input: {'q': 'x'}),
+              metadata: {'thoughtSignature': 'sig'},
+            ),
+          ],
+        ),
+      ];
+      final stripped = stripReasoningParts(messages);
+      final part = stripped.first.content.single;
+      expect(part.toolRequest?.name, 'lookup');
+      expect(part.metadata, isNull);
     });
 
     test('drops messages that become empty', () {

--- a/packages/genkit_google_genai/test/gemma_test.dart
+++ b/packages/genkit_google_genai/test/gemma_test.dart
@@ -117,12 +117,13 @@ void main() {
   });
 
   group('model family predicates', () {
-    test('isGemmaModelName', () {
-      expect(isGemmaModelName('gemma-3-1b-it'), isTrue);
-      expect(isGemmaModelName('gemma-3n-e4b-it'), isTrue);
-      expect(isGemmaModelName('gemma-4-31b-it'), isTrue);
-      expect(isGemmaModelName('gemini-2.5-pro'), isFalse);
-      expect(isGemmaModelName('text-embedding-004'), isFalse);
+    test('isGemma4ModelName', () {
+      expect(isGemma4ModelName('gemma-4-26b-a4b-it'), isTrue);
+      expect(isGemma4ModelName('gemma-4-31b-it'), isTrue);
+      expect(isGemma4ModelName('gemma-3-1b-it'), isFalse);
+      expect(isGemma4ModelName('gemma-3n-e4b-it'), isFalse);
+      expect(isGemma4ModelName('gemini-2.5-pro'), isFalse);
+      expect(isGemma4ModelName('text-embedding-004'), isFalse);
     });
   });
 
@@ -187,50 +188,10 @@ void main() {
     });
   });
 
-  group('foldSystemMessage', () {
-    final system = Message(
-      role: Role.system,
-      content: [TextPart(text: 'be terse')],
-    );
-
-    test('prepends system content to the first user message', () {
-      final folded = foldSystemMessage(system, [
-        Message(
-          role: Role.user,
-          content: [TextPart(text: 'hello')],
-        ),
-        Message(
-          role: Role.model,
-          content: [TextPart(text: 'hi')],
-        ),
-        Message(
-          role: Role.user,
-          content: [TextPart(text: 'again')],
-        ),
-      ]);
-      expect(folded, hasLength(3));
-      expect(folded.first.role, Role.user);
-      expect(folded.first.content.map((p) => p.text), ['be terse', 'hello']);
-      expect(folded[2].content.single.text, 'again');
-    });
-
-    test('inserts a user message when none exists', () {
-      final folded = foldSystemMessage(system, [
-        Message(
-          role: Role.model,
-          content: [TextPart(text: 'hi')],
-        ),
-      ]);
-      expect(folded, hasLength(2));
-      expect(folded.first.role, Role.user);
-      expect(folded.first.content.single.text, 'be terse');
-    });
-  });
-
   group('plugin handle', () {
     test('googleAI.gemma returns a ModelRef with GemmaOptions schema', () {
-      final ref = googleAI.gemma('gemma-3-1b-it');
-      expect(ref.name, 'googleai/gemma-3-1b-it');
+      final ref = googleAI.gemma('gemma-4-26b-a4b-it');
+      expect(ref.name, 'googleai/gemma-4-26b-a4b-it');
       expect(ref.customOptions, same(GemmaOptions.$schema));
     });
   });
@@ -245,22 +206,20 @@ void main() {
       return model['supports'] as Map<String, dynamic>?;
     }
 
-    test('gemma models advertise systemRole: false', () {
-      for (final name in const [
-        'gemma-3-1b-it',
-        'gemma-3-4b-it',
-        'gemma-3-12b-it',
-        'gemma-3-27b-it',
-        'gemma-3n-e4b-it',
-        'gemma-4-26b-a4b-it',
-        'gemma-4-31b-it',
-      ]) {
-        expect(supportsOf(name)?['systemRole'], isFalse, reason: name);
+    test('gemma 4 models advertise systemRole: true', () {
+      for (final name in const ['gemma-4-26b-a4b-it', 'gemma-4-31b-it']) {
+        expect(supportsOf(name)?['systemRole'], isTrue, reason: name);
       }
     });
 
-    test('gemma models advertise constrained: no-tools', () {
-      expect(supportsOf('gemma-3-1b-it')?['constrained'], 'no-tools');
+    test('gemma 4 models advertise constrained: no-tools', () {
+      expect(supportsOf('gemma-4-26b-a4b-it')?['constrained'], 'no-tools');
+    });
+
+    test('gemma 3 model names are not special-cased', () {
+      final supports = supportsOf('gemma-3-4b-it');
+      expect(supports?['systemRole'], isTrue);
+      expect(supports?['constrained'], isTrue);
     });
   });
 }

--- a/packages/genkit_google_genai/test/gemma_test.dart
+++ b/packages/genkit_google_genai/test/gemma_test.dart
@@ -81,6 +81,17 @@ void main() {
       expect(mapped.toJson().keys.toSet(), sample.keys.toSet());
     });
 
+    test('returns options backed by a map independent of the request '
+        'config', () {
+      final config = <String, dynamic>{'topK': 3};
+      final mapped = gemmaToGeminiOptions(GemmaOptions.fromJson(config));
+
+      mapped.topK = 99;
+
+      expect(config['topK'], 3);
+      expect(mapped.topK, 99);
+    });
+
     test('passes temperature at the cap through', () {
       final mapped = gemmaToGeminiOptions(
         GemmaOptions.fromJson({'temperature': 1.0}),

--- a/packages/genkit_google_genai/test/gemma_wire_test.dart
+++ b/packages/genkit_google_genai/test/gemma_wire_test.dart
@@ -107,6 +107,33 @@ void main() {
       ]);
     });
 
+    test('strips reasoning parts from a folded system message', () async {
+      final body = await _onTheWire(
+        model: 'gemma-3-4b-it',
+        messages: [
+          Message(
+            role: Role.system,
+            content: [
+              ReasoningPart(reasoning: 'thinking...'),
+              TextPart(text: 'signed', metadata: {'thoughtSignature': 'sig'}),
+              TextPart(text: 'be terse'),
+            ],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+      );
+      expect(body, isNot(contains('systemInstruction')));
+      final contents = _contentsOf(body);
+      expect(contents, hasLength(1));
+      expect(_partsOf(contents.first).map((p) => p['text']), [
+        'be terse',
+        'hello',
+      ]);
+    });
+
     test('full ai.generate with system prompt folds it on the wire', () async {
       final captured = <Map<String, dynamic>>[];
       final ai = Genkit(
@@ -191,6 +218,35 @@ void main() {
       final generationConfig = (body['generationConfig'] as Map)
           .cast<String, dynamic>();
       expect(generationConfig['temperature'], 0.9);
+    });
+
+    test('rejects a request whose history strips to empty with a message '
+        'naming the cause', () async {
+      final captured = <Map<String, dynamic>>[];
+      final plugin = _WirePlugin(captured);
+      final action = plugin.resolve('model', 'gemma-3-4b-it')!;
+      await expectLater(
+        () => action.run(
+          ModelRequest(
+            messages: [
+              Message(
+                role: Role.model,
+                content: [ReasoningPart(reasoning: 'thinking...')],
+              ),
+            ],
+          ),
+        ),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('reasoning parts were stripped'),
+              ),
+        ),
+      );
+      expect(captured, isEmpty);
     });
 
     test('rejects temperature above 1.0 before any request is sent', () async {

--- a/packages/genkit_google_genai/test/gemma_wire_test.dart
+++ b/packages/genkit_google_genai/test/gemma_wire_test.dart
@@ -80,12 +80,14 @@ List<Map<String, dynamic>> _partsOf(Map<String, dynamic> content) =>
         .map((p) => (p as Map).cast<String, dynamic>())
         .toList();
 
+Map<String, dynamic> _systemInstructionOf(Map<String, dynamic> body) =>
+    (body['systemInstruction'] as Map).cast<String, dynamic>();
+
 void main() {
   group('gemma requests on the wire', () {
-    test('folds the system message into the first user turn and sends no '
-        'systemInstruction', () async {
+    test('sends the system message as a native systemInstruction', () async {
       final body = await _onTheWire(
-        model: 'gemma-3-4b-it',
+        model: 'gemma-4-26b-a4b-it',
         messages: [
           Message(
             role: Role.system,
@@ -97,19 +99,18 @@ void main() {
           ),
         ],
       );
-      expect(body, isNot(contains('systemInstruction')));
+      final systemInstruction = _systemInstructionOf(body);
+      expect(systemInstruction, isNot(contains('role')));
+      expect(_partsOf(systemInstruction).map((p) => p['text']), ['be terse']);
       final contents = _contentsOf(body);
       expect(contents, hasLength(1));
       expect(contents.first['role'], 'user');
-      expect(_partsOf(contents.first).map((p) => p['text']), [
-        'be terse',
-        'hello',
-      ]);
+      expect(_partsOf(contents.first).map((p) => p['text']), ['hello']);
     });
 
-    test('strips reasoning parts from a folded system message', () async {
+    test('strips reasoning parts from systemInstruction', () async {
       final body = await _onTheWire(
-        model: 'gemma-3-4b-it',
+        model: 'gemma-4-26b-a4b-it',
         messages: [
           Message(
             role: Role.system,
@@ -125,35 +126,39 @@ void main() {
           ),
         ],
       );
-      expect(body, isNot(contains('systemInstruction')));
+      final systemInstruction = _systemInstructionOf(body);
+      expect(systemInstruction, isNot(contains('role')));
+      expect(_partsOf(systemInstruction).map((p) => p['text']), ['be terse']);
       final contents = _contentsOf(body);
       expect(contents, hasLength(1));
-      expect(_partsOf(contents.first).map((p) => p['text']), [
-        'be terse',
-        'hello',
-      ]);
+      expect(_partsOf(contents.first).map((p) => p['text']), ['hello']);
     });
 
-    test('full ai.generate with system prompt folds it on the wire', () async {
-      final captured = <Map<String, dynamic>>[];
-      final ai = Genkit(
-        plugins: [_WirePlugin(captured)],
-        promptDir: null,
-        isDevEnv: false,
-      );
-      addTearDown(ai.shutdown);
-      await ai.generate(
-        model: modelRef('googleai/gemma-3-4b-it'),
-        system: 'be terse',
-        prompt: 'hello',
-      );
-      final body = captured.single;
-      expect(body, isNot(contains('systemInstruction')));
-      final texts = _contentsOf(
-        body,
-      ).expand(_partsOf).map((p) => p['text']).toList();
-      expect(texts, ['be terse', 'hello']);
-    });
+    test(
+      'full ai.generate with system prompt sends systemInstruction',
+      () async {
+        final captured = <Map<String, dynamic>>[];
+        final ai = Genkit(
+          plugins: [_WirePlugin(captured)],
+          promptDir: null,
+          isDevEnv: false,
+        );
+        addTearDown(ai.shutdown);
+        await ai.generate(
+          model: modelRef('googleai/gemma-4-26b-a4b-it'),
+          system: 'be terse',
+          prompt: 'hello',
+        );
+        final body = captured.single;
+        final systemInstruction = _systemInstructionOf(body);
+        expect(systemInstruction, isNot(contains('role')));
+        expect(_partsOf(systemInstruction).map((p) => p['text']), ['be terse']);
+        final texts = _contentsOf(
+          body,
+        ).expand(_partsOf).map((p) => p['text']).toList();
+        expect(texts, ['hello']);
+      },
+    );
 
     test('gemini models keep systemInstruction on the wire', () async {
       final body = await _onTheWire(
@@ -176,7 +181,7 @@ void main() {
     test('strips reasoning and thoughtSignature parts from multi-turn '
         'history', () async {
       final body = await _onTheWire(
-        model: 'gemma-3-4b-it',
+        model: 'gemma-4-26b-a4b-it',
         messages: [
           Message(
             role: Role.user,
@@ -206,7 +211,7 @@ void main() {
 
     test('passes in-range temperature through to generationConfig', () async {
       final body = await _onTheWire(
-        model: 'gemma-3-4b-it',
+        model: 'gemma-4-26b-a4b-it',
         messages: [
           Message(
             role: Role.user,
@@ -224,7 +229,7 @@ void main() {
         'naming the cause', () async {
       final captured = <Map<String, dynamic>>[];
       final plugin = _WirePlugin(captured);
-      final action = plugin.resolve('model', 'gemma-3-4b-it')!;
+      final action = plugin.resolve('model', 'gemma-4-26b-a4b-it')!;
       await expectLater(
         () => action.run(
           ModelRequest(
@@ -252,7 +257,7 @@ void main() {
     test('rejects temperature above 1.0 before any request is sent', () async {
       final captured = <Map<String, dynamic>>[];
       final plugin = _WirePlugin(captured);
-      final action = plugin.resolve('model', 'gemma-3-4b-it')!;
+      final action = plugin.resolve('model', 'gemma-4-26b-a4b-it')!;
       await expectLater(
         () => action.run(
           ModelRequest(

--- a/packages/genkit_google_genai/test/gemma_wire_test.dart
+++ b/packages/genkit_google_genai/test/gemma_wire_test.dart
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/src/api_client.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Captures every generateContent request body the plugin puts on the wire
+/// and serves a canned response.
+class _WirePlugin extends GoogleGenAiPluginImpl {
+  final List<Map<String, dynamic>> captured;
+
+  _WirePlugin(this.captured) : super(apiKey: 'test-key');
+
+  @override
+  Future<GenerativeLanguageBaseClient> getApiClient([
+    String? requestApiKey,
+  ]) async {
+    return GenerativeLanguageBaseClient(
+      baseUrl: 'https://example.test/',
+      client: MockClient((request) async {
+        captured.add((jsonDecode(request.body) as Map).cast<String, dynamic>());
+        return http.Response(
+          jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': 'ok'},
+                  ],
+                },
+                'finishReason': 'STOP',
+              },
+            ],
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+    );
+  }
+}
+
+Future<Map<String, dynamic>> _onTheWire({
+  required String model,
+  required List<Message> messages,
+  Map<String, dynamic>? config,
+}) async {
+  final captured = <Map<String, dynamic>>[];
+  final plugin = _WirePlugin(captured);
+  final action = plugin.resolve('model', model)!;
+  await action.run(ModelRequest(messages: messages, config: config));
+  return captured.single;
+}
+
+List<Map<String, dynamic>> _contentsOf(Map<String, dynamic> body) =>
+    (body['contents'] as List)
+        .map((c) => (c as Map).cast<String, dynamic>())
+        .toList();
+
+List<Map<String, dynamic>> _partsOf(Map<String, dynamic> content) =>
+    (content['parts'] as List)
+        .map((p) => (p as Map).cast<String, dynamic>())
+        .toList();
+
+void main() {
+  group('gemma requests on the wire', () {
+    test('folds the system message into the first user turn and sends no '
+        'systemInstruction', () async {
+      final body = await _onTheWire(
+        model: 'gemma-3-4b-it',
+        messages: [
+          Message(
+            role: Role.system,
+            content: [TextPart(text: 'be terse')],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+      );
+      expect(body, isNot(contains('systemInstruction')));
+      final contents = _contentsOf(body);
+      expect(contents, hasLength(1));
+      expect(contents.first['role'], 'user');
+      expect(_partsOf(contents.first).map((p) => p['text']), [
+        'be terse',
+        'hello',
+      ]);
+    });
+
+    test('full ai.generate with system prompt folds it on the wire', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [_WirePlugin(captured)],
+        promptDir: null,
+        isDevEnv: false,
+      );
+      addTearDown(ai.shutdown);
+      await ai.generate(
+        model: modelRef('googleai/gemma-3-4b-it'),
+        system: 'be terse',
+        prompt: 'hello',
+      );
+      final body = captured.single;
+      expect(body, isNot(contains('systemInstruction')));
+      final texts = _contentsOf(
+        body,
+      ).expand(_partsOf).map((p) => p['text']).toList();
+      expect(texts, ['be terse', 'hello']);
+    });
+
+    test('gemini models keep systemInstruction on the wire', () async {
+      final body = await _onTheWire(
+        model: 'gemini-2.0-flash',
+        messages: [
+          Message(
+            role: Role.system,
+            content: [TextPart(text: 'be terse')],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+      );
+      expect(body['systemInstruction'], isNotNull);
+      expect(_contentsOf(body), hasLength(1));
+    });
+
+    test('strips reasoning and thoughtSignature parts from multi-turn '
+        'history', () async {
+      final body = await _onTheWire(
+        model: 'gemma-3-4b-it',
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'question')],
+          ),
+          Message(
+            role: Role.model,
+            content: [
+              ReasoningPart(reasoning: 'thinking...'),
+              TextPart(text: 'signed', metadata: {'thoughtSignature': 'sig'}),
+              TextPart(text: 'answer'),
+            ],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'follow-up')],
+          ),
+        ],
+      );
+      final contents = _contentsOf(body);
+      expect(contents, hasLength(3));
+      final modelParts = _partsOf(contents[1]);
+      expect(modelParts.map((p) => p['text']), ['answer']);
+      expect(modelParts.every((p) => p['thought'] == null), isTrue);
+      expect(modelParts.every((p) => p['thoughtSignature'] == null), isTrue);
+    });
+
+    test('passes in-range temperature through to generationConfig', () async {
+      final body = await _onTheWire(
+        model: 'gemma-3-4b-it',
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+        config: {'temperature': 0.9},
+      );
+      final generationConfig = (body['generationConfig'] as Map)
+          .cast<String, dynamic>();
+      expect(generationConfig['temperature'], 0.9);
+    });
+
+    test('rejects temperature above 1.0 before any request is sent', () async {
+      final captured = <Map<String, dynamic>>[];
+      final plugin = _WirePlugin(captured);
+      final action = plugin.resolve('model', 'gemma-3-4b-it')!;
+      await expectLater(
+        () => action.run(
+          ModelRequest(
+            messages: [
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'hello')],
+              ),
+            ],
+            config: {'temperature': 1.5},
+          ),
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+      expect(captured, isEmpty);
+    });
+  });
+}

--- a/packages/genkit_google_genai/test/gemma_wire_test.dart
+++ b/packages/genkit_google_genai/test/gemma_wire_test.dart
@@ -128,7 +128,14 @@ void main() {
       );
       final systemInstruction = _systemInstructionOf(body);
       expect(systemInstruction, isNot(contains('role')));
-      expect(_partsOf(systemInstruction).map((p) => p['text']), ['be terse']);
+      expect(_partsOf(systemInstruction).map((p) => p['text']), [
+        'signed',
+        'be terse',
+      ]);
+      expect(
+        _partsOf(systemInstruction).every((p) => p['thoughtSignature'] == null),
+        isTrue,
+      );
       final contents = _contentsOf(body);
       expect(contents, hasLength(1));
       expect(_partsOf(contents.first).map((p) => p['text']), ['hello']);
@@ -178,8 +185,8 @@ void main() {
       expect(_contentsOf(body), hasLength(1));
     });
 
-    test('strips reasoning and thoughtSignature parts from multi-turn '
-        'history', () async {
+    test('strips reasoning parts and thoughtSignatures from multi-turn '
+        'history, keeping signed parts', () async {
       final body = await _onTheWire(
         model: 'gemma-4-26b-a4b-it',
         messages: [
@@ -204,9 +211,53 @@ void main() {
       final contents = _contentsOf(body);
       expect(contents, hasLength(3));
       final modelParts = _partsOf(contents[1]);
-      expect(modelParts.map((p) => p['text']), ['answer']);
+      expect(modelParts.map((p) => p['text']), ['signed', 'answer']);
       expect(modelParts.every((p) => p['thought'] == null), isTrue);
       expect(modelParts.every((p) => p['thoughtSignature'] == null), isTrue);
+    });
+
+    test('keeps a signed functionCall paired with its functionResponse, '
+        'with no thoughtSignature on the wire', () async {
+      final body = await _onTheWire(
+        model: 'gemma-4-26b-a4b-it',
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'question')],
+          ),
+          Message(
+            role: Role.model,
+            content: [
+              ToolRequestPart(
+                toolRequest: ToolRequest(name: 'lookup', input: {'q': 'x'}),
+                metadata: {'thoughtSignature': 'sig'},
+              ),
+            ],
+          ),
+          Message(
+            role: Role.tool,
+            content: [
+              ToolResponsePart(
+                toolResponse: ToolResponse(
+                  name: 'lookup',
+                  output: {'answer': 42},
+                ),
+              ),
+            ],
+          ),
+        ],
+      );
+      final contents = _contentsOf(body);
+      expect(contents, hasLength(3));
+      final functionCall = (_partsOf(contents[1]).single['functionCall'] as Map)
+          .cast<String, dynamic>();
+      expect(functionCall['name'], 'lookup');
+      expect(functionCall['args'], {'q': 'x'});
+      final functionResponse =
+          (_partsOf(contents[2]).single['functionResponse'] as Map)
+              .cast<String, dynamic>();
+      expect(functionResponse['name'], 'lookup');
+      expect(jsonEncode(body), isNot(contains('thoughtSignature')));
     });
 
     test('passes in-range temperature through to generationConfig', () async {

--- a/packages/genkit_google_genai/test/known_models_wiring_test.dart
+++ b/packages/genkit_google_genai/test/known_models_wiring_test.dart
@@ -107,6 +107,32 @@ void main() {
       expect(info['stage'], 'stable');
     });
 
+    test('lists discovered gemma models with gemma metadata alongside the '
+        'curated catalog', () async {
+      final client = MockHttpClient(
+        modelsResponse:
+            '{"models": ['
+            '{"name": "models/gemma-3-4b-it"}, '
+            '{"name": "models/gemini-3.5-flash"}]}',
+      );
+      final actions = await plugin(client: client).list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(names, contains('googleai/gemma-3-4b-it'));
+      expect(names.toSet().length, names.length);
+      for (final model in KnownGeminiModel.values) {
+        expect(names, contains('googleai/${model.id}'));
+      }
+
+      final gemma = actions.firstWhere(
+        (a) => a.name == 'googleai/gemma-3-4b-it',
+      );
+      final info = (gemma.metadata['model'] as Map).cast<String, dynamic>();
+      final supports = (info['supports'] as Map).cast<String, dynamic>();
+      expect(supports['systemRole'], isFalse);
+      expect(supports['constrained'], 'no-tools');
+    });
+
     test('appends curated models missing from discovery', () async {
       final actions = await plugin().list();
       final names = actions.map((a) => a.name).toList();

--- a/packages/genkit_google_genai/test/known_models_wiring_test.dart
+++ b/packages/genkit_google_genai/test/known_models_wiring_test.dart
@@ -107,31 +107,47 @@ void main() {
       expect(info['stage'], 'stable');
     });
 
-    test('lists discovered gemma models with gemma metadata alongside the '
-        'curated catalog', () async {
-      final client = MockHttpClient(
-        modelsResponse:
-            '{"models": ['
-            '{"name": "models/gemma-3-4b-it"}, '
-            '{"name": "models/gemini-3.5-flash"}]}',
-      );
-      final actions = await plugin(client: client).list();
-      final names = actions.map((a) => a.name).toList();
+    test(
+      'lists discovered gemma models alongside the curated catalog',
+      () async {
+        final client = MockHttpClient(
+          modelsResponse:
+              '{"models": ['
+              '{"name": "models/gemma-3-4b-it"}, '
+              '{"name": "models/gemma-4-26b-a4b-it"}, '
+              '{"name": "models/gemini-3.5-flash"}]}',
+        );
+        final actions = await plugin(client: client).list();
+        final names = actions.map((a) => a.name).toList();
 
-      expect(names, contains('googleai/gemma-3-4b-it'));
-      expect(names.toSet().length, names.length);
-      for (final model in KnownGeminiModel.values) {
-        expect(names, contains('googleai/${model.id}'));
-      }
+        expect(names, contains('googleai/gemma-3-4b-it'));
+        expect(names, contains('googleai/gemma-4-26b-a4b-it'));
+        expect(names.toSet().length, names.length);
+        for (final model in KnownGeminiModel.values) {
+          expect(names, contains('googleai/${model.id}'));
+        }
 
-      final gemma = actions.firstWhere(
-        (a) => a.name == 'googleai/gemma-3-4b-it',
-      );
-      final info = (gemma.metadata['model'] as Map).cast<String, dynamic>();
-      final supports = (info['supports'] as Map).cast<String, dynamic>();
-      expect(supports['systemRole'], isFalse);
-      expect(supports['constrained'], 'no-tools');
-    });
+        final gemma4 = actions.firstWhere(
+          (a) => a.name == 'googleai/gemma-4-26b-a4b-it',
+        );
+        final gemma4Info = (gemma4.metadata['model'] as Map)
+            .cast<String, dynamic>();
+        final gemma4Supports = (gemma4Info['supports'] as Map)
+            .cast<String, dynamic>();
+        expect(gemma4Supports['systemRole'], isTrue);
+        expect(gemma4Supports['constrained'], 'no-tools');
+
+        final gemma3 = actions.firstWhere(
+          (a) => a.name == 'googleai/gemma-3-4b-it',
+        );
+        final gemma3Info = (gemma3.metadata['model'] as Map)
+            .cast<String, dynamic>();
+        final gemma3Supports = (gemma3Info['supports'] as Map)
+            .cast<String, dynamic>();
+        expect(gemma3Supports['systemRole'], isTrue);
+        expect(gemma3Supports['constrained'], isTrue);
+      },
+    );
 
     test('appends curated models missing from discovery', () async {
       final actions = await plugin().list();

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -73,5 +73,37 @@ void main() {
         'https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-2.5-pro:generateContent',
       );
     });
+
+    test('gemma model names resolve as plain Gemini models', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'global',
+        authClient: mockClient,
+      );
+
+      final model = plugin.resolve('model', 'gemma-3-4b-it') as Action;
+      final modelMeta = (model.metadata['model'] as Map)
+          .cast<String, dynamic>();
+      final supports = (modelMeta['supports'] as Map).cast<String, dynamic>();
+      expect(supports['systemRole'], isTrue);
+
+      await model.run(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.system,
+              content: [TextPart(text: 'be terse')],
+            ),
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'hello')],
+            ),
+          ],
+        ),
+      );
+
+      expect(mockClient.lastBody, contains('systemInstruction'));
+    });
   });
 }


### PR DESCRIPTION
Closes #386

Adds Gemma model family support to the googleai plugin:

- `GemmaOptions` schema (temperature capped at 1.0) and a `googleAI.gemma(name)` handle helper.
- `gemma-*` names route through the googleai plugin with Gemma `ModelInfo` (`systemRole: false`, `constrained: 'no-tools'`); `list()` discovery surfaces `models/gemma-*`. Gemma handling is gated to googleai, so `vertexai/gemma-*` still resolves as a plain Gemini-style model.
- Dart core has no system-prompt simulation middleware, so the plugin folds a system message into the first user turn instead of sending `systemInstruction`, which Gemma endpoints reject with a 400.
- Temperature outside 0.0-1.0 throws `INVALID_ARGUMENT` at runtime; the schema cap alone is JSON-schema metadata.
- Strips `ReasoningPart`s and `thoughtSignature` metadata from history before calling the Gemma endpoint.
- Gemma 3 and 4 are treated uniformly; routing is by the `gemma-` prefix and the specific model IDs appear in tests only. JS and Dart constrained values diverge, so this is not full JS parity.

Tests: 25 gemma cases (16 unit, 8 wire-level via MockClient, 1 vertexai gating) plus a combined gemma-discovery/curated-catalog listing test; analyze, format, and tests green in google_genai (84/84) and vertexai (27/27).

- [x] Live smoke test against `gemma-4-26b-a4b-it`: system folding honored (constraint followed, no 400) and plain generation works. Note: the live API currently serves only `gemma-4-26b-a4b-it` and `gemma-4-31b-it`; the gemma-3 names appear in tests as routing fixtures only and are never advertised, since `list()` is discovery-driven.


