### PR TITLE
feat(chrome): Update implementation and add a few things

### DIFF
--- a/packages/genkit_chrome/README.md
+++ b/packages/genkit_chrome/README.md
@@ -4,6 +4,10 @@ This plugin allows you to run Gemini Nano locally in Chrome, providing low-laten
 
 ## Prerequisites
 
+> **Note:** The API is expected to ship in Chrome 148.
+
+### Local flags
+
 To use this plugin, you must be running Chrome 128 or later and enable the necessary flags:
 
 1.  Open `chrome://flags`
@@ -11,6 +15,15 @@ To use this plugin, you must be running Chrome 128 or later and enable the neces
 3.  Set **"Enables optimization guide on device"** (`chrome://flags/#optimization-guide-on-device-model`) to **"Enabled BypassPerfRequirement"**
 4.  Relaunch Chrome.
 5.  Open `chrome://components` and find **"Optimization Guide On Device Model"**. Click **"Check for update"** to download the model.
+
+### Origin trial
+
+You can also enable the [Prompt API origin trial](https://developer.chrome.com/origintrials/#/view_trial/2533837740349325313). Follow the
+[instructions](https://developer.chrome.com/docs/web-platform/origin-trials) to register and get a token, then add it to your page:
+
+```html
+<meta http-equiv="origin-trial" content="TOKEN_HERE">
+```
 
 ## Installation
 
@@ -22,61 +35,208 @@ dart pub add genkit_chrome
 
 ### 1. Initialize Genkit
 
-Add the `ChromeAIPlugin` to your Genkit configuration:
-
 ```dart
 import 'package:genkit/genkit.dart';
 import 'package:genkit_chrome/genkit_chrome.dart';
 
-void main() {
-  final ai = Genkit(plugins: [ChromeAIPlugin()]);
-}
+final ai = Genkit(plugins: [ChromeAIPlugin()]);
 ```
 
 ### 2. Generate Text
 
-Use the `chrome/gemini-nano` model to generate text:
+```dart
+final response = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'Explain quantum computing in simple terms.',
+);
+
+print(response.text);
+```
+
+### 3. Streaming
+
+Each chunk is an independent piece of text — concatenate them to build the full response:
 
 ```dart
-import 'package:genkit/genkit.dart';
-import 'package:genkit_chrome/genkit_chrome.dart';
+final buffer = StringBuffer();
 
-void main() async {
-  final ai = Genkit(plugins: [ChromeAIPlugin()]);
+await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'Write a story about a robot.',
+  onChunk: (chunk) => buffer.write(chunk.text),
+);
 
-  final response = await ai.generate(
+print(buffer.toString());
+```
+
+### 4. Multi-turn Conversations
+
+Pass a list of `Message` objects to maintain conversation history:
+
+```dart
+final history = <Message>[];
+
+// First turn
+history.add(Message(role: Role.user, content: [TextPart(text: 'Hello!')]));
+final r1 = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  messages: history,
+);
+history.add(r1.message!);
+
+// Second turn — model remembers the conversation
+history.add(Message(role: Role.user, content: [TextPart(text: 'What did I just say?')]));
+final r2 = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  messages: history,
+);
+print(r2.text);
+```
+
+### 5. System Prompt
+
+Pass a `systemPrompt` string in config. It is automatically placed as the first entry in `initialPrompts` as required by the Prompt API:
+
+```dart
+final response = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'Hello!',
+  config: {'systemPrompt': 'You are a pirate. Respond only in pirate speak.'},
+);
+```
+
+> **Note:** Changing the system prompt mid-conversation requires starting a new session (i.e., clearing message history and calling `generate` again).
+
+### 6. Aborting a Request
+
+Use a `web.AbortController` from `package:web` to cancel an in-flight request:
+
+```dart
+import 'package:web/web.dart' as web;
+
+final controller = web.AbortController();
+
+// Cancel after 3 seconds
+Future.delayed(Duration(seconds: 3), () => controller.abort());
+
+try {
+  await ai.generate(
     model: modelRef('chrome/gemini-nano'),
-    prompt: 'Explain quantum computing in simple terms.',
+    prompt: 'Write a very long essay...',
+    config: {'signal': controller.signal},
+    onChunk: (chunk) => print(chunk.text),
   );
-
-  print(response.text);
+} catch (e) {
+  print('Aborted or error: $e');
 }
 ```
 
-### 3. Streaming Responses
+### 7. Response Constraints
 
-Stream text as it is generated:
+Constrain the model's output to a JSON Schema or a regular expression by passing a JS object or JS RegExp as `responseConstraint`. This requires `dart:js_interop`:
 
 ```dart
-import 'package:genkit/genkit.dart';
-import 'package:genkit_chrome/genkit_chrome.dart';
+import 'dart:js_interop';
 
-void main() async {
-  final ai = Genkit(plugins: [ChromeAIPlugin()]);
+// JSON Schema constraint
+@JS('JSON.parse')
+external JSAny jsonParse(JSString json);
 
-  final stream = ai.generateStream(
-    model: modelRef('chrome/gemini-nano'),
-    prompt: 'Write a story about a robot.',
-  );
+final schema = jsonParse(
+  '{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}'
+  .toJS,
+);
 
-  await for (final chunk in stream) {
-    print(chunk.text);
-  }
+final response = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'What is 2 + 2?',
+  config: {'responseConstraint': schema},
+);
+
+print(response.text); // e.g. {"answer":"4"}
+```
+
+### 8. Expected Input / Output Languages
+
+Hint to the model which languages to expect:
+
+```dart
+final response = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'Hola, ¿cómo estás?',
+  config: {
+    'expectedInputs':  [{'type': 'text', 'languages': ['es']}],
+    'expectedOutputs': [{'type': 'text', 'languages': ['en']}],
+  },
+);
+```
+
+> **Note:** Changing language settings mid-conversation requires starting a new session.
+
+### 9. Model Download Progress
+
+The model may need to be downloaded the first time it is used. Pass an `onDownloadProgress` callback to track progress:
+
+```dart
+final response = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'Hello!',
+  config: {
+    'onDownloadProgress': (int loaded, int total) {
+      if (total > 0) {
+        final pct = (loaded / total * 100).toStringAsFixed(0);
+        print('Downloading: $pct%');
+      } else {
+        print('Downloading...');
+      }
+    },
+  },
+);
+```
+
+When `total` is `0`, the total size is unknown — show an indeterminate progress indicator.
+
+### 10. Token Usage
+
+The response includes context usage information. `inputTokens` is the number of tokens consumed by the current context, and `totalTokens` is the maximum context window size:
+
+```dart
+final response = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'Hello!',
+);
+
+final usage = response.usage;
+if (usage != null) {
+  print('Tokens used: ${usage.inputTokens} / ${usage.totalTokens}');
 }
+```
+
+### 11. Model Parameters (with separateOrigin Trial)
+
+`ChromeModel.getParams()` returns default and maximum values for `temperature` and `topK`. This is only available in an separate
+[Prompt API Sampling Parameters origin trial](https://developer.chrome.com/origintrials/#/view_trial/4469259680211795969) — it
+returns `null` on the open web:
+
+```dart
+final params = await ChromeModel.getParams();
+if (params != null) {
+  print('Default topK: ${params.defaultTopK}');
+  print('Default temperature: ${params.defaultTemperature}');
+}
+```
+
+`temperature` and `topK` can be passed in config and are currently available via an origin trial:
+
+```dart
+final response = await ai.generate(
+  model: modelRef('chrome/gemini-nano'),
+  prompt: 'Tell me a joke.',
+  config: {'temperature': 1.2, 'topK': 3},
+);
 ```
 
 ## Limitations
 
--   **Chrome Only**: This plugin currently only works in Google Chrome (and potentially other Chromium-based browsers that support the Prompt API).
--   **Text-Only**: The current implementation primarily supports text generation.
--   **Experimental**: The Chrome Prompt API is experimental and subject to change.
+-   **Chrome/Edge Only**: This plugin works in Google Chrome and Microsoft Edge, but _not_ in other Chromium-based browsers.
+-   **Text-Only**: Only text input and output are currently supported.

--- a/packages/genkit_chrome/README.md
+++ b/packages/genkit_chrome/README.md
@@ -214,7 +214,7 @@ if (usage != null) {
 
 ### 11. Model Parameters (with separateOrigin Trial)
 
-`ChromeModel.getParams()` returns default and maximum values for `temperature` and `topK`. This is only available in an separate
+ChromeModel.getParams() returns default and maximum values for temperature and topK (both must be set if either is used). This is only available in a separate
 [Prompt API Sampling Parameters origin trial](https://developer.chrome.com/origintrials/#/view_trial/4469259680211795969) — it
 returns `null` on the open web:
 

--- a/packages/genkit_chrome/README.md
+++ b/packages/genkit_chrome/README.md
@@ -198,7 +198,7 @@ When `total` is `0`, the total size is unknown — show an indeterminate progres
 
 ### 10. Token Usage
 
-The response includes context usage information. `inputTokens` is the number of tokens consumed by the current context, and `totalTokens` is the maximum context window size:
+The response includes context usage information. `inputTokens` is the number of tokens consumed by the current context. The model's maximum context window size is available in `usage.custom['contextWindow']`:
 
 ```dart
 final response = await ai.generate(
@@ -208,7 +208,9 @@ final response = await ai.generate(
 
 final usage = response.usage;
 if (usage != null) {
-  print('Tokens used: ${usage.inputTokens} / ${usage.totalTokens}');
+  final used = usage.inputTokens;
+  final max = usage.custom?['contextWindow'];
+  print('Tokens used: $used / $max');
 }
 ```
 

--- a/packages/genkit_chrome/lib/src/chrome_interop.dart
+++ b/packages/genkit_chrome/lib/src/chrome_interop.dart
@@ -31,8 +31,8 @@ extension type LanguageModelFactory._(JSObject _) implements JSObject {
 
   /// Returns the limits of the language model.
   ///
-  /// Deprecated: only available in extension contexts; resolves to null on the
-  /// open web.
+  /// Deprecated: only available in extension contexts or with the Prompt API
+  /// Sampling Parameters origin trial enabled; resolves to null otherwise.
   external JSPromise<LanguageModelParams?> params();
 }
 

--- a/packages/genkit_chrome/lib/src/chrome_interop.dart
+++ b/packages/genkit_chrome/lib/src/chrome_interop.dart
@@ -22,7 +22,8 @@ external LanguageModelFactory? get languageModelImpl;
 extension type LanguageModelFactory._(JSObject _) implements JSObject {
   /// Returns the availability of the language model.
   ///
-  /// Returns a promise that resolves to "readily", "after-download", or "no".
+  /// Returns a promise that resolves to "available", "downloadable",
+  /// "downloading", or "unavailable".
   external JSPromise<JSString> availability([LanguageModelOptions? options]);
 
   /// Creates a new session with the language model.
@@ -30,8 +31,9 @@ extension type LanguageModelFactory._(JSObject _) implements JSObject {
 
   /// Returns the limits of the language model.
   ///
-  /// Returns a promise that resolves to the limits of the language model.
-  external JSPromise<LanguageModelParams> params();
+  /// Deprecated: only available in extension contexts; resolves to null on the
+  /// open web.
+  external JSPromise<LanguageModelParams?> params();
 }
 
 @JS()
@@ -47,30 +49,57 @@ extension type LanguageModelOptions._(JSObject _) implements JSObject {
   factory LanguageModelOptions({
     num? temperature,
     num? topK,
-    String? systemPrompt,
     List<LanguageModelInitialPrompt>? initialPrompts,
+    String? systemPrompt,
     List<LanguageModelExpectedInput>? expectedInputs,
     List<LanguageModelExpectedOutput>? expectedOutputs,
+    void Function(int loaded, int total)? onDownloadProgress,
   }) {
     final options = JSObject();
     if (temperature != null) options['temperature'] = temperature.toJS;
     if (topK != null) options['topK'] = topK.toJS;
-    if (systemPrompt != null) options['systemPrompt'] = systemPrompt.toJS;
-    if (initialPrompts != null && initialPrompts.isNotEmpty) {
-      options['initialPrompts'] = initialPrompts.toJS;
+
+    // Build the final initialPrompts list: system prompt must be first.
+    final allPrompts = <LanguageModelInitialPrompt>[];
+    if (systemPrompt != null && systemPrompt.isNotEmpty) {
+      allPrompts.add(LanguageModelInitialPrompt(role: 'system', content: systemPrompt));
     }
+    if (initialPrompts != null && initialPrompts.isNotEmpty) {
+      allPrompts.addAll(initialPrompts);
+    }
+    if (allPrompts.isNotEmpty) {
+      options['initialPrompts'] = allPrompts.toJS;
+    }
+
     if (expectedInputs != null && expectedInputs.isNotEmpty) {
       options['expectedInputs'] = expectedInputs.toJS;
     }
     if (expectedOutputs != null && expectedOutputs.isNotEmpty) {
       options['expectedOutputs'] = expectedOutputs.toJS;
     }
+
+    if (onDownloadProgress != null) {
+      final cb = onDownloadProgress;
+      void monitorFn(JSAny? monitorObj) {
+        if (monitorObj == null) return;
+        final m = monitorObj as JSObject;
+        void progressFn(JSAny? eventObj) {
+          if (eventObj == null) return;
+          final e = eventObj as JSObject;
+          final loaded = (e['loaded'] as JSNumber).toDartDouble.toInt();
+          final total = (e['total'] as JSNumber).toDartDouble.toInt();
+          cb(loaded, total);
+        }
+        m['ondownloadprogress'] = progressFn.toJS;
+      }
+      options['monitor'] = monitorFn.toJS;
+    }
+
     return options as LanguageModelOptions;
   }
 
   external num? get temperature;
   external num? get topK;
-  external String? get systemPrompt;
   external JSArray<LanguageModelInitialPrompt>? get initialPrompts;
   external JSArray<LanguageModelExpectedInput>? get expectedInputs;
   external JSArray<LanguageModelExpectedOutput>? get expectedOutputs;
@@ -98,30 +127,39 @@ extension type LanguageModelInitialPrompt._(JSObject _) implements JSObject {
 }
 
 @JS()
+extension type LanguageModelPromptOptions._(JSObject _) implements JSObject {
+  factory LanguageModelPromptOptions({JSObject? signal, JSAny? responseConstraint}) {
+    final options = JSObject();
+    if (signal != null) options['signal'] = signal;
+    if (responseConstraint != null) options['responseConstraint'] = responseConstraint;
+    return options as LanguageModelPromptOptions;
+  }
+}
+
+@JS()
 extension type LanguageModel._(JSObject _) implements JSObject {
   /// Prompts the model with the given input.
-  external JSPromise<JSString> prompt(String input);
+  external JSPromise<JSString> prompt(
+    String input, [
+    LanguageModelPromptOptions? options,
+  ]);
 
   /// Prompts the model with the given input and returns a streaming response.
-  external ReadableStream promptStreaming(String input);
+  external ReadableStream promptStreaming(
+    String input, [
+    LanguageModelPromptOptions? options,
+  ]);
 
   /// Destroys the session.
   external void destroy();
 
-  // Clone is also available but we might not use it yet
   external JSPromise<LanguageModel> clone();
 
-  /// Returns the number of tokens in the given input.
-  external JSPromise<JSNumber> countPromptTokens(String input);
+  /// Tokens consumed by the current context.
+  external double? get contextUsage;
 
-  /// Returns the number of tokens in the given input.
-  external JSPromise<JSNumber> measureInputUsage(String input);
-
-  external int? get maxTokens;
-  external int? get inputQuota;
-
-  external int? get tokensSoFar;
-  external int? get inputUsage;
+  /// Maximum context window size.
+  external double? get contextWindow;
 }
 
 @JS()

--- a/packages/genkit_chrome/lib/src/chrome_interop.dart
+++ b/packages/genkit_chrome/lib/src/chrome_interop.dart
@@ -62,7 +62,9 @@ extension type LanguageModelOptions._(JSObject _) implements JSObject {
     // Build the final initialPrompts list: system prompt must be first.
     final allPrompts = <LanguageModelInitialPrompt>[];
     if (systemPrompt != null && systemPrompt.isNotEmpty) {
-      allPrompts.add(LanguageModelInitialPrompt(role: 'system', content: systemPrompt));
+      allPrompts.add(
+        LanguageModelInitialPrompt(role: 'system', content: systemPrompt),
+      );
     }
     if (initialPrompts != null && initialPrompts.isNotEmpty) {
       allPrompts.addAll(initialPrompts);
@@ -90,8 +92,10 @@ extension type LanguageModelOptions._(JSObject _) implements JSObject {
           final total = (e['total'] as JSNumber?)?.toDartDouble.toInt() ?? 0;
           cb(loaded, total);
         }
+
         m['ondownloadprogress'] = progressFn.toJS;
       }
+
       options['monitor'] = monitorFn.toJS;
     }
 
@@ -128,10 +132,15 @@ extension type LanguageModelInitialPrompt._(JSObject _) implements JSObject {
 
 @JS()
 extension type LanguageModelPromptOptions._(JSObject _) implements JSObject {
-  factory LanguageModelPromptOptions({JSObject? signal, JSAny? responseConstraint}) {
+  factory LanguageModelPromptOptions({
+    JSObject? signal,
+    JSAny? responseConstraint,
+  }) {
     final options = JSObject();
     if (signal != null) options['signal'] = signal;
-    if (responseConstraint != null) options['responseConstraint'] = responseConstraint;
+    if (responseConstraint != null) {
+      options['responseConstraint'] = responseConstraint;
+    }
     return options as LanguageModelPromptOptions;
   }
 }

--- a/packages/genkit_chrome/lib/src/chrome_interop.dart
+++ b/packages/genkit_chrome/lib/src/chrome_interop.dart
@@ -83,17 +83,19 @@ extension type LanguageModelOptions._(JSObject _) implements JSObject {
     if (onDownloadProgress != null) {
       final cb = onDownloadProgress;
       void monitorFn(JSAny? monitorObj) {
-        if (monitorObj == null) return;
-        final m = monitorObj as JSObject;
-        void progressFn(JSAny? eventObj) {
-          if (eventObj == null) return;
-          final e = eventObj as JSObject;
-          final loaded = (e['loaded'] as JSNumber?)?.toDartDouble.toInt() ?? 0;
-          final total = (e['total'] as JSNumber?)?.toDartDouble.toInt() ?? 0;
-          cb(loaded, total);
-        }
+        if (monitorObj case JSObject m) {
+          void progressFn(JSAny? eventObj) {
+            if (eventObj case JSObject e) {
+              final loaded =
+                  (e['loaded'] as JSNumber?)?.toDartDouble.toInt() ?? 0;
+              final total =
+                  (e['total'] as JSNumber?)?.toDartDouble.toInt() ?? 0;
+              cb(loaded, total);
+            }
+          }
 
-        m['ondownloadprogress'] = progressFn.toJS;
+          m['ondownloadprogress'] = progressFn.toJS;
+        }
       }
 
       options['monitor'] = monitorFn.toJS;

--- a/packages/genkit_chrome/lib/src/chrome_interop.dart
+++ b/packages/genkit_chrome/lib/src/chrome_interop.dart
@@ -86,8 +86,8 @@ extension type LanguageModelOptions._(JSObject _) implements JSObject {
         void progressFn(JSAny? eventObj) {
           if (eventObj == null) return;
           final e = eventObj as JSObject;
-          final loaded = (e['loaded'] as JSNumber).toDartDouble.toInt();
-          final total = (e['total'] as JSNumber).toDartDouble.toInt();
+          final loaded = (e['loaded'] as JSNumber?)?.toDartDouble.toInt() ?? 0;
+          final total = (e['total'] as JSNumber?)?.toDartDouble.toInt() ?? 0;
           cb(loaded, total);
         }
         m['ondownloadprogress'] = progressFn.toJS;

--- a/packages/genkit_chrome/lib/src/chrome_model.dart
+++ b/packages/genkit_chrome/lib/src/chrome_model.dart
@@ -54,8 +54,7 @@ class ChromeModel extends Model<LanguageModelOptions> {
     }
 
     final config = req.config ?? const {};
-    final systemPrompt =
-        config['systemPrompt'] as String?;
+    final systemPrompt = config['systemPrompt'] as String?;
 
     final historyPrompts = <LanguageModelInitialPrompt>[];
 
@@ -100,7 +99,9 @@ class ChromeModel extends Model<LanguageModelOptions> {
     final promptOptions = (signalObj != null || constraintObj != null)
         ? LanguageModelPromptOptions(
             signal: signalObj != null ? signalObj as JSObject : null,
-            responseConstraint: constraintObj != null ? constraintObj as JSAny : null,
+            responseConstraint: constraintObj != null
+                ? constraintObj as JSAny
+                : null,
           )
         : null;
 

--- a/packages/genkit_chrome/lib/src/chrome_model.dart
+++ b/packages/genkit_chrome/lib/src/chrome_model.dart
@@ -34,7 +34,9 @@ class ChromeModel extends Model<LanguageModelOptions> {
          fn: (req, ctx) => _processRequest(req, ctx, options),
        );
 
-  static Future<LanguageModelParams> getParams() {
+  /// Returns model params. Only available in Chrome extension contexts;
+  /// returns null on the open web.
+  static Future<LanguageModelParams?> getParams() {
     return _languageModel.params().toDart;
   }
 
@@ -52,20 +54,14 @@ class ChromeModel extends Model<LanguageModelOptions> {
 
     final config = req.config ?? const {};
     final systemPrompt =
-        config['systemPrompt'] as String? ?? defaultOptions?.systemPrompt;
+        config['systemPrompt'] as String?;
 
-    final initialPrompts = <LanguageModelInitialPrompt>[];
+    final historyPrompts = <LanguageModelInitialPrompt>[];
 
-    if (systemPrompt != null && systemPrompt.isNotEmpty) {
-      initialPrompts.add(
-        LanguageModelInitialPrompt(role: 'system', content: systemPrompt),
-      );
-    }
-
-    // Add all messages except the last one to initialPrompts
+    // Add all messages except the last one as conversation history.
     if (req.messages.isNotEmpty) {
       for (final m in req.messages.take(req.messages.length - 1)) {
-        initialPrompts.add(
+        historyPrompts.add(
           LanguageModelInitialPrompt(
             role: m.role == Role.model ? 'assistant' : m.role.value,
             content: m.content.map((p) => p.text).join(' '),
@@ -74,22 +70,38 @@ class ChromeModel extends Model<LanguageModelOptions> {
       }
     }
 
+    final onDownloadProgress =
+        config['onDownloadProgress'] as void Function(int, int)?;
+
+    // LanguageModelOptions factory places systemPrompt first in initialPrompts.
     final options = LanguageModelOptions(
       temperature: config['temperature'] as num? ?? defaultOptions?.temperature,
       topK: config['topK'] as num? ?? defaultOptions?.topK,
-      initialPrompts: initialPrompts,
+      systemPrompt: systemPrompt,
+      initialPrompts: historyPrompts,
       expectedInputs:
           _parseExpectedInputs(config) ??
           defaultOptions?.expectedInputs?.toDart,
       expectedOutputs:
           _parseExpectedOutputs(config) ??
           defaultOptions?.expectedOutputs?.toDart,
+      onDownloadProgress: onDownloadProgress,
     );
 
-    // Availability check
+    // Availability check — use the same options we pass to create().
     await _ensureAvailability(options);
 
     final session = await _languageModel.create(options).toDart;
+
+    // AbortSignal and responseConstraint are passed through config.
+    final signalObj = config['signal'];
+    final constraintObj = config['responseConstraint'];
+    final promptOptions = (signalObj != null || constraintObj != null)
+        ? LanguageModelPromptOptions(
+            signal: signalObj != null ? signalObj as JSObject : null,
+            responseConstraint: constraintObj != null ? constraintObj as JSAny : null,
+          )
+        : null;
 
     try {
       final prompt = req.messages.isEmpty
@@ -98,7 +110,7 @@ class ChromeModel extends Model<LanguageModelOptions> {
 
       String? lastResponseText;
       if (ctx.streamingRequested) {
-        final stream = session.promptStreaming(prompt);
+        final stream = session.promptStreaming(prompt, promptOptions);
         final reader = stream.getReader();
         while (true) {
           final result = await reader.read().toDart;
@@ -110,16 +122,12 @@ class ChromeModel extends Model<LanguageModelOptions> {
           lastResponseText = (lastResponseText ?? '') + chunkText;
         }
       } else {
-        lastResponseText = (await session.prompt(prompt).toDart).toDart;
+        lastResponseText =
+            (await session.prompt(prompt, promptOptions).toDart).toDart;
       }
 
-      // Collect usage stats
-      // tokensSoFar and inputUsage are likely the same (renamed)
-      final inputTokens = (session.inputUsage ?? session.tokensSoFar)
-          ?.toDouble();
-      // We don't have output tokens from the session directly usually
-      // Quota is maxTokens or inputQuota
-      // final totalTokens = session.maxTokens ?? session.inputQuota;
+      final contextUsage = session.contextUsage;
+      final contextWindow = session.contextWindow;
 
       return ModelResponse(
         finishReason: FinishReason.stop,
@@ -127,11 +135,13 @@ class ChromeModel extends Model<LanguageModelOptions> {
           role: Role.model,
           content: [TextPart(text: lastResponseText ?? '')],
         ),
-        usage: inputTokens != null
+        // inputTokens = tokens consumed so far (contextUsage).
+        // totalTokens = maximum context window size (contextWindow).
+        usage: contextUsage != null
             ? GenerationUsage(
-                inputTokens: inputTokens,
-                outputTokens: 0, // Not available directly
-                totalTokens: inputTokens,
+                inputTokens: contextUsage,
+                outputTokens: 0,
+                totalTokens: contextWindow ?? contextUsage,
               )
             : null,
       );
@@ -144,7 +154,7 @@ class ChromeModel extends Model<LanguageModelOptions> {
 Future<void> _ensureAvailability([LanguageModelOptions? options]) async {
   final availability =
       (await _languageModel.availability(options).toDart).toDart;
-  if (availability == 'no') {
+  if (availability == 'unavailable') {
     throw GenkitException(
       'Chrome AI is not available.',
       status: StatusCodes.UNAVAILABLE,

--- a/packages/genkit_chrome/lib/src/chrome_model.dart
+++ b/packages/genkit_chrome/lib/src/chrome_model.dart
@@ -34,7 +34,8 @@ class ChromeModel extends Model<LanguageModelOptions> {
          fn: (req, ctx) => _processRequest(req, ctx, options),
        );
 
-  /// Returns model params. Only available in Chrome extension contexts;
+  /// Returns model params. Only available in Chrome extension contexts or with
+  /// the Prompt API Sampling Parameters origin trial enabled;
   /// returns null on the open web.
   static Future<LanguageModelParams?> getParams() {
     return _languageModel.params().toDart;

--- a/packages/genkit_chrome/lib/src/chrome_model.dart
+++ b/packages/genkit_chrome/lib/src/chrome_model.dart
@@ -136,13 +136,14 @@ class ChromeModel extends Model<LanguageModelOptions> {
           role: Role.model,
           content: [TextPart(text: lastResponseText ?? '')],
         ),
-        // inputTokens = tokens consumed so far (contextUsage).
-        // totalTokens = maximum context window size (contextWindow).
         usage: contextUsage != null
             ? GenerationUsage(
                 inputTokens: contextUsage,
                 outputTokens: 0,
-                totalTokens: contextWindow ?? contextUsage,
+                totalTokens: contextUsage,
+                custom: contextWindow != null
+                    ? {'contextWindow': contextWindow}
+                    : null,
               )
             : null,
       );

--- a/testapps/chrome_example/web/index.html
+++ b/testapps/chrome_example/web/index.html
@@ -36,17 +36,51 @@
         }
         
         #header {
-            padding: 20px;
+            padding: 16px 20px;
             border-bottom: 1px solid var(--border-color);
             background: rgba(255, 255, 255, 0.9);
             backdrop-filter: blur(10px);
             z-index: 10;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
         }
-        
+
         h1 {
             margin: 0;
             font-size: 1.2rem;
             font-weight: 600;
+        }
+
+        #reset, #reset-settings {
+            height: 34px;
+            padding: 0 14px;
+            background: #f0f2f5;
+            color: #333;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            font-size: 0.82rem;
+            font-weight: 500;
+        }
+
+        #reset:hover:not(:disabled),
+        #reset-settings:hover:not(:disabled) {
+            background: #e4e6eb;
+        }
+
+        .settings-actions {
+            display: flex;
+            justify-content: flex-end;
+        }
+
+        .session-hint {
+            display: none;
+            background: #fff8e1;
+            border: 1px solid #ffe082;
+            border-radius: 6px;
+            padding: 8px 12px;
+            font-size: 0.82rem;
+            color: #7a5c00;
         }
 
         #chat-container {
@@ -167,9 +201,14 @@
             cursor: not-allowed;
             background-color: #ccc;
         }
-        
+
         button:hover:not(:disabled) {
             opacity: 0.9;
+        }
+
+        #stop {
+            background-color: #ff3b30;
+            display: none;
         }
 
         #settings-panel {
@@ -255,11 +294,89 @@
         input.invalid {
             border-color: red;
         }
+
+        #constraintInput {
+            font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+            font-size: 0.82rem;
+            margin-top: 4px;
+        }
+
+        #token-stats {
+            padding: 5px 20px 6px;
+            background: white;
+            border-top: 1px solid var(--border-color);
+            font-size: 0.75rem;
+            color: var(--gray);
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        #token-text {
+            white-space: nowrap;
+            flex-shrink: 0;
+        }
+
+        #token-track {
+            flex: 1;
+            height: 4px;
+            background: #e4e6eb;
+            border-radius: 2px;
+            overflow: hidden;
+        }
+
+        #token-fill {
+            height: 100%;
+            width: 0%;
+            background: var(--primary-color);
+            border-radius: 2px;
+            transition: width 0.4s ease, background-color 0.4s ease;
+        }
+
+        #token-fill.warn  { background: #f59e0b; }
+        #token-fill.danger { background: #ef4444; }
+
+        #download-progress {
+            display: none;
+            padding: 8px 20px 10px;
+            background: #eff6ff;
+            border-bottom: 1px solid #bfdbfe;
+            font-size: 0.8rem;
+            color: #1e40af;
+        }
+
+        #download-bar-track {
+            margin-top: 6px;
+            height: 5px;
+            background: #bfdbfe;
+            border-radius: 3px;
+            overflow: hidden;
+        }
+
+        #download-bar-fill {
+            height: 100%;
+            width: 0%;
+            background: #3b82f6;
+            border-radius: 3px;
+            transition: width 0.3s ease;
+        }
+
+        @keyframes indeterminate {
+            0%   { transform: translateX(-100%); }
+            100% { transform: translateX(400%); }
+        }
+
+        #download-bar-fill.indeterminate {
+            width: 25% !important;
+            animation: indeterminate 1.5s infinite ease-in-out;
+            transition: none;
+        }
     </style>
 </head>
 <body>
     <div id="header">
         <h1>Genkit Chrome Sample</h1>
+        <button id="reset">Reset session</button>
     </div>
     
     <div id="settings-panel">
@@ -308,16 +425,47 @@
                         <option value="ja">Japanese (ja)</option>
                     </select>
                 </div>
+                <div class="setting-group">
+                    <label for="constraintType">
+                        Response Constraint
+                        <span class="help-icon" title="Constrain the model output to a JSON Schema or a regular expression.">?</span>
+                    </label>
+                    <select id="constraintType">
+                        <option value="none">None</option>
+                        <option value="json">JSON Schema</option>
+                        <option value="regexp">Regular Expression</option>
+                    </select>
+                    <textarea id="constraintInput" rows="3" style="display:none"
+                        placeholder='{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}'></textarea>
+                    <div id="constraint-error" class="validation-error"></div>
+                </div>
+                <div id="session-hint" class="session-hint">
+                    System prompt and language settings take effect in a new session — press <strong>Reset session</strong> to apply.
+                </div>
                 <div id="validation-error" class="validation-error"></div>
+                <div class="settings-actions">
+                    <button id="reset-settings">Reset settings</button>
+                </div>
             </div>
         </details>
     </div>
     
+    <div id="download-progress">
+        <span id="download-text">Downloading model...</span>
+        <div id="download-bar-track"><div id="download-bar-fill"></div></div>
+    </div>
+
     <div id="chat-container"></div>
-    
+
+    <div id="token-stats">
+        <span id="token-text">Context: — tokens</span>
+        <div id="token-track"><div id="token-fill"></div></div>
+    </div>
+
     <div id="input-container">
         <textarea id="prompt" placeholder="waiting to load..." disabled></textarea>
         <button id="generate" disabled>Send</button>
+        <button id="stop">Stop</button>
     </div>
 </body>
 </html>

--- a/testapps/chrome_example/web/main.dart
+++ b/testapps/chrome_example/web/main.dart
@@ -321,7 +321,7 @@ JSAny? _buildConstraint() {
 
 void _updateTokenStats(GenerationUsage? usage) {
   final used = usage?.inputTokens?.toInt();
-  final max = usage?.totalTokens?.toInt();
+  final max = (usage?.custom?['contextWindow'] as num?)?.toInt();
   if (used == null) return;
 
   final text = max != null && max > 0

--- a/testapps/chrome_example/web/main.dart
+++ b/testapps/chrome_example/web/main.dart
@@ -31,7 +31,8 @@ extension type _JSRegExp._(JSObject _) implements JSObject {
 final _validationError =
     web.document.querySelector('#validation-error') as web.HTMLDivElement;
 
-// Model params — null when params() is unavailable (non-extension context).
+// Model params — null when params() is unavailable (requires an extension
+// context or the Prompt API Sampling Parameters origin trial).
 int? _defaultTopK;
 int? _maxTopK;
 double? _defaultTemperature;
@@ -40,8 +41,9 @@ double? _maxTemperature;
 void main() async {
   final ai = Genkit(plugins: [genkit_chrome.ChromeAIPlugin()]);
 
-  // params() is only available in Chrome extension contexts; it resolves to
-  // null on the open web. Be defensive: treat null as "params unavailable".
+  // params() is only available in extension contexts or with the Prompt API
+  // Sampling Parameters origin trial enabled; resolves to null otherwise.
+  // Be defensive: treat null as "params unavailable".
   try {
     final params = await genkit_chrome.ChromeModel.getParams();
     if (params != null) {
@@ -72,8 +74,8 @@ void main() async {
                 'Valid range: 0-$_maxTemperature. Default: $_defaultTemperature.',
           );
     } else {
-      // params() is unavailable (non-extension context) — disable the fields
-      // so users can't set values the browser would reject.
+      // params() is unavailable (no extension context or origin trial) —
+      // disable the fields so users can't set values the browser would reject.
       _topKInput.disabled = true;
       _topKInput.placeholder = 'unavailable';
       _temperatureInput.disabled = true;

--- a/testapps/chrome_example/web/main.dart
+++ b/testapps/chrome_example/web/main.dart
@@ -194,10 +194,8 @@ final _promptInput =
     web.document.querySelector('#prompt') as web.HTMLTextAreaElement;
 final _generateBtn =
     web.document.querySelector('#generate') as web.HTMLButtonElement;
-final _stopBtn =
-    web.document.querySelector('#stop') as web.HTMLButtonElement;
-final _resetBtn =
-    web.document.querySelector('#reset') as web.HTMLButtonElement;
+final _stopBtn = web.document.querySelector('#stop') as web.HTMLButtonElement;
+final _resetBtn = web.document.querySelector('#reset') as web.HTMLButtonElement;
 final _resetSettingsBtn =
     web.document.querySelector('#reset-settings') as web.HTMLButtonElement;
 final _sessionHint =
@@ -335,8 +333,8 @@ void _updateTokenStats(GenerationUsage? usage) {
     _tokenFill.className = pct >= 90
         ? 'danger'
         : pct >= 75
-            ? 'warn'
-            : '';
+        ? 'warn'
+        : '';
   }
 }
 
@@ -466,9 +464,7 @@ Future<void> _submit(Genkit ai) async {
       final constraintTypeValue = _constraintType.value;
       final constraintText = _constraintInput.value.trim();
       if (constraint != null) {
-        settingsList.add(
-          'Constraint ($constraintTypeValue): $constraintText',
-        );
+        settingsList.add('Constraint ($constraintTypeValue): $constraintText');
       }
 
       final contentDiv = _appendMessage(
@@ -501,7 +497,7 @@ Future<void> _submit(Genkit ai) async {
                 {'type': 'text', 'languages': outputLangs},
               ],
             'signal': _currentController!.signal,
-            if (constraint != null) 'responseConstraint': constraint,
+            'responseConstraint': ?constraint,
             'onDownloadProgress': _showDownloadProgress,
           },
           onChunk: (chunk) {

--- a/testapps/chrome_example/web/main.dart
+++ b/testapps/chrome_example/web/main.dart
@@ -18,10 +18,20 @@ import 'package:genkit_chrome/genkit_chrome.dart' as genkit_chrome;
 import 'package:markdown/markdown.dart';
 import 'package:web/web.dart' as web;
 
+// JSON.parse — used to convert a JSON Schema string into a JS object.
+@JS('JSON.parse')
+external JSAny _jsonParse(JSString json);
+
+// JS RegExp constructor — used to build a regex constraint.
+@JS('RegExp')
+extension type _JSRegExp._(JSObject _) implements JSObject {
+  external factory _JSRegExp(JSString pattern);
+}
+
 final _validationError =
     web.document.querySelector('#validation-error') as web.HTMLDivElement;
 
-// Model params
+// Model params — null when params() is unavailable (non-extension context).
 int? _defaultTopK;
 int? _maxTopK;
 double? _defaultTemperature;
@@ -30,41 +40,53 @@ double? _maxTemperature;
 void main() async {
   final ai = Genkit(plugins: [genkit_chrome.ChromeAIPlugin()]);
 
-  // Fetch model params if available
+  // params() is only available in Chrome extension contexts; it resolves to
+  // null on the open web. Be defensive: treat null as "params unavailable".
   try {
     final params = await genkit_chrome.ChromeModel.getParams();
-    _defaultTopK = params.defaultTopK;
-    _maxTopK = params.maxTopK;
-    _defaultTemperature = params.defaultTemperature.toDouble();
-    _maxTemperature = params.maxTemperature.toDouble();
+    if (params != null) {
+      _defaultTopK = params.defaultTopK;
+      _maxTopK = params.maxTopK;
+      _defaultTemperature = params.defaultTemperature.toDouble();
+      _maxTemperature = params.maxTemperature.toDouble();
 
-    _topKInput.placeholder = 'default: $_defaultTopK (1-$_maxTopK)';
-    _topKInput.max = '$_maxTopK';
+      _topKInput.placeholder = 'default: $_defaultTopK (1-$_maxTopK)';
+      _topKInput.max = '$_maxTopK';
 
-    _temperatureInput.placeholder =
-        'default: $_defaultTemperature (0.0-${_maxTemperature!.toStringAsFixed(1)})';
-    _temperatureInput.max = '$_maxTemperature';
+      _temperatureInput.placeholder =
+          'default: $_defaultTemperature (0.0-${_maxTemperature!.toStringAsFixed(1)})';
+      _temperatureInput.max = '$_maxTemperature';
 
-    // Update titles for help icons
-    web.document
-        .querySelector('label[for="topK"] .help-icon')
-        ?.setAttribute(
-          'title',
-          'Controls diversity. Lower values limit the token pool. '
-              'Valid range: 1-$_maxTopK. Default: $_defaultTopK.',
-        );
-    web.document
-        .querySelector('label[for="temperature"] .help-icon')
-        ?.setAttribute(
-          'title',
-          'Controls randomness. Lower values are more deterministic. '
-              'Valid range: 0-$_maxTemperature. Default: $_defaultTemperature.',
-        );
+      web.document
+          .querySelector('label[for="topK"] .help-icon')
+          ?.setAttribute(
+            'title',
+            'Controls diversity. Lower values limit the token pool. '
+                'Valid range: 1-$_maxTopK. Default: $_defaultTopK.',
+          );
+      web.document
+          .querySelector('label[for="temperature"] .help-icon')
+          ?.setAttribute(
+            'title',
+            'Controls randomness. Lower values are more deterministic. '
+                'Valid range: 0-$_maxTemperature. Default: $_defaultTemperature.',
+          );
+    } else {
+      // params() is unavailable (non-extension context) — disable the fields
+      // so users can't set values the browser would reject.
+      _topKInput.disabled = true;
+      _topKInput.placeholder = 'unavailable';
+      _temperatureInput.disabled = true;
+      _temperatureInput.placeholder = 'unavailable';
+    }
   } catch (e) {
     print('Error fetching model params: $e');
   }
 
   _generateBtn.onClick.listen((event) => _submit(ai));
+  _stopBtn.onClick.listen((_) => _currentController?.abort());
+  _resetBtn.onClick.listen((_) => _resetSession());
+  _resetSettingsBtn.onClick.listen((_) => _resetSettings());
 
   _promptInput.onKeyDown.listen((event) {
     if (event.key == 'Enter' && !event.shiftKey) {
@@ -76,6 +98,23 @@ void main() async {
   // Validation listeners
   _temperatureInput.onInput.listen((_) => _validateInputs());
   _topKInput.onInput.listen((_) => _validateInputs());
+
+  // Session-hint listeners: system prompt and language selectors affect the
+  // session and require a reset to take effect mid-conversation.
+  _systemPromptInput.onInput.listen((_) => _updateSessionHint());
+  _expectedInputLanguages.onChange.listen((_) => _updateSessionHint());
+  _expectedOutputLanguages.onChange.listen((_) => _updateSessionHint());
+
+  // Constraint listeners: show/hide textarea, update placeholder, validate.
+  _constraintType.onChange.listen((_) {
+    if (_constraintType.value != 'none') {
+      _constraintInput.placeholder = _constraintType.value == 'json'
+          ? '{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}'
+          : r'^[A-Za-z ]+$';
+    }
+    _validateConstraint();
+  });
+  _constraintInput.onInput.listen((_) => _validateConstraint());
 
   // Focus input on load
   _promptInput.disabled = false;
@@ -140,11 +179,12 @@ void _validateInputs() {
     _generateBtn.disabled = true;
   } else {
     _validationError.style.display = 'none';
-    _generateBtn.disabled = false;
+    _generateBtn.disabled = _constraintHasError;
   }
 }
 
 bool _running = false;
+web.AbortController? _currentController;
 
 final _outputDiv =
     web.document.querySelector('#chat-container') as web.HTMLDivElement;
@@ -152,6 +192,24 @@ final _promptInput =
     web.document.querySelector('#prompt') as web.HTMLTextAreaElement;
 final _generateBtn =
     web.document.querySelector('#generate') as web.HTMLButtonElement;
+final _stopBtn =
+    web.document.querySelector('#stop') as web.HTMLButtonElement;
+final _resetBtn =
+    web.document.querySelector('#reset') as web.HTMLButtonElement;
+final _resetSettingsBtn =
+    web.document.querySelector('#reset-settings') as web.HTMLButtonElement;
+final _sessionHint =
+    web.document.querySelector('#session-hint') as web.HTMLDivElement;
+final _tokenText =
+    web.document.querySelector('#token-text') as web.HTMLSpanElement;
+final _tokenFill =
+    web.document.querySelector('#token-fill') as web.HTMLDivElement;
+final _downloadProgress =
+    web.document.querySelector('#download-progress') as web.HTMLDivElement;
+final _downloadText =
+    web.document.querySelector('#download-text') as web.HTMLSpanElement;
+final _downloadFill =
+    web.document.querySelector('#download-bar-fill') as web.HTMLDivElement;
 
 final _systemPromptInput =
     web.document.querySelector('#systemPrompt') as web.HTMLTextAreaElement;
@@ -164,8 +222,185 @@ final _expectedInputLanguages =
 final _expectedOutputLanguages =
     web.document.querySelector('#expectedOutputLanguages')
         as web.HTMLSelectElement;
+final _constraintType =
+    web.document.querySelector('#constraintType') as web.HTMLSelectElement;
+final _constraintInput =
+    web.document.querySelector('#constraintInput') as web.HTMLTextAreaElement;
+final _constraintError =
+    web.document.querySelector('#constraint-error') as web.HTMLDivElement;
 
 final List<Message> _history = [];
+
+// Settings committed at the start of the current session (first message sent
+// or after a manual reset). Used to detect when a new session is needed.
+String _sessionSystemPrompt = '';
+List<String> _sessionInputLangs = [];
+List<String> _sessionOutputLangs = [];
+
+List<String> _parseSelectedLangs(web.HTMLSelectElement selectElement) {
+  final selected = <String>[];
+  final options = selectElement.selectedOptions;
+  for (var i = 0; i < options.length; i++) {
+    selected.add((options.item(i) as web.HTMLOptionElement).value);
+  }
+  return selected;
+}
+
+void _updateSessionHint() {
+  if (_history.isEmpty) {
+    _sessionHint.style.display = 'none';
+    return;
+  }
+  final changed =
+      _systemPromptInput.value.trim() != _sessionSystemPrompt ||
+      _parseSelectedLangs(_expectedInputLanguages).join(',') !=
+          _sessionInputLangs.join(',') ||
+      _parseSelectedLangs(_expectedOutputLanguages).join(',') !=
+          _sessionOutputLangs.join(',');
+  _sessionHint.style.display = changed ? 'block' : 'none';
+}
+
+bool _constraintHasError = false;
+
+void _validateConstraint() {
+  final type = _constraintType.value;
+
+  if (type == 'none') {
+    _constraintInput.style.display = 'none';
+    _constraintError.style.display = 'none';
+    _constraintInput.classList.remove('invalid');
+    _constraintHasError = false;
+    _validateInputs();
+    return;
+  }
+
+  _constraintInput.style.display = 'block';
+  final text = _constraintInput.value.trim();
+
+  if (text.isEmpty) {
+    _constraintError.style.display = 'none';
+    _constraintInput.classList.remove('invalid');
+    _constraintHasError = false;
+    _validateInputs();
+    return;
+  }
+
+  String? err;
+  try {
+    if (type == 'json') {
+      _jsonParse(text.toJS);
+    } else {
+      _JSRegExp(text.toJS);
+    }
+  } catch (_) {
+    err = type == 'json' ? 'Invalid JSON.' : 'Invalid regular expression.';
+  }
+
+  _constraintHasError = err != null;
+  if (err != null) {
+    _constraintError.innerText = err;
+    _constraintError.style.display = 'block';
+    _constraintInput.classList.add('invalid');
+  } else {
+    _constraintError.style.display = 'none';
+    _constraintInput.classList.remove('invalid');
+  }
+  _validateInputs();
+}
+
+JSAny? _buildConstraint() {
+  final type = _constraintType.value;
+  if (type == 'none') return null;
+  final text = _constraintInput.value.trim();
+  if (text.isEmpty) return null;
+  if (type == 'json') return _jsonParse(text.toJS);
+  return _JSRegExp(text.toJS);
+}
+
+void _updateTokenStats(GenerationUsage? usage) {
+  final used = usage?.inputTokens?.toInt();
+  final max = usage?.totalTokens?.toInt();
+  if (used == null) return;
+
+  final text = max != null && max > 0
+      ? 'Context: $used / $max tokens'
+      : 'Context: $used tokens';
+  _tokenText.innerText = text;
+
+  if (max != null && max > 0) {
+    final pct = (used / max * 100).clamp(0.0, 100.0);
+    _tokenFill.style.width = '$pct%';
+    _tokenFill.className = pct >= 90
+        ? 'danger'
+        : pct >= 75
+            ? 'warn'
+            : '';
+  }
+}
+
+void _resetTokenStats() {
+  _tokenText.innerText = 'Context: — tokens';
+  _tokenFill.style.width = '0%';
+  _tokenFill.className = '';
+}
+
+void _showDownloadProgress(int loaded, int total) {
+  _downloadProgress.style.display = 'block';
+  if (total > 0) {
+    final pct = (loaded / total * 100).clamp(0.0, 100.0);
+    _downloadText.innerText = 'Downloading model: ${pct.toStringAsFixed(0)}%';
+    _downloadFill.style.width = '${pct.toStringAsFixed(1)}%';
+    _downloadFill.classList.remove('indeterminate');
+  } else {
+    _downloadText.innerText = 'Downloading model...';
+    _downloadFill.style.width = '0%';
+    _downloadFill.classList.add('indeterminate');
+  }
+}
+
+void _hideDownloadProgress() {
+  _downloadProgress.style.display = 'none';
+  _downloadFill.style.width = '0%';
+  _downloadFill.classList.remove('indeterminate');
+}
+
+void _resetSettings() {
+  _systemPromptInput.value = '';
+
+  // Only clear if the fields are enabled (i.e. params() was available).
+  if (!_temperatureInput.disabled) _temperatureInput.value = '';
+  if (!_topKInput.disabled) _topKInput.value = '';
+
+  // Reset language selects to English only.
+  for (final select in [_expectedInputLanguages, _expectedOutputLanguages]) {
+    final options = select.options;
+    for (var i = 0; i < options.length; i++) {
+      final opt = options.item(i) as web.HTMLOptionElement;
+      opt.selected = opt.value == 'en';
+    }
+  }
+
+  // Reset response constraint.
+  _constraintType.value = 'none';
+  _constraintInput.value = '';
+  _constraintInput.style.display = 'none';
+  _constraintError.style.display = 'none';
+  _constraintInput.classList.remove('invalid');
+  _constraintHasError = false;
+
+  _validateInputs();
+  _updateSessionHint();
+}
+
+void _resetSession() {
+  _currentController?.abort();
+  _history.clear();
+  while (_outputDiv.firstChild != null) {
+    _outputDiv.removeChild(_outputDiv.firstChild!);
+  }
+  _sessionHint.style.display = 'none';
+  _resetTokenStats();
+}
 
 Future<void> _submit(Genkit ai) async {
   final prompt = _promptInput.value.trim();
@@ -177,9 +412,10 @@ Future<void> _submit(Genkit ai) async {
   if (_validationError.style.display == 'block') return;
 
   _running = true;
-  // Disable input while running
+  _currentController = web.AbortController();
   _promptInput.disabled = true;
   _generateBtn.disabled = true;
+  _stopBtn.style.display = 'block';
 
   try {
     _appendMessage('User', prompt);
@@ -195,33 +431,26 @@ Future<void> _submit(Genkit ai) async {
     final systemPrompt = _systemPromptInput.value.trim();
     final temperature = double.tryParse(_temperatureInput.value);
     final topK = int.tryParse(_topKInput.value);
-    List<String> parseSelectedLangs(web.HTMLSelectElement selectElement) {
-      final selected = <String>[];
-      final options = selectElement.selectedOptions;
-      for (var i = 0; i < options.length; i++) {
-        selected.add((options.item(i) as web.HTMLOptionElement).value);
-      }
-      return selected;
+    final inputLangs = _parseSelectedLangs(_expectedInputLanguages);
+    final outputLangs = _parseSelectedLangs(_expectedOutputLanguages);
+
+    // Commit session settings on the first message so we can detect drift.
+    if (_history.length == 1) {
+      _sessionSystemPrompt = systemPrompt;
+      _sessionInputLangs = inputLangs;
+      _sessionOutputLangs = outputLangs;
+      _sessionHint.style.display = 'none';
     }
-
-    final inputLangs = parseSelectedLangs(_expectedInputLanguages);
-    final outputLangs = parseSelectedLangs(_expectedOutputLanguages);
-
-    // Update system prompt in history if it changed or is new
-    // For simplicity in this sample, we'll just prepend it if it exists
-    // A more robust app might manage system prompt as a distinct state
 
     try {
       final settingsList = <String>[];
       if (systemPrompt.isNotEmpty) {
         settingsList.add('System Prompt: $systemPrompt');
       }
-      if (temperature != null &&
-          _defaultTemperature != null &&
-          temperature != _defaultTemperature) {
+      if (temperature != null) {
         settingsList.add('Temperature: $temperature');
       }
-      if (topK != null && _defaultTopK != null && topK != _defaultTopK) {
+      if (topK != null) {
         settingsList.add('Top K: $topK');
       }
       if (inputLangs.isNotEmpty) {
@@ -229,6 +458,15 @@ Future<void> _submit(Genkit ai) async {
       }
       if (outputLangs.isNotEmpty) {
         settingsList.add('Output Langs: ${outputLangs.join(", ")}');
+      }
+
+      final constraint = _buildConstraint();
+      final constraintTypeValue = _constraintType.value;
+      final constraintText = _constraintInput.value.trim();
+      if (constraint != null) {
+        settingsList.add(
+          'Constraint ($constraintTypeValue): $constraintText',
+        );
       }
 
       final contentDiv = _appendMessage(
@@ -245,7 +483,7 @@ Future<void> _submit(Genkit ai) async {
       _scrollToBottom();
 
       try {
-        await ai.generate(
+        final response = await ai.generate(
           model: modelRef('chrome/gemini-nano'),
           messages: _history,
           config: {
@@ -260,10 +498,14 @@ Future<void> _submit(Genkit ai) async {
               'expectedOutputs': [
                 {'type': 'text', 'languages': outputLangs},
               ],
+            'signal': _currentController!.signal,
+            if (constraint != null) 'responseConstraint': constraint,
+            'onDownloadProgress': _showDownloadProgress,
           },
           onChunk: (chunk) {
             if (buffer.isEmpty) {
               loadingSpan.remove(); // Remove loading indicator on first chunk
+              _hideDownloadProgress();
             }
             final text = chunk.text;
             buffer.write(text);
@@ -271,6 +513,7 @@ Future<void> _submit(Genkit ai) async {
             _scrollToBottom();
           },
         );
+        _updateTokenStats(response.usage);
         _history.add(
           Message(
             role: Role.model,
@@ -281,16 +524,22 @@ Future<void> _submit(Genkit ai) async {
         if (buffer.isEmpty) {
           loadingSpan.remove();
         }
+        _hideDownloadProgress();
         _scrollToBottom();
       }
     } catch (e, stack) {
-      _appendMessage('System', 'Error: $e\n$stack');
-      print('Error: $e\n$stack');
+      // Suppress errors caused by a user-initiated stop.
+      if (_currentController?.signal.aborted != true) {
+        _appendMessage('System', 'Error: $e\n$stack');
+        print('Error: $e\n$stack');
+      }
     }
   } finally {
     _running = false;
+    _currentController = null;
     _promptInput.disabled = false;
     _generateBtn.disabled = false;
+    _stopBtn.style.display = 'none';
   }
 }
 

--- a/testapps/chrome_example/web/main.dart
+++ b/testapps/chrome_example/web/main.dart
@@ -443,29 +443,19 @@ Future<void> _submit(Genkit ai) async {
     }
 
     try {
-      final settingsList = <String>[];
-      if (systemPrompt.isNotEmpty) {
-        settingsList.add('System Prompt: $systemPrompt');
-      }
-      if (temperature != null) {
-        settingsList.add('Temperature: $temperature');
-      }
-      if (topK != null) {
-        settingsList.add('Top K: $topK');
-      }
-      if (inputLangs.isNotEmpty) {
-        settingsList.add('Input Langs: ${inputLangs.join(", ")}');
-      }
-      if (outputLangs.isNotEmpty) {
-        settingsList.add('Output Langs: ${outputLangs.join(", ")}');
-      }
-
       final constraint = _buildConstraint();
       final constraintTypeValue = _constraintType.value;
       final constraintText = _constraintInput.value.trim();
-      if (constraint != null) {
-        settingsList.add('Constraint ($constraintTypeValue): $constraintText');
-      }
+
+      final settingsList = <String>[
+        if (systemPrompt.isNotEmpty) 'System Prompt: $systemPrompt',
+        if (temperature != null) 'Temperature: $temperature',
+        if (topK != null) 'Top K: $topK',
+        if (inputLangs.isNotEmpty) 'Input Langs: ${inputLangs.join(", ")}',
+        if (outputLangs.isNotEmpty) 'Output Langs: ${outputLangs.join(", ")}',
+        if (constraint != null)
+          'Constraint ($constraintTypeValue): $constraintText',
+      ];
 
       final contentDiv = _appendMessage(
         'Model',

--- a/testapps/firebase_ai/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/testapps/firebase_ai/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,7 @@ import record_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FirebaseAIPlugin.register(with: registry.registrar(forPlugin: "FirebaseAIPlugin"))
-  FLTFirebaseAppCheckPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAppCheckPlugin"))
+  FirebaseAppCheckPlugin.register(with: registry.registrar(forPlugin: "FirebaseAppCheckPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))


### PR DESCRIPTION
**`packages/genkit_chrome` — API updates**

- Updated `LanguageModelOptions` factory to convert `systemPrompt` into the first `initialPrompts` entry (as required by the current Prompt API; the top-level `systemPrompt` option no longer exists)
- Changed `params()` return type to `JSPromise<LanguageModelParams?>` — it resolves to `null` on the open web and is only available in extension contexts or with the Prompt API Sampling Parameters origin trial enabled.
- Replaced deprecated session members (`inputUsage`, `inputQuota`, `tokensSoFar`, `maxTokens`) with `contextUsage` / `contextWindow`
- Fixed availability check string from `'no'` to `'unavailable'`
- Added `LanguageModelPromptOptions` with `signal` (AbortSignal) and `responseConstraint` (JSON Schema object or JS RegExp) fields
- Added `onDownloadProgress` callback to `LanguageModelOptions`, wired as the JS `monitor` function that fires `downloadprogress` events during model download
- Threaded `signal`, `responseConstraint`, and `onDownloadProgress` through the config map in `chrome_model.dart`
- Token usage now reports `contextUsage` as `inputTokens` and `contextWindow` as `totalTokens`

**`testapps/chrome_example` — demo app**

- Added **Stop button** — uses `AbortController` to abort a streaming response mid-flight
- Added **Reset session button** — clears history and token stats; shows an amber hint when system prompt or language settings have drifted from their committed values
- Added **token stats bar** — live context usage meter with colour thresholds at 75% (amber) and 90% (red)
- Added **response constraint setting** — choose between JSON Schema or RegExp; textarea validates input inline before enabling Send
- Added **Reset settings button** — restores all settings fields to defaults
- Added **model download progress bar** — shown during `LanguageModel.create()` with percentage when size is known, indeterminate animation otherwise; auto-hides on first chunk
- Disabled temperature and topK inputs (with placeholder "unavailable") when `params()` returns null (non-extension context or not having the Prompt API Sampling Parameters origin trial enabled)

**`packages/genkit_chrome/README.md`**

- Rewrote to cover all supported features: streaming, multi-turn conversations, system prompt, aborting, response constraints, expected languages, download progress, token usage, and model parameters
- Added prerequisites note that the API is expected to ship in Chrome 148 and documented the origin trial option
- Clarified that `temperature`/`topK`/`params()` require a separate origin trial