### PR TITLE
feat(google_genai): add Imagen 4 model support

### DIFF
--- a/packages/genkit_google_genai/lib/genkit_google_genai.dart
+++ b/packages/genkit_google_genai/lib/genkit_google_genai.dart
@@ -32,6 +32,10 @@ class GoogleGenAiPluginHandle {
     return modelRef('googleai/$name', customOptions: GeminiOptions.$schema);
   }
 
+  ModelRef<ImagenOptions> imagen(String name) {
+    return modelRef('googleai/$name', customOptions: ImagenOptions.$schema);
+  }
+
   EmbedderRef<TextEmbedderOptions> textEmbedding(String name) {
     return embedderRef(
       'googleai/$name',

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -119,12 +119,12 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
       customOptions: ImagenOptions.$schema,
       metadata: {'model': imagenModelInfo.toJson()},
       fn: (req, ctx) async {
-        final options = req?.config == null
+        final options = req!.config == null
             ? ImagenOptions()
-            : ImagenOptions.$schema.parse(req!.config!);
+            : ImagenOptions.$schema.parse(req.config!);
         final service = await getApiClient(options.apiKey);
         try {
-          final prompt = extractPrompt(req!.messages);
+          final prompt = extractPrompt(req.messages);
           final image = extractImagenImage(req.messages);
           final body = <String, dynamic>{
             'instances': [

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -18,6 +18,7 @@ import 'package:meta/meta.dart';
 import 'api_client.dart';
 import 'common_plugin.dart';
 import 'generated/generativelanguage.dart' as gcl;
+import 'imagen.dart';
 import 'model.dart';
 
 @visibleForTesting
@@ -51,15 +52,31 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
         logger.warning('Failed to list models: $e', e, stack);
         throw handleException(e, stack);
       }
+      const predictMethods = ['predict', 'predictLongRunning'];
       final models = (modelsResponse.models ?? [])
           .where((model) {
-            return model.name != null &&
-                model.name!.startsWith('models/gemini-');
+            final n = model.name;
+            if (n == null) return false;
+            if (n.startsWith('models/gemini-')) return true;
+            if (n.startsWith('models/imagen-')) {
+              return (model.supportedGenerationMethods ?? const []).any(
+                predictMethods.contains,
+              );
+            }
+            return false;
           })
           .map((model) {
-            final isTts = model.name!.contains('-tts');
+            final short = model.name!.split('/').last;
+            if (isImagenModelName(short)) {
+              return modelMetadata(
+                '$name/$short',
+                customOptions: ImagenOptions.$schema,
+                modelInfo: imagenModelInfo,
+              );
+            }
+            final isTts = short.contains('-tts');
             return modelMetadata(
-              '$name/${model.name!.split('/').last}',
+              '$name/$short',
               customOptions: isTts
                   ? GeminiTtsOptions.$schema
                   : GeminiOptions.$schema,
@@ -86,6 +103,63 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
     } finally {
       service.client.close();
     }
+  }
+
+  @override
+  Action? resolve(String actionType, String name) {
+    if (actionType == 'model' && isImagenModelName(name)) {
+      return createImagenModel(name);
+    }
+    return super.resolve(actionType, name);
+  }
+
+  Model createImagenModel(String modelName) {
+    return Model(
+      name: '$name/$modelName',
+      customOptions: ImagenOptions.$schema,
+      metadata: {'model': imagenModelInfo.toJson()},
+      fn: (req, ctx) async {
+        final options = req?.config == null
+            ? ImagenOptions()
+            : ImagenOptions.$schema.parse(req!.config!);
+        final service = await getApiClient(options.apiKey);
+        try {
+          final prompt = extractPrompt(req!.messages);
+          final image = extractImagenImage(req.messages);
+          final body = <String, dynamic>{
+            'instances': [
+              {'prompt': prompt, 'image': ?image},
+            ],
+            'parameters': toImagenParameters(options),
+          };
+          final raw = await service.predict(body, model: 'models/$modelName');
+          final predictions =
+              (raw['predictions'] as List?)
+                  ?.whereType<Map<String, dynamic>>()
+                  .toList() ??
+              const [];
+          final parts = predictions
+              .map(fromImagenPrediction)
+              .whereType<MediaPart>()
+              .toList();
+          if (parts.isEmpty) {
+            throw GenkitException(
+              'Model returned no predictions. Possibly due to content filters.',
+              status: StatusCodes.FAILED_PRECONDITION,
+            );
+          }
+          return ModelResponse(
+            finishReason: FinishReason('stop'),
+            message: Message(role: Role.model, content: parts),
+            raw: raw,
+          );
+        } catch (e, stack) {
+          throw handleException(e, stack);
+        } finally {
+          service.client.close();
+        }
+      },
+    );
   }
 
   @override

--- a/packages/genkit_google_genai/lib/src/imagen.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.dart
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+
+import 'model.dart';
+
+final imagenModelInfo = ModelInfo(
+  supports: {
+    'media': true,
+    'multiturn': false,
+    'tools': false,
+    'toolChoice': false,
+    'systemRole': false,
+    'output': ['media'],
+  },
+);
+
+bool isImagenModelName(String name) => name.startsWith('imagen-');
+
+String extractPrompt(List<Message> messages) {
+  return messages
+      .where((m) => m.role == Role.user)
+      .expand((m) => m.content)
+      .where((p) => p.isText)
+      .map((p) => p.text!)
+      .join('\n');
+}
+
+/// Extracts a single input image from the last message for img2img.
+///
+/// Mirrors JS `extractImagenImage` (googleai/utils.ts): looks at the last
+/// message's media parts, matching parts with no `metadata.type` or
+/// `metadata.type == 'base'`, and returns the base64 payload of the first
+/// match. Only `data:` URIs are supported (matches JS behaviour — the JS
+/// impl splits the URL on `,` and takes the second segment, which yields
+/// `undefined` for non-data URLs).
+Map<String, dynamic>? extractImagenImage(List<Message> messages) {
+  if (messages.isEmpty) return null;
+  final last = messages.last;
+  for (final p in last.content) {
+    if (!p.isMedia) continue;
+    final type = p.metadata?['type'] as String?;
+    final matches = type == null || type == 'base';
+    if (!matches) continue;
+    final url = p.media!.url;
+    if (!url.startsWith('data:')) continue;
+    final commaIdx = url.indexOf(',');
+    if (commaIdx < 0 || commaIdx == url.length - 1) continue;
+    return {'bytesBase64Encoded': url.substring(commaIdx + 1)};
+  }
+  return null;
+}
+
+Map<String, dynamic> toImagenParameters(ImagenOptions options) {
+  return {
+    if (options.numberOfImages != null) 'sampleCount': options.numberOfImages,
+    if (options.aspectRatio != null) 'aspectRatio': options.aspectRatio,
+    if (options.personGeneration != null)
+      'personGeneration': options.personGeneration,
+  };
+}
+
+MediaPart? fromImagenPrediction(Map<String, dynamic> p) {
+  final b64 = p['bytesBase64Encoded'] as String?;
+  final mimeType = p['mimeType'] as String?;
+  if (b64 == null || b64.isEmpty) return null;
+  return MediaPart(
+    media: Media(
+      url: 'data:${mimeType ?? ''};base64,$b64',
+      contentType: mimeType,
+    ),
+  );
+}

--- a/packages/genkit_google_genai/lib/src/model.dart
+++ b/packages/genkit_google_genai/lib/src/model.dart
@@ -57,6 +57,26 @@ abstract class $GeminiOptions {
 }
 
 @Schema()
+abstract class $ImagenOptions {
+  String? get apiKey;
+
+  @IntegerField(minimum: 1, maximum: 4)
+  int? get numberOfImages;
+
+  @StringField(
+    enumValues: ['1:1', '9:16', '16:9', '3:4', '4:3'],
+    description: 'Aspect ratio of the generated image.',
+  )
+  String? get aspectRatio;
+
+  @StringField(
+    enumValues: ['dont_allow', 'allow_adult', 'allow_all'],
+    description: 'Controls generation of people.',
+  )
+  String? get personGeneration;
+}
+
+@Schema()
 abstract class $SafetySettings {
   @StringField(
     enumValues: [

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -413,6 +413,120 @@ base class _GeminiOptionsTypeFactory extends SchemanticType<GeminiOptions> {
   );
 }
 
+base class ImagenOptions {
+  factory ImagenOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  ImagenOptions._(this._json);
+
+  ImagenOptions({
+    String? apiKey,
+    int? numberOfImages,
+    String? aspectRatio,
+    String? personGeneration,
+  }) {
+    _json = {
+      'apiKey': ?apiKey,
+      'numberOfImages': ?numberOfImages,
+      'aspectRatio': ?aspectRatio,
+      'personGeneration': ?personGeneration,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static const SchemanticType<ImagenOptions> $schema =
+      _ImagenOptionsTypeFactory();
+
+  String? get apiKey {
+    return _json['apiKey'] as String?;
+  }
+
+  set apiKey(String? value) {
+    if (value == null) {
+      _json.remove('apiKey');
+    } else {
+      _json['apiKey'] = value;
+    }
+  }
+
+  int? get numberOfImages {
+    return _json['numberOfImages'] as int?;
+  }
+
+  set numberOfImages(int? value) {
+    if (value == null) {
+      _json.remove('numberOfImages');
+    } else {
+      _json['numberOfImages'] = value;
+    }
+  }
+
+  String? get aspectRatio {
+    return _json['aspectRatio'] as String?;
+  }
+
+  set aspectRatio(String? value) {
+    if (value == null) {
+      _json.remove('aspectRatio');
+    } else {
+      _json['aspectRatio'] = value;
+    }
+  }
+
+  String? get personGeneration {
+    return _json['personGeneration'] as String?;
+  }
+
+  set personGeneration(String? value) {
+    if (value == null) {
+      _json.remove('personGeneration');
+    } else {
+      _json['personGeneration'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _ImagenOptionsTypeFactory extends SchemanticType<ImagenOptions> {
+  const _ImagenOptionsTypeFactory();
+
+  @override
+  ImagenOptions parse(Object? json) {
+    return ImagenOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'ImagenOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'apiKey': $Schema.string(),
+            'numberOfImages': $Schema.integer(minimum: 1, maximum: 4),
+            'aspectRatio': $Schema.string(
+              description: 'Aspect ratio of the generated image.',
+              enumValues: ['1:1', '9:16', '16:9', '3:4', '4:3'],
+            ),
+            'personGeneration': $Schema.string(
+              description: 'Controls generation of people.',
+              enumValues: ['dont_allow', 'allow_adult', 'allow_all'],
+            ),
+          },
+        )
+        .value,
+    dependencies: [],
+  );
+}
+
 base class SafetySettings {
   factory SafetySettings.fromJson(Map<String, dynamic> json) =>
       $schema.parse(json);

--- a/packages/genkit_google_genai/test/imagen_test.dart
+++ b/packages/genkit_google_genai/test/imagen_test.dart
@@ -1,0 +1,246 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:genkit_google_genai/src/imagen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isImagenModelName', () {
+    test('matches imagen prefix', () {
+      expect(isImagenModelName('imagen-4.0-generate-001'), isTrue);
+      expect(isImagenModelName('imagen-4.0-fast-generate-001'), isTrue);
+      expect(isImagenModelName('imagen-4.0-ultra-generate-001'), isTrue);
+    });
+
+    test('does not match other families', () {
+      expect(isImagenModelName('gemini-2.5-pro'), isFalse);
+      expect(isImagenModelName('gemma-3-1b-it'), isFalse);
+      expect(isImagenModelName('text-embedding-004'), isFalse);
+    });
+  });
+
+  group('extractPrompt', () {
+    test('joins text parts across user messages with newlines', () {
+      final messages = [
+        Message(
+          role: Role.user,
+          content: [
+            TextPart(text: 'hello'),
+            TextPart(text: 'world'),
+          ],
+        ),
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'again')],
+        ),
+      ];
+      expect(extractPrompt(messages), 'hello\nworld\nagain');
+    });
+
+    test('ignores media parts and model-role messages', () {
+      final messages = [
+        Message(
+          role: Role.model,
+          content: [TextPart(text: 'should be ignored')],
+        ),
+        Message(
+          role: Role.user,
+          content: [
+            TextPart(text: 'draw this:'),
+            MediaPart(media: Media(url: 'data:image/png;base64,AAA')),
+          ],
+        ),
+      ];
+      expect(extractPrompt(messages), 'draw this:');
+    });
+  });
+
+  group('extractImagenImage', () {
+    test('returns null when there are no messages', () {
+      expect(extractImagenImage(const []), isNull);
+    });
+
+    test('returns null when last message has no media', () {
+      final messages = [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hi')],
+        ),
+      ];
+      expect(extractImagenImage(messages), isNull);
+    });
+
+    test('returns base64 payload from a data URI with no metadata', () {
+      final messages = [
+        Message(
+          role: Role.user,
+          content: [MediaPart(media: Media(url: 'data:image/png;base64,ABC'))],
+        ),
+      ];
+      expect(extractImagenImage(messages), {'bytesBase64Encoded': 'ABC'});
+    });
+
+    test('matches metadata.type == "base"', () {
+      final messages = [
+        Message(
+          role: Role.user,
+          content: [
+            MediaPart(
+              media: Media(url: 'data:image/png;base64,ABC'),
+              metadata: {'type': 'base'},
+            ),
+          ],
+        ),
+      ];
+      expect(extractImagenImage(messages), {'bytesBase64Encoded': 'ABC'});
+    });
+
+    test('skips media with a non-"base" metadata.type', () {
+      final messages = [
+        Message(
+          role: Role.user,
+          content: [
+            MediaPart(
+              media: Media(url: 'data:image/png;base64,ABC'),
+              metadata: {'type': 'mask'},
+            ),
+          ],
+        ),
+      ];
+      expect(extractImagenImage(messages), isNull);
+    });
+
+    test('returns null for a plain https URL (non-data URI)', () {
+      final messages = [
+        Message(
+          role: Role.user,
+          content: [MediaPart(media: Media(url: 'https://example.com/x.png'))],
+        ),
+      ];
+      expect(extractImagenImage(messages), isNull);
+    });
+
+    test('only looks at the last message', () {
+      final messages = [
+        Message(
+          role: Role.user,
+          content: [MediaPart(media: Media(url: 'data:image/png;base64,OLD'))],
+        ),
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'new turn')],
+        ),
+      ];
+      expect(extractImagenImage(messages), isNull);
+    });
+  });
+
+  group('toImagenParameters', () {
+    test('empty options yields empty map', () {
+      expect(toImagenParameters(ImagenOptions()), <String, dynamic>{});
+    });
+
+    test('maps numberOfImages to sampleCount', () {
+      final params = toImagenParameters(
+        ImagenOptions(
+          numberOfImages: 2,
+          aspectRatio: '16:9',
+          personGeneration: 'allow_adult',
+        ),
+      );
+      expect(params, {
+        'sampleCount': 2,
+        'aspectRatio': '16:9',
+        'personGeneration': 'allow_adult',
+      });
+    });
+
+    test('never emits apiKey', () {
+      final params = toImagenParameters(ImagenOptions(apiKey: 'secret'));
+      expect(params.containsKey('apiKey'), isFalse);
+    });
+  });
+
+  group('fromImagenPrediction', () {
+    test('builds a MediaPart with a data URI', () {
+      final part = fromImagenPrediction({
+        'bytesBase64Encoded': 'abc',
+        'mimeType': 'image/png',
+      });
+      expect(part, isNotNull);
+      expect(part!.media.url, 'data:image/png;base64,abc');
+      expect(part.media.contentType, 'image/png');
+    });
+
+    test('returns null when bytesBase64Encoded is missing', () {
+      expect(fromImagenPrediction({'mimeType': 'image/png'}), isNull);
+    });
+
+    test('returns null when bytesBase64Encoded is empty', () {
+      expect(
+        fromImagenPrediction({'bytesBase64Encoded': '', 'mimeType': 'x'}),
+        isNull,
+      );
+    });
+  });
+
+  group('plugin handle', () {
+    test('googleAI.imagen returns a ModelRef with ImagenOptions schema', () {
+      final ref = googleAI.imagen('imagen-4.0-generate-001');
+      expect(ref.name, 'googleai/imagen-4.0-generate-001');
+      expect(ref.customOptions, same(ImagenOptions.$schema));
+    });
+  });
+
+  group('GoogleGenAiPluginImpl.resolve for imagen models', () {
+    test('returns a Model with imagen supports metadata', () {
+      final plugin = GoogleGenAiPluginImpl();
+      final action = plugin.resolve('model', 'imagen-4.0-fast-generate-001');
+      expect(action, isNotNull);
+      expect(action!.name, 'googleai/imagen-4.0-fast-generate-001');
+
+      final model = action.metadata['model'] as Map<String, dynamic>;
+      final supports = model['supports'] as Map<String, dynamic>;
+      expect(supports['media'], isTrue);
+      expect(supports['multiturn'], isFalse);
+      expect(supports['tools'], isFalse);
+      expect(supports['toolChoice'], isFalse);
+      expect(supports['systemRole'], isFalse);
+      expect(supports['output'], ['media']);
+    });
+
+    test('non-imagen names still reach the gemini/embedder path', () {
+      final plugin = GoogleGenAiPluginImpl();
+      final action = plugin.resolve('model', 'gemini-2.5-pro');
+      expect(action, isNotNull);
+      expect(action!.name, 'googleai/gemini-2.5-pro');
+    });
+  });
+
+  group('ImagenOptions schema', () {
+    test('round-trips all fields', () {
+      final opts = ImagenOptions.$schema.parse({
+        'numberOfImages': 2,
+        'aspectRatio': '16:9',
+        'personGeneration': 'allow_adult',
+      });
+      expect(opts.numberOfImages, 2);
+      expect(opts.aspectRatio, '16:9');
+      expect(opts.personGeneration, 'allow_adult');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds an `ImagenOptions` config schema (`numberOfImages`, `aspectRatio`, `personGeneration`, `apiKey`) with strict `@StringField(enumValues: [...])` enums to match the rest of the Dart codebase.
- Adds a `googleAI.imagen(name)` handle helper alongside `.gemini(...)` and `.textEmbedding(...)`.
- Overrides `resolve()` in `GoogleGenAiPluginImpl` so `imagen-*` names short-circuit onto a dedicated `createImagenModel()` backed by the existing `:predict` endpoint on `GenerativeLanguageBaseClient`.
- New `lib/src/imagen.dart` mirrors the JS `imagen.ts` layout — keeps `common_plugin.dart` out of the Imagen flow entirely since the `generateContent` and `predict` shapes share nothing but the HTTP client.
- Supports both text-to-image **and** img2img via `extractImagenImage`, matching JS parity: first `base`/untyped `MediaPart` from the last user message, data-URI only (plain URLs yield no match — same as JS `url.split(',')[1]`).
- Extends `list()` to surface `models/imagen-*` with the correct `ModelInfo` (`media: true, multiturn: false, tools: false, systemRole: false, output: ['media']`) when `supportedGenerationMethods` contains `predict` or `predictLongRunning`.

Closes the P3 parity gap for:
- `imagen-4.0-generate-001`
- `imagen-4.0-fast-generate-001`
- `imagen-4.0-ultra-generate-001`

The name-prefix check covers future Imagen variants automatically.

### Notes

- Streaming is intentionally not implemented — matches JS, which has no `streamingCallback`/`sendChunk` path for Imagen. `streamGenerate` callers still receive a final `ModelResponse`.
- Empty `predictions` list throws `GenkitException('Model returned no predictions. Possibly due to content filters.', status: StatusCodes.FAILED_PRECONDITION)`.
- Individual predictions with missing `bytesBase64Encoded` are silently skipped; if *all* predictions are skipped, the empty-predictions branch fires.
- Vertex AI plugin is untouched — the `resolve()` override is on `GoogleGenAiPluginImpl`, not the common base. Vertex serves Imagen on a different host (`aiplatform.googleapis.com`), so there was no shared-plugin win here.

## Test plan

- [x] `dart analyze` clean in `packages/genkit_google_genai`
- [x] `dart analyze` clean in `packages/genkit_vertexai`
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart test` passes (50/50) in `packages/genkit_google_genai`, including 21 new cases in `test/imagen_test.dart`
- [x] `dart test` passes (2/2) in `packages/genkit_vertexai`
- [ ] Live smoke test against `imagen-4.0-fast-generate-001` with `GEMINI_API_KEY` (not run in this branch)
- [ ] Live img2img smoke test with a data-URI input image