### PR TITLE
feat(googleai): support Imagen models

### DIFF
--- a/packages/genkit_google_genai/lib/common.dart
+++ b/packages/genkit_google_genai/lib/common.dart
@@ -17,4 +17,5 @@ library;
 
 export 'src/api_client.dart';
 export 'src/common_plugin.dart';
+export 'src/imagen.dart';
 export 'src/model.dart';

--- a/packages/genkit_google_genai/lib/genkit_google_genai.dart
+++ b/packages/genkit_google_genai/lib/genkit_google_genai.dart
@@ -15,8 +15,10 @@
 import 'package:genkit/plugin.dart';
 
 import 'src/google_api_client.dart';
+import 'src/imagen.dart';
 import 'src/model.dart';
 
+export 'src/imagen.dart';
 export 'src/model.dart';
 
 const GoogleGenAiPluginHandle googleAI = GoogleGenAiPluginHandle();
@@ -30,6 +32,10 @@ class GoogleGenAiPluginHandle {
 
   ModelRef<GeminiOptions> gemini(String name) {
     return modelRef('googleai/$name', customOptions: GeminiOptions.$schema);
+  }
+
+  ModelRef<ImagenOptions> imagen(String name) {
+    return modelRef('googleai/$name', customOptions: ImagenOptions.$schema);
   }
 
   EmbedderRef<TextEmbedderOptions> textEmbedding(String name) {

--- a/packages/genkit_google_genai/lib/src/api_client.dart
+++ b/packages/genkit_google_genai/lib/src/api_client.dart
@@ -62,12 +62,13 @@ class GenerativeLanguageBaseClient {
 
   Future<Map<String, dynamic>> listPublisherModels({
     required String projectId,
+    String publisher = 'google',
   }) async {
     // Vertex AI endpoint for publisher models uses v1beta1 and does not have the 'projects/...' in the path
     // when using this specific endpoint, but it requires the google user project header (or just works with ADC).
     // The base URL for this is https://{location}-aiplatform.googleapis.com
-    // And path is /v1beta1/publishers/google/models
-    final url = 'v1beta1/publishers/google/models';
+    // And path is /v1beta1/publishers/{publisher}/models
+    final url = 'v1beta1/publishers/$publisher/models';
     return await _call('GET', url, null, {'x-goog-user-project': projectId});
   }
 

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -18,6 +18,7 @@ import 'package:meta/meta.dart';
 import 'api_client.dart';
 import 'common_plugin.dart';
 import 'generated/generativelanguage.dart' as gcl;
+import 'imagen.dart';
 import 'model.dart';
 
 @visibleForTesting
@@ -53,17 +54,23 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
       }
       final models = (modelsResponse.models ?? [])
           .where((model) {
-            return model.name != null &&
-                model.name!.startsWith('models/gemini-');
+            final modelName = model.name;
+            return modelName != null &&
+                (modelName.startsWith('models/gemini-') ||
+                    modelName.startsWith('models/imagen-'));
           })
           .map((model) {
-            final isTts = model.name!.contains('-tts');
+            final modelName = model.name!.split('/').last;
+            final isImagen = isImagenModelName(modelName);
+            final isTts = modelName.contains('-tts');
             return modelMetadata(
-              '$name/${model.name!.split('/').last}',
-              customOptions: isTts
+              '$name/$modelName',
+              customOptions: isImagen
+                  ? ImagenOptions.$schema
+                  : isTts
                   ? GeminiTtsOptions.$schema
                   : GeminiOptions.$schema,
-              modelInfo: commonModelInfo,
+              modelInfo: isImagen ? imagenModelInfo : commonModelInfo,
             );
           })
           .toList();
@@ -149,5 +156,13 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
         }
       },
     );
+  }
+
+  @override
+  Action? resolve(String actionType, String name) {
+    if (actionType == 'model' && isImagenModelName(name)) {
+      return createImagenModel(this, name);
+    }
+    return super.resolve(actionType, name);
   }
 }

--- a/packages/genkit_google_genai/lib/src/imagen.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.dart
@@ -1,0 +1,197 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+import 'package:meta/meta.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'common_plugin.dart';
+
+part 'imagen.g.dart';
+
+@Schema(additionalProperties: true)
+abstract class $ImagenOptions {
+  String? get apiKey;
+
+  @IntegerField(
+    minimum: 1,
+    maximum: 4,
+    description:
+        'The number of images to generate, from 1 to 4 inclusive. '
+        'Defaults to 1.',
+  )
+  int? get numberOfImages;
+
+  @StringField(
+    enumValues: ['1:1', '9:16', '16:9', '3:4', '4:3'],
+    description: 'Desired aspect ratio of the output image.',
+  )
+  String? get aspectRatio;
+
+  @StringField(
+    enumValues: ['dont_allow', 'allow_adult', 'allow_all'],
+    description: 'Control if and how images of people are generated.',
+  )
+  String? get personGeneration;
+}
+
+final imagenModelInfo = ModelInfo(
+  supports: {
+    'media': true,
+    'multiturn': false,
+    'tools': false,
+    'toolChoice': false,
+    'systemRole': false,
+    'output': ['media'],
+  },
+);
+
+Model<ImagenOptions> createImagenModel(
+  CommonGoogleGenPlugin plugin,
+  String modelName,
+) {
+  return Model(
+    name: '${plugin.name}/$modelName',
+    customOptions: ImagenOptions.$schema,
+    metadata: {'model': imagenModelInfo.toJson()},
+    fn: (req, ctx) async {
+      if (ctx.streamingRequested) {
+        throw GenkitException(
+          'Streaming is not supported for Imagen models.',
+          status: StatusCodes.INVALID_ARGUMENT,
+        );
+      }
+      if (req == null) {
+        throw GenkitException(
+          'Imagen requires a generation request.',
+          status: StatusCodes.INVALID_ARGUMENT,
+        );
+      }
+      if (req.tools?.isNotEmpty ?? false) {
+        throw GenkitException(
+          'Tools are not supported for Imagen models.',
+          status: StatusCodes.INVALID_ARGUMENT,
+        );
+      }
+
+      final options = req.config == null
+          ? ImagenOptions()
+          : ImagenOptions.$schema.parse(req.config!);
+      final service = await plugin.getApiClient(options.apiKey);
+
+      try {
+        final prompt = extractImagenPrompt(req);
+        if (prompt.isEmpty) {
+          throw GenkitException(
+            'Imagen requires a non-empty text prompt.',
+            status: StatusCodes.INVALID_ARGUMENT,
+          );
+        }
+        final image = extractImagenImage(req);
+
+        final response = await service.predict({
+          'instances': [
+            {'prompt': prompt, if (image != null) 'image': image},
+          ],
+          'parameters': toImagenParameters(options),
+        }, model: 'models/$modelName');
+        final predictions = response['predictions'] as List?;
+        if (predictions == null || predictions.isEmpty) {
+          throw GenkitException(
+            'Model returned no predictions. Possibly due to content filters.',
+            status: StatusCodes.FAILED_PRECONDITION,
+          );
+        }
+
+        return ModelResponse(
+          finishReason: FinishReason.stop,
+          message: Message(
+            role: Role.model,
+            content: predictions.map(fromImagenPrediction).toList(),
+          ),
+          raw: response,
+        );
+      } catch (e, stack) {
+        throw plugin.handleException(e, stack);
+      } finally {
+        service.client.close();
+      }
+    },
+  );
+}
+
+@visibleForTesting
+String extractImagenPrompt(ModelRequest request) {
+  final buffer = StringBuffer();
+  for (final message in request.messages) {
+    if (message.role != Role.user) continue;
+    for (final part in message.content) {
+      if (part.isText) {
+        buffer.write(part.text);
+      }
+    }
+  }
+  return buffer.toString();
+}
+
+@visibleForTesting
+Map<String, dynamic>? extractImagenImage(ModelRequest request) {
+  for (final message in request.messages.reversed) {
+    for (final part in message.content) {
+      final media = part.media;
+      if (media == null) continue;
+      final isImage =
+          media.contentType?.startsWith('image/') ??
+          media.url.startsWith('data:image/');
+      if (!isImage) continue;
+
+      final dataUrlParts = media.url.split(',');
+      if (dataUrlParts.length < 2 || dataUrlParts.last.isEmpty) {
+        return null;
+      }
+      return {'bytesBase64Encoded': dataUrlParts.last};
+    }
+  }
+  return null;
+}
+
+@visibleForTesting
+Map<String, dynamic> toImagenParameters(ImagenOptions options) {
+  final params = <String, dynamic>{
+    'sampleCount': options.numberOfImages ?? 1,
+    ...options.toJson(),
+  };
+  params.remove('apiKey');
+  params.remove('numberOfImages');
+  params.removeWhere((_, value) => value == null);
+  return params;
+}
+
+@visibleForTesting
+MediaPart fromImagenPrediction(Object? prediction) {
+  final predictionMap = prediction as Map<String, dynamic>;
+  final b64Data = predictionMap['bytesBase64Encoded'] as String?;
+  final mimeType = predictionMap['mimeType'] as String? ?? 'image/png';
+  if (b64Data == null || b64Data.isEmpty) {
+    throw GenkitException(
+      'Imagen prediction did not include image bytes.',
+      status: StatusCodes.INTERNAL,
+    );
+  }
+  return MediaPart(
+    media: Media(url: 'data:$mimeType;base64,$b64Data', contentType: mimeType),
+  );
+}
+
+bool isImagenModelName(String name) => name.startsWith('imagen-');

--- a/packages/genkit_google_genai/lib/src/imagen.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.dart
@@ -34,6 +34,14 @@ abstract class $ImagenOptions {
   int? get numberOfImages;
 
   @StringField(
+    enumValues: ['1K', '2K'],
+    description:
+        'The size of the generated image. Supported by Standard and Ultra '
+        'models.',
+  )
+  String? get imageSize;
+
+  @StringField(
     enumValues: ['1:1', '9:16', '16:9', '3:4', '4:3'],
     description: 'Desired aspect ratio of the output image.',
   )
@@ -98,11 +106,10 @@ Model<ImagenOptions> createImagenModel(
             status: StatusCodes.INVALID_ARGUMENT,
           );
         }
-        final image = extractImagenImage(req);
 
         final response = await service.predict({
           'instances': [
-            {'prompt': prompt, if (image != null) 'image': image},
+            {'prompt': prompt},
           ],
           'parameters': toImagenParameters(options),
         }, model: 'models/$modelName');
@@ -138,32 +145,12 @@ String extractImagenPrompt(ModelRequest request) {
     if (message.role != Role.user) continue;
     for (final part in message.content) {
       if (part.isText) {
+        if (buffer.isNotEmpty) buffer.write(' ');
         buffer.write(part.text);
       }
     }
   }
   return buffer.toString();
-}
-
-@visibleForTesting
-Map<String, dynamic>? extractImagenImage(ModelRequest request) {
-  for (final message in request.messages.reversed) {
-    for (final part in message.content) {
-      final media = part.media;
-      if (media == null) continue;
-      final isImage =
-          media.contentType?.startsWith('image/') ??
-          media.url.startsWith('data:image/');
-      if (!isImage) continue;
-
-      final dataUrlParts = media.url.split(',');
-      if (dataUrlParts.length < 2 || dataUrlParts.last.isEmpty) {
-        return null;
-      }
-      return {'bytesBase64Encoded': dataUrlParts.last};
-    }
-  }
-  return null;
 }
 
 @visibleForTesting
@@ -180,7 +167,13 @@ Map<String, dynamic> toImagenParameters(ImagenOptions options) {
 
 @visibleForTesting
 MediaPart fromImagenPrediction(Object? prediction) {
-  final predictionMap = prediction as Map<String, dynamic>;
+  if (prediction is! Map<String, dynamic>) {
+    throw GenkitException(
+      'Imagen prediction did not include a valid image map.',
+      status: StatusCodes.INTERNAL,
+    );
+  }
+  final predictionMap = prediction;
   final b64Data = predictionMap['bytesBase64Encoded'] as String?;
   final mimeType = predictionMap['mimeType'] as String? ?? 'image/png';
   if (b64Data == null || b64Data.isEmpty) {

--- a/packages/genkit_google_genai/lib/src/imagen.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.dart
@@ -140,17 +140,19 @@ Model<ImagenOptions> createImagenModel(
 
 @visibleForTesting
 String extractImagenPrompt(ModelRequest request) {
-  final buffer = StringBuffer();
+  final segments = <String>[];
   for (final message in request.messages) {
     if (message.role != Role.user) continue;
     for (final part in message.content) {
       if (part.isText) {
-        if (buffer.isNotEmpty) buffer.write(' ');
-        buffer.write(part.text);
+        final text = part.text?.trim();
+        if (text?.isNotEmpty ?? false) {
+          segments.add(text!);
+        }
       }
     }
   }
-  return buffer.toString();
+  return segments.join(' ');
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/lib/src/imagen.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.dart
@@ -22,7 +22,15 @@ part 'imagen.g.dart';
 
 @Schema(additionalProperties: true)
 abstract class $ImagenOptions {
-  String? get apiKey;
+  @StringField(
+    description: 'Cloud Storage URI used to store the generated images.',
+  )
+  String? get outputGcsUri;
+
+  @StringField(
+    description: 'Description of what to discourage in the generated images.',
+  )
+  String? get negativePrompt;
 
   @IntegerField(
     minimum: 1,
@@ -47,11 +55,77 @@ abstract class $ImagenOptions {
   )
   String? get aspectRatio;
 
+  @DoubleField(
+    description:
+        'Controls how much the model adheres to the text prompt. Large values '
+        'increase output and prompt alignment, but may compromise image '
+        'quality.',
+  )
+  double? get guidanceScale;
+
+  @IntegerField(
+    description:
+        'Random seed for image generation. This is not available when '
+        'addWatermark is set to true.',
+  )
+  int? get seed;
+
+  @StringField(
+    enumValues: [
+      'BLOCK_LOW_AND_ABOVE',
+      'BLOCK_MEDIUM_AND_ABOVE',
+      'BLOCK_ONLY_HIGH',
+      'BLOCK_NONE',
+    ],
+    description: 'Filter level for safety filtering.',
+  )
+  String? get safetyFilterLevel;
+
   @StringField(
     enumValues: ['dont_allow', 'allow_adult', 'allow_all'],
     description: 'Control if and how images of people are generated.',
   )
   String? get personGeneration;
+
+  @Field(
+    description:
+        'Whether to report safety scores of each generated image and the '
+        'positive prompt in the response.',
+  )
+  bool? get includeSafetyAttributes;
+
+  @Field(
+    description:
+        'Whether to include the Responsible AI filter reason if the image is '
+        'filtered out of the response.',
+  )
+  bool? get includeRaiReason;
+
+  @StringField(
+    enumValues: ['auto', 'en', 'ja', 'ko', 'hi', 'zh', 'pt', 'es'],
+    description: 'Language of the text in the prompt.',
+  )
+  String? get language;
+
+  @StringField(description: 'MIME type of the generated image.')
+  String? get outputMimeType;
+
+  @IntegerField(
+    minimum: 0,
+    maximum: 100,
+    description:
+        'Compression quality of the generated image, for image/jpeg only.',
+  )
+  int? get outputCompressionQuality;
+
+  @Field(description: 'Whether to add a watermark to the generated images.')
+  bool? get addWatermark;
+
+  @Field(description: 'User specified labels to track billing usage.')
+  Map<String, String>? get labels;
+
+  @Field(description: 'Whether to use prompt rewriting logic.')
+  bool? get enhancePrompt;
 }
 
 final imagenModelInfo = ModelInfo(
@@ -96,7 +170,7 @@ Model<ImagenOptions> createImagenModel(
       final options = req.config == null
           ? ImagenOptions()
           : ImagenOptions.$schema.parse(req.config!);
-      final service = await plugin.getApiClient(options.apiKey);
+      final service = await plugin.getApiClient();
 
       try {
         final prompt = extractImagenPrompt(req);
@@ -161,7 +235,6 @@ Map<String, dynamic> toImagenParameters(ImagenOptions options) {
     'sampleCount': options.numberOfImages ?? 1,
     ...options.toJson(),
   };
-  params.remove('apiKey');
   params.remove('numberOfImages');
   params.removeWhere((_, value) => value == null);
   return params;

--- a/packages/genkit_google_genai/lib/src/imagen.g.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.g.dart
@@ -22,6 +22,7 @@ part of 'imagen.dart';
 // **************************************************************************
 
 base class ImagenOptions {
+  /// Creates a [ImagenOptions] from a JSON map.
   factory ImagenOptions.fromJson(Map<String, dynamic> json) =>
       $schema.parse(json);
 
@@ -45,6 +46,7 @@ base class ImagenOptions {
 
   late final Map<String, dynamic> _json;
 
+  /// The JSON schema and type descriptor for [ImagenOptions].
   static const SchemanticType<ImagenOptions> $schema =
       _ImagenOptionsTypeFactory();
 
@@ -113,6 +115,7 @@ base class ImagenOptions {
     return _json.toString();
   }
 
+  /// Serializes this [ImagenOptions] to a JSON map.
   Map<String, dynamic> toJson() {
     return _json;
   }

--- a/packages/genkit_google_genai/lib/src/imagen.g.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.g.dart
@@ -1,0 +1,141 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+part of 'imagen.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+base class ImagenOptions {
+  factory ImagenOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  ImagenOptions._(this._json);
+
+  ImagenOptions({
+    String? apiKey,
+    int? numberOfImages,
+    String? aspectRatio,
+    String? personGeneration,
+  }) {
+    _json = {
+      'apiKey': ?apiKey,
+      'numberOfImages': ?numberOfImages,
+      'aspectRatio': ?aspectRatio,
+      'personGeneration': ?personGeneration,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static const SchemanticType<ImagenOptions> $schema =
+      _ImagenOptionsTypeFactory();
+
+  String? get apiKey {
+    return _json['apiKey'] as String?;
+  }
+
+  set apiKey(String? value) {
+    if (value == null) {
+      _json.remove('apiKey');
+    } else {
+      _json['apiKey'] = value;
+    }
+  }
+
+  int? get numberOfImages {
+    return _json['numberOfImages'] as int?;
+  }
+
+  set numberOfImages(int? value) {
+    if (value == null) {
+      _json.remove('numberOfImages');
+    } else {
+      _json['numberOfImages'] = value;
+    }
+  }
+
+  String? get aspectRatio {
+    return _json['aspectRatio'] as String?;
+  }
+
+  set aspectRatio(String? value) {
+    if (value == null) {
+      _json.remove('aspectRatio');
+    } else {
+      _json['aspectRatio'] = value;
+    }
+  }
+
+  String? get personGeneration {
+    return _json['personGeneration'] as String?;
+  }
+
+  set personGeneration(String? value) {
+    if (value == null) {
+      _json.remove('personGeneration');
+    } else {
+      _json['personGeneration'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _ImagenOptionsTypeFactory extends SchemanticType<ImagenOptions> {
+  const _ImagenOptionsTypeFactory();
+
+  @override
+  ImagenOptions parse(Object? json) {
+    return ImagenOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'ImagenOptions',
+    definition: $Schema.fromMap({
+      'type': 'object',
+      'properties': {
+        'apiKey': $Schema.string(),
+        'numberOfImages': $Schema.integer(
+          description:
+              'The number of images to generate, from 1 to 4 inclusive. Defaults to 1.',
+          minimum: 1,
+          maximum: 4,
+        ),
+        'aspectRatio': $Schema.string(
+          description: 'Desired aspect ratio of the output image.',
+          enumValues: ['1:1', '9:16', '16:9', '3:4', '4:3'],
+        ),
+        'personGeneration': $Schema.string(
+          description: 'Control if and how images of people are generated.',
+          enumValues: ['dont_allow', 'allow_adult', 'allow_all'],
+        ),
+      },
+      'additionalProperties': true,
+    }).value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_google_genai/lib/src/imagen.g.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.g.dart
@@ -29,18 +29,42 @@ base class ImagenOptions {
   ImagenOptions._(this._json);
 
   ImagenOptions({
-    String? apiKey,
+    String? outputGcsUri,
+    String? negativePrompt,
     int? numberOfImages,
     String? imageSize,
     String? aspectRatio,
+    double? guidanceScale,
+    int? seed,
+    String? safetyFilterLevel,
     String? personGeneration,
+    bool? includeSafetyAttributes,
+    bool? includeRaiReason,
+    String? language,
+    String? outputMimeType,
+    int? outputCompressionQuality,
+    bool? addWatermark,
+    Map<String, String>? labels,
+    bool? enhancePrompt,
   }) {
     _json = {
-      'apiKey': ?apiKey,
+      'outputGcsUri': ?outputGcsUri,
+      'negativePrompt': ?negativePrompt,
       'numberOfImages': ?numberOfImages,
       'imageSize': ?imageSize,
       'aspectRatio': ?aspectRatio,
+      'guidanceScale': ?guidanceScale,
+      'seed': ?seed,
+      'safetyFilterLevel': ?safetyFilterLevel,
       'personGeneration': ?personGeneration,
+      'includeSafetyAttributes': ?includeSafetyAttributes,
+      'includeRaiReason': ?includeRaiReason,
+      'language': ?language,
+      'outputMimeType': ?outputMimeType,
+      'outputCompressionQuality': ?outputCompressionQuality,
+      'addWatermark': ?addWatermark,
+      'labels': ?labels,
+      'enhancePrompt': ?enhancePrompt,
     };
   }
 
@@ -50,15 +74,27 @@ base class ImagenOptions {
   static const SchemanticType<ImagenOptions> $schema =
       _ImagenOptionsTypeFactory();
 
-  String? get apiKey {
-    return _json['apiKey'] as String?;
+  String? get outputGcsUri {
+    return _json['outputGcsUri'] as String?;
   }
 
-  set apiKey(String? value) {
+  set outputGcsUri(String? value) {
     if (value == null) {
-      _json.remove('apiKey');
+      _json.remove('outputGcsUri');
     } else {
-      _json['apiKey'] = value;
+      _json['outputGcsUri'] = value;
+    }
+  }
+
+  String? get negativePrompt {
+    return _json['negativePrompt'] as String?;
+  }
+
+  set negativePrompt(String? value) {
+    if (value == null) {
+      _json.remove('negativePrompt');
+    } else {
+      _json['negativePrompt'] = value;
     }
   }
 
@@ -98,6 +134,42 @@ base class ImagenOptions {
     }
   }
 
+  double? get guidanceScale {
+    return (_json['guidanceScale'] as num?)?.toDouble();
+  }
+
+  set guidanceScale(double? value) {
+    if (value == null) {
+      _json.remove('guidanceScale');
+    } else {
+      _json['guidanceScale'] = value;
+    }
+  }
+
+  int? get seed {
+    return _json['seed'] as int?;
+  }
+
+  set seed(int? value) {
+    if (value == null) {
+      _json.remove('seed');
+    } else {
+      _json['seed'] = value;
+    }
+  }
+
+  String? get safetyFilterLevel {
+    return _json['safetyFilterLevel'] as String?;
+  }
+
+  set safetyFilterLevel(String? value) {
+    if (value == null) {
+      _json.remove('safetyFilterLevel');
+    } else {
+      _json['safetyFilterLevel'] = value;
+    }
+  }
+
   String? get personGeneration {
     return _json['personGeneration'] as String?;
   }
@@ -107,6 +179,102 @@ base class ImagenOptions {
       _json.remove('personGeneration');
     } else {
       _json['personGeneration'] = value;
+    }
+  }
+
+  bool? get includeSafetyAttributes {
+    return _json['includeSafetyAttributes'] as bool?;
+  }
+
+  set includeSafetyAttributes(bool? value) {
+    if (value == null) {
+      _json.remove('includeSafetyAttributes');
+    } else {
+      _json['includeSafetyAttributes'] = value;
+    }
+  }
+
+  bool? get includeRaiReason {
+    return _json['includeRaiReason'] as bool?;
+  }
+
+  set includeRaiReason(bool? value) {
+    if (value == null) {
+      _json.remove('includeRaiReason');
+    } else {
+      _json['includeRaiReason'] = value;
+    }
+  }
+
+  String? get language {
+    return _json['language'] as String?;
+  }
+
+  set language(String? value) {
+    if (value == null) {
+      _json.remove('language');
+    } else {
+      _json['language'] = value;
+    }
+  }
+
+  String? get outputMimeType {
+    return _json['outputMimeType'] as String?;
+  }
+
+  set outputMimeType(String? value) {
+    if (value == null) {
+      _json.remove('outputMimeType');
+    } else {
+      _json['outputMimeType'] = value;
+    }
+  }
+
+  int? get outputCompressionQuality {
+    return _json['outputCompressionQuality'] as int?;
+  }
+
+  set outputCompressionQuality(int? value) {
+    if (value == null) {
+      _json.remove('outputCompressionQuality');
+    } else {
+      _json['outputCompressionQuality'] = value;
+    }
+  }
+
+  bool? get addWatermark {
+    return _json['addWatermark'] as bool?;
+  }
+
+  set addWatermark(bool? value) {
+    if (value == null) {
+      _json.remove('addWatermark');
+    } else {
+      _json['addWatermark'] = value;
+    }
+  }
+
+  Map<String, String>? get labels {
+    return (_json['labels'] as Map?)?.cast<String, String>();
+  }
+
+  set labels(Map<String, String>? value) {
+    if (value == null) {
+      _json.remove('labels');
+    } else {
+      _json['labels'] = value;
+    }
+  }
+
+  bool? get enhancePrompt {
+    return _json['enhancePrompt'] as bool?;
+  }
+
+  set enhancePrompt(bool? value) {
+    if (value == null) {
+      _json.remove('enhancePrompt');
+    } else {
+      _json['enhancePrompt'] = value;
     }
   }
 
@@ -135,7 +303,13 @@ base class _ImagenOptionsTypeFactory extends SchemanticType<ImagenOptions> {
     definition: $Schema.fromMap({
       'type': 'object',
       'properties': {
-        'apiKey': $Schema.string(),
+        'outputGcsUri': $Schema.string(
+          description: 'Cloud Storage URI used to store the generated images.',
+        ),
+        'negativePrompt': $Schema.string(
+          description:
+              'Description of what to discourage in the generated images.',
+        ),
         'numberOfImages': $Schema.integer(
           description:
               'The number of images to generate, from 1 to 4 inclusive. Defaults to 1.',
@@ -151,9 +325,57 @@ base class _ImagenOptionsTypeFactory extends SchemanticType<ImagenOptions> {
           description: 'Desired aspect ratio of the output image.',
           enumValues: ['1:1', '9:16', '16:9', '3:4', '4:3'],
         ),
+        'guidanceScale': $Schema.number(
+          description:
+              'Controls how much the model adheres to the text prompt. Large values increase output and prompt alignment, but may compromise image quality.',
+        ),
+        'seed': $Schema.integer(
+          description:
+              'Random seed for image generation. This is not available when addWatermark is set to true.',
+        ),
+        'safetyFilterLevel': $Schema.string(
+          description: 'Filter level for safety filtering.',
+          enumValues: [
+            'BLOCK_LOW_AND_ABOVE',
+            'BLOCK_MEDIUM_AND_ABOVE',
+            'BLOCK_ONLY_HIGH',
+            'BLOCK_NONE',
+          ],
+        ),
         'personGeneration': $Schema.string(
           description: 'Control if and how images of people are generated.',
           enumValues: ['dont_allow', 'allow_adult', 'allow_all'],
+        ),
+        'includeSafetyAttributes': $Schema.boolean(
+          description:
+              'Whether to report safety scores of each generated image and the positive prompt in the response.',
+        ),
+        'includeRaiReason': $Schema.boolean(
+          description:
+              'Whether to include the Responsible AI filter reason if the image is filtered out of the response.',
+        ),
+        'language': $Schema.string(
+          description: 'Language of the text in the prompt.',
+          enumValues: ['auto', 'en', 'ja', 'ko', 'hi', 'zh', 'pt', 'es'],
+        ),
+        'outputMimeType': $Schema.string(
+          description: 'MIME type of the generated image.',
+        ),
+        'outputCompressionQuality': $Schema.integer(
+          description:
+              'Compression quality of the generated image, for image/jpeg only.',
+          minimum: 0,
+          maximum: 100,
+        ),
+        'addWatermark': $Schema.boolean(
+          description: 'Whether to add a watermark to the generated images.',
+        ),
+        'labels': $Schema.object(
+          description: 'User specified labels to track billing usage.',
+          additionalProperties: $Schema.string(),
+        ),
+        'enhancePrompt': $Schema.boolean(
+          description: 'Whether to use prompt rewriting logic.',
         ),
       },
       'additionalProperties': true,

--- a/packages/genkit_google_genai/lib/src/imagen.g.dart
+++ b/packages/genkit_google_genai/lib/src/imagen.g.dart
@@ -30,12 +30,14 @@ base class ImagenOptions {
   ImagenOptions({
     String? apiKey,
     int? numberOfImages,
+    String? imageSize,
     String? aspectRatio,
     String? personGeneration,
   }) {
     _json = {
       'apiKey': ?apiKey,
       'numberOfImages': ?numberOfImages,
+      'imageSize': ?imageSize,
       'aspectRatio': ?aspectRatio,
       'personGeneration': ?personGeneration,
     };
@@ -67,6 +69,18 @@ base class ImagenOptions {
       _json.remove('numberOfImages');
     } else {
       _json['numberOfImages'] = value;
+    }
+  }
+
+  String? get imageSize {
+    return _json['imageSize'] as String?;
+  }
+
+  set imageSize(String? value) {
+    if (value == null) {
+      _json.remove('imageSize');
+    } else {
+      _json['imageSize'] = value;
     }
   }
 
@@ -124,6 +138,11 @@ base class _ImagenOptionsTypeFactory extends SchemanticType<ImagenOptions> {
               'The number of images to generate, from 1 to 4 inclusive. Defaults to 1.',
           minimum: 1,
           maximum: 4,
+        ),
+        'imageSize': $Schema.string(
+          description:
+              'The size of the generated image. Supported by Standard and Ultra models.',
+          enumValues: ['1K', '2K'],
         ),
         'aspectRatio': $Schema.string(
           description: 'Desired aspect ratio of the output image.',

--- a/packages/genkit_google_genai/test/imagen_test.dart
+++ b/packages/genkit_google_genai/test/imagen_test.dart
@@ -41,11 +41,22 @@ void main() {
 
     test('maps options to predict parameters', () {
       final options = ImagenOptions.fromJson({
-        'apiKey': 'secret',
+        'outputGcsUri': 'gs://bucket/images',
         'numberOfImages': 2,
         'imageSize': '2K',
         'aspectRatio': '16:9',
+        'guidanceScale': 7.5,
+        'seed': 123,
+        'safetyFilterLevel': 'BLOCK_ONLY_HIGH',
         'personGeneration': 'allow_adult',
+        'includeSafetyAttributes': true,
+        'includeRaiReason': true,
+        'language': 'en',
+        'outputMimeType': 'image/jpeg',
+        'outputCompressionQuality': 90,
+        'addWatermark': true,
+        'labels': {'app': 'genkit'},
+        'enhancePrompt': true,
         'negativePrompt': 'blurry',
       });
 
@@ -53,9 +64,21 @@ void main() {
 
       expect(params, {
         'sampleCount': 2,
+        'outputGcsUri': 'gs://bucket/images',
         'imageSize': '2K',
         'aspectRatio': '16:9',
+        'guidanceScale': 7.5,
+        'seed': 123,
+        'safetyFilterLevel': 'BLOCK_ONLY_HIGH',
         'personGeneration': 'allow_adult',
+        'includeSafetyAttributes': true,
+        'includeRaiReason': true,
+        'language': 'en',
+        'outputMimeType': 'image/jpeg',
+        'outputCompressionQuality': 90,
+        'addWatermark': true,
+        'labels': {'app': 'genkit'},
+        'enhancePrompt': true,
         'negativePrompt': 'blurry',
       });
     });

--- a/packages/genkit_google_genai/test/imagen_test.dart
+++ b/packages/genkit_google_genai/test/imagen_test.dart
@@ -1,0 +1,112 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:genkit_google_genai/src/imagen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Imagen', () {
+    test('resolve returns Imagen model action', () {
+      final plugin = GoogleGenAiPluginImpl();
+      final action = plugin.resolve('model', 'imagen-4.0-generate-001');
+
+      expect(action, isNotNull);
+      expect(action!.name, 'googleai/imagen-4.0-generate-001');
+    });
+
+    test('maps options to predict parameters', () {
+      final options = ImagenOptions.fromJson({
+        'apiKey': 'secret',
+        'numberOfImages': 2,
+        'aspectRatio': '16:9',
+        'personGeneration': 'allow_adult',
+        'negativePrompt': 'blurry',
+      });
+
+      final params = toImagenParameters(options);
+
+      expect(params, {
+        'sampleCount': 2,
+        'aspectRatio': '16:9',
+        'personGeneration': 'allow_adult',
+        'negativePrompt': 'blurry',
+      });
+    });
+
+    test('defaults sample count to one', () {
+      final params = toImagenParameters(ImagenOptions());
+
+      expect(params, {'sampleCount': 1});
+    });
+
+    test('converts predictions to media parts', () {
+      final part = fromImagenPrediction({
+        'bytesBase64Encoded': 'abc123',
+        'mimeType': 'image/jpeg',
+      });
+
+      expect(part.media.url, 'data:image/jpeg;base64,abc123');
+      expect(part.media.contentType, 'image/jpeg');
+    });
+
+    test('extracts text from user messages only', () {
+      final request = ModelRequest(
+        messages: [
+          Message(
+            role: Role.system,
+            content: [TextPart(text: 'system')],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello ')],
+          ),
+          Message(
+            role: Role.model,
+            content: [TextPart(text: 'model')],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'world')],
+          ),
+        ],
+      );
+
+      expect(extractImagenPrompt(request), 'hello world');
+    });
+
+    test('extracts base64 image inputs', () {
+      final request = ModelRequest(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [
+              TextPart(text: 'edit this'),
+              MediaPart(
+                media: Media(
+                  url: 'data:image/png;base64,abc123',
+                  contentType: 'image/png',
+                ),
+              ),
+            ],
+          ),
+        ],
+      );
+
+      expect(extractImagenImage(request), {'bytesBase64Encoded': 'abc123'});
+    });
+  });
+}

--- a/packages/genkit_google_genai/test/imagen_test.dart
+++ b/packages/genkit_google_genai/test/imagen_test.dart
@@ -28,10 +28,22 @@ void main() {
       expect(action!.name, 'googleai/imagen-4.0-generate-001');
     });
 
+    test('exposes image size in custom options metadata', () {
+      final plugin = GoogleGenAiPluginImpl();
+      final action = plugin.resolve('model', 'imagen-4.0-generate-001');
+      final model = action!.metadata['model'] as Map<String, dynamic>;
+      final customOptions = model['customOptions'] as Map<String, dynamic>;
+      final properties = customOptions['properties'] as Map<String, dynamic>;
+
+      expect(properties, contains('imageSize'));
+      expect(properties['imageSize'], containsPair('enum', ['1K', '2K']));
+    });
+
     test('maps options to predict parameters', () {
       final options = ImagenOptions.fromJson({
         'apiKey': 'secret',
         'numberOfImages': 2,
+        'imageSize': '2K',
         'aspectRatio': '16:9',
         'personGeneration': 'allow_adult',
         'negativePrompt': 'blurry',
@@ -41,6 +53,7 @@ void main() {
 
       expect(params, {
         'sampleCount': 2,
+        'imageSize': '2K',
         'aspectRatio': '16:9',
         'personGeneration': 'allow_adult',
         'negativePrompt': 'blurry',
@@ -88,25 +101,11 @@ void main() {
       expect(extractImagenPrompt(request), 'hello world');
     });
 
-    test('extracts base64 image inputs', () {
-      final request = ModelRequest(
-        messages: [
-          Message(
-            role: Role.user,
-            content: [
-              TextPart(text: 'edit this'),
-              MediaPart(
-                media: Media(
-                  url: 'data:image/png;base64,abc123',
-                  contentType: 'image/png',
-                ),
-              ),
-            ],
-          ),
-        ],
+    test('throws clear error for invalid prediction shape', () {
+      expect(
+        () => fromImagenPrediction('not-a-map'),
+        throwsA(isA<GenkitException>()),
       );
-
-      expect(extractImagenImage(request), {'bytesBase64Encoded': 'abc123'});
     });
   });
 }


### PR DESCRIPTION
Add Imagen model support in GoogleAI plugin.

## Testing

<img width="1250" height="833" alt="image" src="https://github.com/user-attachments/assets/8af47585-f3b8-4e49-a8af-4c17a7d99237" />