### PR TITLE
feat(vertexai): tuned models (endpoints/YOUR_ENDPOINT_ID)

### DIFF
--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -40,9 +40,16 @@ final commonModelInfo = ModelInfo(
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
 
-  Model createModel(String modelName, SchemanticType customOptions) {
+  Model createModel(
+    String modelName,
+    SchemanticType customOptions, {
+    String? actionName,
+    String? apiModelName,
+    Future<GenerativeLanguageBaseClient> Function(String? apiKey)?
+    getApiClientOverride,
+  }) {
     return Model(
-      name: '$name/$modelName',
+      name: '$name/${actionName ?? modelName}',
       customOptions: customOptions,
       metadata: {'model': commonModelInfo.toJson()},
       fn: (req, ctx) async {
@@ -92,7 +99,9 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         }
 
-        final service = await getApiClient(apiKey);
+        final service =
+            await (getApiClientOverride?.call(apiKey) ?? getApiClient(apiKey));
+        final resolvedApiModelName = apiModelName ?? 'models/$modelName';
 
         try {
           final systemMessage = req.messages
@@ -121,7 +130,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           if (ctx.streamingRequested) {
             final stream = service.streamGenerateContent(
               generateRequest,
-              model: 'models/$modelName',
+              model: resolvedApiModelName,
             );
             final chunks = <gcl.GenerateContentResponse>[];
             await for (final chunk in stream) {
@@ -154,7 +163,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           } else {
             final response = await service.generateContent(
               generateRequest,
-              model: 'models/$modelName',
+              model: resolvedApiModelName,
             );
             if (response.candidates?.isEmpty ?? true) {
               final blockReason = response.promptFeedback?.blockReason;

--- a/packages/genkit_vertexai/lib/genkit_vertexai.dart
+++ b/packages/genkit_vertexai/lib/genkit_vertexai.dart
@@ -53,6 +53,13 @@ class VertexAiPluginHandle {
     return modelRef('vertexai/$name', customOptions: GeminiOptions.$schema);
   }
 
+  ModelRef<GeminiOptions> tunedModel(String endpointId) {
+    final name = endpointId.startsWith('endpoints/')
+        ? endpointId
+        : 'endpoints/$endpointId';
+    return modelRef('vertexai/$name', customOptions: GeminiOptions.$schema);
+  }
+
   EmbedderRef<TextEmbedderOptions> textEmbedding(String name) {
     return embedderRef(
       'vertexai/$name',

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -40,6 +40,39 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   @override
   String get name => 'vertexai';
 
+  Future<GenerativeLanguageBaseClient> _createVertexApiClient({
+    required String apiUrlPrefix,
+  }) async {
+    final validFormat = RegExp(r'^[a-z0-9-]+$');
+    final resolvedProjectId = _getResolvedProjectId;
+    final resolvedLocation = location ?? 'global';
+
+    if (!validFormat.hasMatch(resolvedLocation) ||
+        !validFormat.hasMatch(resolvedProjectId)) {
+      throw ArgumentError('Invalid projectId or location format.');
+    }
+    final safeLocation = Uri.encodeComponent(resolvedLocation);
+
+    final tokenProvider = createAdcAccessTokenProvider(baseClient: authClient);
+
+    final baseUrl = safeLocation == 'global'
+        ? 'https://aiplatform.googleapis.com/'
+        : 'https://$safeLocation-aiplatform.googleapis.com/';
+
+    final headers = {'X-Goog-Api-Client': googleApiClientHeaderValue()};
+    final customClient = CustomClient(
+      defaultHeaders: headers,
+      inner: authClient,
+    );
+    final client = VertexAuthClient(tokenProvider, inner: customClient);
+
+    return GenerativeLanguageBaseClient(
+      baseUrl: baseUrl,
+      client: client,
+      apiUrlPrefix: apiUrlPrefix,
+    );
+  }
+
   @override
   Future<GenerativeLanguageBaseClient> getApiClient([
     String? requestApiKey,
@@ -55,25 +88,26 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
     final safeLocation = Uri.encodeComponent(resolvedLocation);
     final safeProjectId = Uri.encodeComponent(resolvedProjectId);
 
-    final tokenProvider = createAdcAccessTokenProvider(baseClient: authClient);
-
-    final baseUrl = safeLocation == 'global'
-        ? 'https://aiplatform.googleapis.com/'
-        : 'https://$safeLocation-aiplatform.googleapis.com/';
-    final apiUrlPrefix =
-        'v1beta1/projects/$safeProjectId/locations/$safeLocation/publishers/google/';
-
-    final headers = {'X-Goog-Api-Client': googleApiClientHeaderValue()};
-    final customClient = CustomClient(
-      defaultHeaders: headers,
-      inner: authClient,
+    return _createVertexApiClient(
+      apiUrlPrefix:
+          'v1beta1/projects/$safeProjectId/locations/$safeLocation/publishers/google/',
     );
-    final client = VertexAuthClient(tokenProvider, inner: customClient);
+  }
 
-    return GenerativeLanguageBaseClient(
-      baseUrl: baseUrl,
-      client: client,
-      apiUrlPrefix: apiUrlPrefix,
+  Future<GenerativeLanguageBaseClient> getEndpointApiClient() async {
+    final validFormat = RegExp(r'^[a-z0-9-]+$');
+    final resolvedProjectId = _getResolvedProjectId;
+    final resolvedLocation = location ?? 'global';
+
+    if (!validFormat.hasMatch(resolvedLocation) ||
+        !validFormat.hasMatch(resolvedProjectId)) {
+      throw ArgumentError('Invalid projectId or location format.');
+    }
+    final safeLocation = Uri.encodeComponent(resolvedLocation);
+    final safeProjectId = Uri.encodeComponent(resolvedProjectId);
+
+    return _createVertexApiClient(
+      apiUrlPrefix: 'v1/projects/$safeProjectId/locations/$safeLocation/',
     );
   }
 
@@ -189,5 +223,27 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
         }
       },
     );
+  }
+
+  Model createTunedModel(String endpointName) {
+    final endpointId = endpointName.startsWith('endpoints/')
+        ? endpointName.substring('endpoints/'.length)
+        : endpointName;
+    final safeEndpointId = Uri.encodeComponent(endpointId);
+    return createModel(
+      endpointId,
+      GeminiOptions.$schema,
+      actionName: 'endpoints/$endpointId',
+      apiModelName: 'endpoints/$safeEndpointId',
+      getApiClientOverride: (_) => getEndpointApiClient(),
+    );
+  }
+
+  @override
+  Action? resolve(String actionType, String name) {
+    if (actionType == 'model' && name.startsWith('endpoints/')) {
+      return createTunedModel(name);
+    }
+    return super.resolve(actionType, name);
   }
 }

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 
 import 'package:genkit/genkit.dart';
+import 'package:genkit_vertexai/genkit_vertexai.dart';
 
 import 'package:genkit_vertexai/src/vertex_api_client.dart';
 import 'package:http/http.dart' as http;
@@ -103,6 +104,44 @@ void main() {
       expect(
         mockClient.lastUrl.toString(),
         'https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-1.5-pro:generateContent',
+      );
+    });
+
+    test('uses tuned model endpoint path', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: mockClient,
+      );
+
+      final model = plugin.resolve('model', 'endpoints/123456789') as Action;
+      final req = ModelRequest(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+      );
+
+      await model.run(req);
+
+      expect(mockClient.lastUrl, isNotNull);
+      expect(
+        mockClient.lastUrl.toString(),
+        'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/endpoints/123456789:generateContent',
+      );
+    });
+
+    test('creates tuned model refs under endpoints path', () {
+      expect(
+        vertexAI.tunedModel('123456789').name,
+        'vertexai/endpoints/123456789',
+      );
+      expect(
+        vertexAI.tunedModel('endpoints/123456789').name,
+        'vertexai/endpoints/123456789',
       );
     });
   });


### PR DESCRIPTION
This pull request adds support for Vertex AI tuned models (custom endpoints) in the `genkit_vertexai` package, allowing users to call models deployed to Vertex AI endpoints. It introduces new methods for creating and resolving tuned model actions, refactors API client creation for flexibility, and includes tests to validate the new functionality.