### PR TITLE
feat(vertexai): add support for mistral models

### DIFF
--- a/packages/genkit_google_genai/lib/src/api_client.dart
+++ b/packages/genkit_google_genai/lib/src/api_client.dart
@@ -62,12 +62,14 @@ class GenerativeLanguageBaseClient {
 
   Future<Map<String, dynamic>> listPublisherModels({
     required String projectId,
+    String publisher = 'google',
   }) async {
     // Vertex AI endpoint for publisher models uses v1beta1 and does not have the 'projects/...' in the path
     // when using this specific endpoint, but it requires the google user project header (or just works with ADC).
     // The base URL for this is https://{location}-aiplatform.googleapis.com
-    // And path is /v1beta1/publishers/google/models
-    final url = 'v1beta1/publishers/google/models';
+    // And path is /v1beta1/publishers/{publisher}/models
+    final safePublisher = Uri.encodeComponent(publisher);
+    final url = 'v1beta1/publishers/$safePublisher/models';
     return await _call('GET', url, null, {'x-goog-user-project': projectId});
   }
 

--- a/packages/genkit_vertexai/lib/genkit_vertexai.dart
+++ b/packages/genkit_vertexai/lib/genkit_vertexai.dart
@@ -16,6 +16,7 @@ import 'package:genkit/plugin.dart';
 import 'package:genkit_google_genai/genkit_google_genai.dart';
 import 'package:http/http.dart' as http;
 
+import 'src/mistral.dart';
 import 'src/vertex_api_client.dart';
 
 export 'package:genkit_google_genai/genkit_google_genai.dart'
@@ -31,6 +32,7 @@ export 'package:genkit_google_genai/genkit_google_genai.dart'
         TextEmbedderOptions,
         ThinkingConfig,
         VoiceConfig;
+export 'src/mistral.dart' show MistralOptions;
 
 const VertexAiPluginHandle vertexAI = VertexAiPluginHandle();
 
@@ -51,6 +53,10 @@ class VertexAiPluginHandle {
 
   ModelRef<GeminiOptions> gemini(String name) {
     return modelRef('vertexai/$name', customOptions: GeminiOptions.$schema);
+  }
+
+  ModelRef<MistralOptions> mistral(String name) {
+    return modelRef('vertexai/$name', customOptions: MistralOptions.$schema);
   }
 
   EmbedderRef<TextEmbedderOptions> textEmbedding(String name) {

--- a/packages/genkit_vertexai/lib/src/common.dart
+++ b/packages/genkit_vertexai/lib/src/common.dart
@@ -1,0 +1,19 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+String? publisherModelName(dynamic model) {
+  if (model is! Map<String, dynamic>) return null;
+  final name = model['name'] as String?;
+  return name?.split('/').last;
+}

--- a/packages/genkit_vertexai/lib/src/mistral.dart
+++ b/packages/genkit_vertexai/lib/src/mistral.dart
@@ -38,7 +38,8 @@ final mistralModelInfo = ModelInfo(
 
 bool isMistralModelName(String name) {
   final normalized = name.toLowerCase();
-  return normalized.startsWith('mistral-') ||
+  return (normalized.startsWith('mistral-') &&
+          !normalized.startsWith('mistral-ocr-')) ||
       normalized.startsWith('codestral-');
 }
 
@@ -122,12 +123,19 @@ base class MistralOptions {
     double? temperature,
     double? topP,
     int? maxTokens,
-    List<String>? stop,
+    Object? stop,
     double? presencePenalty,
     double? frequencyPenalty,
     int? randomSeed,
     bool? safePrompt,
-    String? toolChoice,
+    Object? toolChoice,
+    bool? parallelToolCalls,
+    Map<String, dynamic>? prediction,
+    String? promptCacheKey,
+    Map<String, dynamic>? metadata,
+    List<Object?>? guardrails,
+    String? promptMode,
+    String? reasoningEffort,
     Map<String, dynamic>? responseFormat,
   }) {
     _json = {
@@ -141,6 +149,13 @@ base class MistralOptions {
       'randomSeed': ?randomSeed,
       'safePrompt': ?safePrompt,
       'toolChoice': ?toolChoice,
+      'parallelToolCalls': ?parallelToolCalls,
+      'prediction': ?prediction,
+      'promptCacheKey': ?promptCacheKey,
+      'metadata': ?metadata,
+      'guardrails': ?guardrails,
+      'promptMode': ?promptMode,
+      'reasoningEffort': ?reasoningEffort,
       'responseFormat': ?responseFormat,
     };
   }
@@ -156,16 +171,39 @@ base class MistralOptions {
         'topP': {'type': 'number', 'minimum': 0, 'maximum': 1},
         'maxTokens': {'type': 'integer'},
         'stop': {
-          'type': 'array',
-          'items': {'type': 'string'},
+          'oneOf': [
+            {'type': 'string'},
+            {
+              'type': 'array',
+              'items': {'type': 'string'},
+            },
+          ],
         },
         'presencePenalty': {'type': 'number', 'minimum': -2, 'maximum': 2},
         'frequencyPenalty': {'type': 'number', 'minimum': -2, 'maximum': 2},
         'randomSeed': {'type': 'integer'},
         'safePrompt': {'type': 'boolean'},
         'toolChoice': {
+          'oneOf': [
+            {
+              'type': 'string',
+              'enum': ['auto', 'none', 'any', 'required'],
+            },
+            {'type': 'object'},
+          ],
+        },
+        'parallelToolCalls': {'type': 'boolean'},
+        'prediction': {'type': 'object'},
+        'promptCacheKey': {'type': 'string'},
+        'metadata': {'type': 'object'},
+        'guardrails': {'type': 'array'},
+        'promptMode': {
           'type': 'string',
-          'enum': ['auto', 'none', 'any', 'required'],
+          'enum': ['reasoning'],
+        },
+        'reasoningEffort': {
+          'type': 'string',
+          'enum': ['high', 'none'],
         },
         'responseFormat': {'type': 'object'},
       },
@@ -181,7 +219,7 @@ base class MistralOptions {
 
   int? get maxTokens => _json['maxTokens'] as int?;
 
-  List<String>? get stop => (_json['stop'] as List?)?.cast<String>();
+  Object? get stop => _json['stop'];
 
   double? get presencePenalty => (_json['presencePenalty'] as num?)?.toDouble();
 
@@ -192,7 +230,24 @@ base class MistralOptions {
 
   bool? get safePrompt => _json['safePrompt'] as bool?;
 
-  String? get toolChoice => _json['toolChoice'] as String?;
+  Object? get toolChoice => _json['toolChoice'];
+
+  bool? get parallelToolCalls => _json['parallelToolCalls'] as bool?;
+
+  Map<String, dynamic>? get prediction =>
+      (_json['prediction'] as Map?)?.cast<String, dynamic>();
+
+  String? get promptCacheKey => _json['promptCacheKey'] as String?;
+
+  Map<String, dynamic>? get metadata =>
+      (_json['metadata'] as Map?)?.cast<String, dynamic>();
+
+  List<Object?>? get guardrails =>
+      (_json['guardrails'] as List?)?.cast<Object?>();
+
+  String? get promptMode => _json['promptMode'] as String?;
+
+  String? get reasoningEffort => _json['reasoningEffort'] as String?;
 
   Map<String, dynamic>? get responseFormat =>
       (_json['responseFormat'] as Map?)?.cast<String, dynamic>();
@@ -263,6 +318,16 @@ Map<String, dynamic> _toMistralRequest(
     if (options.randomSeed != null) 'random_seed': options.randomSeed,
     if (options.safePrompt != null) 'safe_prompt': options.safePrompt,
     if (options.toolChoice != null) 'tool_choice': options.toolChoice,
+    if (options.parallelToolCalls != null)
+      'parallel_tool_calls': options.parallelToolCalls,
+    if (options.prediction != null) 'prediction': options.prediction,
+    if (options.promptCacheKey != null)
+      'prompt_cache_key': options.promptCacheKey,
+    if (options.metadata != null) 'metadata': options.metadata,
+    if (options.guardrails != null) 'guardrails': options.guardrails,
+    if (options.promptMode != null) 'prompt_mode': options.promptMode,
+    if (options.reasoningEffort != null)
+      'reasoning_effort': options.reasoningEffort,
     if (request.tools?.isNotEmpty == true)
       'tools': request.tools!.map(_toMistralTool).toList(),
     if (options.responseFormat != null)

--- a/packages/genkit_vertexai/lib/src/mistral.dart
+++ b/packages/genkit_vertexai/lib/src/mistral.dart
@@ -1,0 +1,580 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit/plugin.dart';
+import 'package:genkit_google_genai/common.dart';
+import 'package:http/http.dart' as http;
+import 'package:schemantic/schemantic.dart';
+
+import 'common.dart';
+
+const _mistralPublisher = 'mistralai';
+const _mistralApiVersion = 'v1';
+
+final mistralModelInfo = ModelInfo(
+  supports: {
+    'multiturn': true,
+    'media': true,
+    'tools': true,
+    'toolChoice': true,
+    'systemRole': true,
+    'constrained': true,
+  },
+);
+
+bool isMistralModelName(String name) {
+  final normalized = name.toLowerCase();
+  return normalized.startsWith('mistral-') ||
+      normalized.startsWith('codestral-');
+}
+
+List<ActionMetadata<dynamic, dynamic, dynamic, dynamic>> mistralMetadata(
+  String pluginName,
+  List<dynamic> publisherModels,
+) {
+  return publisherModels
+      .map(publisherModelName)
+      .nonNulls
+      .where(isMistralModelName)
+      .map(
+        (modelName) => modelMetadata(
+          '$pluginName/$modelName',
+          customOptions: MistralOptions.$schema,
+          modelInfo: _mistralModelInfoFor(modelName),
+        ),
+      )
+      .toList();
+}
+
+Model createMistralModel({
+  required String pluginName,
+  required String modelName,
+  required Future<GenerativeLanguageBaseClient> Function() getApiClient,
+}) {
+  final modelInfo = _mistralModelInfoFor(modelName);
+
+  return Model(
+    name: '$pluginName/$modelName',
+    customOptions: MistralOptions.$schema,
+    metadata: {'model': modelInfo.toJson()},
+    fn: (req, ctx) async {
+      final modelRequest = req!;
+      final options = modelRequest.config == null
+          ? MistralOptions()
+          : MistralOptions.$schema.parse(modelRequest.config!);
+      final service = await getApiClient();
+      final client = _MistralRawPredictClient(service);
+
+      try {
+        final body = _toMistralRequest(
+          modelRequest,
+          options,
+          modelName,
+          stream: ctx.streamingRequested,
+        );
+
+        if (ctx.streamingRequested) {
+          return await _handleMistralStream(client, body, modelName, ctx);
+        }
+
+        final response = await client.rawPredict(body, model: modelName);
+        return _fromMistralResponse(response);
+      } catch (e, stack) {
+        if (e is GenkitException) rethrow;
+        throw GenkitException(
+          'Mistral API error: $e',
+          status: StatusCodes.INTERNAL,
+          underlyingException: e,
+          stackTrace: stack,
+        );
+      } finally {
+        service.client.close();
+      }
+    },
+  );
+}
+
+base class MistralOptions {
+  factory MistralOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  MistralOptions._(this._json);
+
+  MistralOptions({
+    String? version,
+    double? temperature,
+    double? topP,
+    int? maxTokens,
+    List<String>? stop,
+    double? presencePenalty,
+    double? frequencyPenalty,
+    int? randomSeed,
+    bool? safePrompt,
+    String? toolChoice,
+    Map<String, dynamic>? responseFormat,
+  }) {
+    _json = {
+      'version': ?version,
+      'temperature': ?temperature,
+      'topP': ?topP,
+      'maxTokens': ?maxTokens,
+      'stop': ?stop,
+      'presencePenalty': ?presencePenalty,
+      'frequencyPenalty': ?frequencyPenalty,
+      'randomSeed': ?randomSeed,
+      'safePrompt': ?safePrompt,
+      'toolChoice': ?toolChoice,
+      'responseFormat': ?responseFormat,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static final SchemanticType<MistralOptions> $schema = SchemanticType.from(
+    jsonSchema: {
+      'type': 'object',
+      'properties': {
+        'version': {'type': 'string'},
+        'temperature': {'type': 'number', 'minimum': 0, 'maximum': 1.5},
+        'topP': {'type': 'number', 'minimum': 0, 'maximum': 1},
+        'maxTokens': {'type': 'integer'},
+        'stop': {
+          'type': 'array',
+          'items': {'type': 'string'},
+        },
+        'presencePenalty': {'type': 'number', 'minimum': -2, 'maximum': 2},
+        'frequencyPenalty': {'type': 'number', 'minimum': -2, 'maximum': 2},
+        'randomSeed': {'type': 'integer'},
+        'safePrompt': {'type': 'boolean'},
+        'toolChoice': {
+          'type': 'string',
+          'enum': ['auto', 'none', 'any', 'required'],
+        },
+        'responseFormat': {'type': 'object'},
+      },
+    },
+    parse: (json) => MistralOptions._(Map<String, dynamic>.from(json as Map)),
+  );
+
+  String? get version => _json['version'] as String?;
+
+  double? get temperature => (_json['temperature'] as num?)?.toDouble();
+
+  double? get topP => (_json['topP'] as num?)?.toDouble();
+
+  int? get maxTokens => _json['maxTokens'] as int?;
+
+  List<String>? get stop => (_json['stop'] as List?)?.cast<String>();
+
+  double? get presencePenalty => (_json['presencePenalty'] as num?)?.toDouble();
+
+  double? get frequencyPenalty =>
+      (_json['frequencyPenalty'] as num?)?.toDouble();
+
+  int? get randomSeed => _json['randomSeed'] as int?;
+
+  bool? get safePrompt => _json['safePrompt'] as bool?;
+
+  String? get toolChoice => _json['toolChoice'] as String?;
+
+  Map<String, dynamic>? get responseFormat =>
+      (_json['responseFormat'] as Map?)?.cast<String, dynamic>();
+
+  Map<String, dynamic> toJson() => _json;
+}
+
+Future<ModelResponse> _handleMistralStream(
+  _MistralRawPredictClient client,
+  Map<String, dynamic> body,
+  String modelName,
+  ActionFnArg<ModelResponseChunk, ModelRequest, void> ctx,
+) async {
+  final content = StringBuffer();
+  Map<String, dynamic>? lastChunk;
+  String? finishReason;
+
+  await for (final chunk in client.streamRawPredict(body, model: modelName)) {
+    lastChunk = chunk;
+    final choices = chunk['choices'] as List?;
+    if (choices == null || choices.isEmpty) continue;
+
+    final choice = choices.first as Map<String, dynamic>;
+    finishReason = choice['finish_reason'] as String?;
+    final delta = choice['delta'] as Map<String, dynamic>?;
+    final deltaContent = delta?['content'];
+    final text = _contentToText(deltaContent);
+    if (text == null || text.isEmpty) continue;
+
+    content.write(text);
+    ctx.sendChunk(
+      ModelResponseChunk(index: 0, content: [TextPart(text: text)]),
+    );
+  }
+
+  return ModelResponse(
+    finishReason: _mapFinishReason(finishReason),
+    message: Message(
+      role: Role.model,
+      content: [TextPart(text: '$content')],
+    ),
+    raw: lastChunk,
+  );
+}
+
+Map<String, dynamic> _toMistralRequest(
+  ModelRequest request,
+  MistralOptions options,
+  String modelName, {
+  required bool stream,
+}) {
+  final isJsonMode =
+      request.output?.format == 'json' ||
+      request.output?.contentType == 'application/json';
+
+  return {
+    'model': _bodyModelName(options.version ?? modelName),
+    'messages': _toMistralMessages(request.messages),
+    'stream': stream,
+    if (options.temperature != null) 'temperature': options.temperature,
+    if (options.topP != null) 'top_p': options.topP,
+    if (options.maxTokens != null) 'max_tokens': options.maxTokens,
+    if (options.stop != null) 'stop': options.stop,
+    if (options.presencePenalty != null)
+      'presence_penalty': options.presencePenalty,
+    if (options.frequencyPenalty != null)
+      'frequency_penalty': options.frequencyPenalty,
+    if (options.randomSeed != null) 'random_seed': options.randomSeed,
+    if (options.safePrompt != null) 'safe_prompt': options.safePrompt,
+    if (options.toolChoice != null) 'tool_choice': options.toolChoice,
+    if (request.tools?.isNotEmpty == true)
+      'tools': request.tools!.map(_toMistralTool).toList(),
+    if (options.responseFormat != null)
+      'response_format': options.responseFormat
+    else if (isJsonMode)
+      'response_format': {'type': 'json_object'},
+  };
+}
+
+String _bodyModelName(String modelName) => modelName.split('@').first;
+
+List<Map<String, dynamic>> _toMistralMessages(List<Message> messages) {
+  final converted = <Map<String, dynamic>>[];
+  for (final message in messages) {
+    if (message.role == Role.tool) {
+      final toolResponses = message.content
+          .where((part) => part.isToolResponse)
+          .map((part) => part.toolResponse!)
+          .toList();
+      if (toolResponses.isEmpty) {
+        throw ArgumentError(
+          'Mistral tool messages must contain at least one ToolResponsePart.',
+        );
+      }
+      converted.addAll(toolResponses.map(_toMistralToolResponseMessage));
+    } else {
+      converted.add(_toMistralMessage(message));
+    }
+  }
+  return converted;
+}
+
+Map<String, dynamic> _toMistralMessage(Message message) {
+  final role = message.role == Role.model ? 'assistant' : message.role.value;
+  final toolCalls = message.content
+      .where((part) => part.isToolRequest)
+      .map((part) => _toMistralToolCall(part.toolRequest!))
+      .toList();
+
+  return {
+    'role': role,
+    'content': _toMistralContent(message.content),
+    if (toolCalls.isNotEmpty) 'tool_calls': toolCalls,
+  };
+}
+
+Map<String, dynamic> _toMistralToolResponseMessage(ToolResponse response) {
+  return {
+    'role': 'tool',
+    'tool_call_id': response.ref,
+    'name': response.name,
+    'content': jsonEncode(response.output),
+  };
+}
+
+Object _toMistralContent(List<Part> parts) {
+  final contentParts = parts
+      .where((part) => part.isText || part.isReasoning || part.isMedia)
+      .map(_toMistralContentPart)
+      .toList();
+
+  if (contentParts.isEmpty) {
+    return '';
+  }
+  if (contentParts.length == 1 && contentParts.first['type'] == 'text') {
+    return contentParts.first['text'] as String;
+  }
+  return contentParts;
+}
+
+Map<String, dynamic> _toMistralContentPart(Part part) {
+  if (part.isText) {
+    return {'type': 'text', 'text': part.text};
+  }
+  if (part.isReasoning) {
+    return {'type': 'text', 'text': part.reasoning};
+  }
+  if (part.isMedia) {
+    final media = part.media!;
+    if (_isDocumentMedia(media)) {
+      return {'type': 'document_url', 'document_url': media.url};
+    }
+    return {
+      'type': 'image_url',
+      'image_url': {'url': media.url},
+    };
+  }
+  throw UnimplementedError('Unsupported Mistral content part: $part');
+}
+
+bool _isDocumentMedia(Media media) {
+  final contentType = media.contentType?.toLowerCase();
+  return contentType == 'application/pdf' ||
+      media.url.toLowerCase().endsWith('.pdf');
+}
+
+Map<String, dynamic> _toMistralTool(ToolDefinition tool) {
+  final parameters = tool.inputSchema == null
+      ? {'type': 'object', 'properties': <String, dynamic>{}}
+      : ({
+          if (!tool.inputSchema!.containsKey('type')) 'type': 'object',
+          ...tool.inputSchema!,
+        });
+
+  return {
+    'type': 'function',
+    'function': {
+      'name': tool.name,
+      'description': tool.description,
+      'parameters': parameters,
+    },
+  };
+}
+
+Map<String, dynamic> _toMistralToolCall(ToolRequest request) {
+  final ref = request.ref;
+  if (ref == null || ref.isEmpty) {
+    throw ArgumentError(
+      'ToolRequest.ref must be a non-empty string for Mistral tool calls.',
+    );
+  }
+
+  return {
+    'id': ref,
+    'type': 'function',
+    'function': {
+      'name': request.name,
+      'arguments': jsonEncode(request.input ?? {}),
+    },
+  };
+}
+
+ModelResponse _fromMistralResponse(Map<String, dynamic> response) {
+  final choices = response['choices'] as List?;
+  if (choices == null || choices.isEmpty) {
+    throw GenkitException('Mistral model returned no choices.');
+  }
+
+  final choice = choices.first as Map<String, dynamic>;
+  final message = choice['message'] as Map<String, dynamic>;
+
+  return ModelResponse(
+    finishReason: _mapFinishReason(choice['finish_reason'] as String?),
+    message: _fromMistralMessage(message),
+    raw: response,
+    usage: _extractMistralUsage(response['usage'] as Map<String, dynamic>?),
+  );
+}
+
+Message _fromMistralMessage(Map<String, dynamic> message) {
+  final parts = <Part>[];
+  final text = _contentToText(message['content']);
+  if (text != null && text.isNotEmpty) {
+    parts.add(TextPart(text: text));
+  }
+
+  final toolCalls = message['tool_calls'] as List?;
+  if (toolCalls != null) {
+    for (final toolCall in toolCalls.cast<Map<String, dynamic>>()) {
+      parts.add(_fromMistralToolCall(toolCall));
+    }
+  }
+
+  return Message(role: Role.model, content: parts);
+}
+
+String? _contentToText(Object? content) {
+  if (content == null) return null;
+  if (content is String) return content;
+  if (content is List) {
+    final buffer = StringBuffer();
+    for (final part in content) {
+      if (part is Map && part['type'] == 'text') {
+        buffer.write(part['text']);
+      }
+    }
+    return '$buffer';
+  }
+  return content.toString();
+}
+
+ToolRequestPart _fromMistralToolCall(Map<String, dynamic> toolCall) {
+  final function = toolCall['function'] as Map<String, dynamic>;
+  final arguments = function['arguments'];
+
+  return ToolRequestPart(
+    toolRequest: ToolRequest(
+      ref: toolCall['id'] as String?,
+      name: function['name'] as String,
+      input: _parseToolArguments(arguments),
+    ),
+  );
+}
+
+Map<String, dynamic>? _parseToolArguments(Object? arguments) {
+  if (arguments == null) return null;
+  if (arguments is Map<String, dynamic>) return arguments;
+  if (arguments is String && arguments.isNotEmpty) {
+    return jsonDecode(arguments) as Map<String, dynamic>;
+  }
+  return null;
+}
+
+FinishReason _mapFinishReason(String? reason) {
+  return switch (reason) {
+    'stop' || 'tool_calls' => FinishReason.stop,
+    'length' || 'model_length' => FinishReason.length,
+    'content_filter' => FinishReason.blocked,
+    _ => FinishReason.unknown,
+  };
+}
+
+GenerationUsage? _extractMistralUsage(Map<String, dynamic>? usage) {
+  if (usage == null) return null;
+  return GenerationUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toDouble(),
+    outputTokens: (usage['completion_tokens'] as num?)?.toDouble(),
+    totalTokens: (usage['total_tokens'] as num?)?.toDouble(),
+  );
+}
+
+ModelInfo _mistralModelInfoFor(String modelName) {
+  final normalized = modelName.toLowerCase();
+  return ModelInfo(
+    label: modelName,
+    supports: {
+      ...mistralModelInfo.supports!,
+      'media': !normalized.startsWith('codestral-'),
+    },
+  );
+}
+
+class _MistralRawPredictClient {
+  final GenerativeLanguageBaseClient _service;
+
+  _MistralRawPredictClient(this._service);
+
+  Future<Map<String, dynamic>> rawPredict(
+    Map<String, dynamic> request, {
+    required String model,
+  }) async {
+    final url = '${_service.apiUrlPrefix}models/$model:rawPredict';
+    final response = await _service.client.post(
+      Uri.parse('${_service.baseUrl}$url'),
+      headers: {'Content-Type': 'application/json; charset=utf-8'},
+      body: jsonEncode(request),
+    );
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    throw _parseMistralError(response.statusCode, response.body);
+  }
+
+  Stream<Map<String, dynamic>> streamRawPredict(
+    Map<String, dynamic> request, {
+    required String model,
+  }) async* {
+    final url = '${_service.apiUrlPrefix}models/$model:streamRawPredict';
+    final httpRequest = http.Request(
+      'POST',
+      Uri.parse('${_service.baseUrl}$url'),
+    );
+    httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
+    httpRequest.body = jsonEncode(request);
+
+    final response = await _service.client.send(httpRequest);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final body = await response.stream.bytesToString();
+      throw _parseMistralError(response.statusCode, body);
+    }
+
+    final stream = response.stream
+        .transform(utf8.decoder)
+        .transform(const LineSplitter());
+    await for (var line in stream) {
+      line = line.trim();
+      if (line.isEmpty || line == '[DONE]') continue;
+      if (line.startsWith('data: ')) line = line.substring(6).trim();
+      if (line == '[DONE]') continue;
+      yield jsonDecode(line) as Map<String, dynamic>;
+    }
+  }
+
+  GenkitException _parseMistralError(int statusCode, String body) {
+    var message = body;
+    try {
+      final json = jsonDecode(body) as Map<String, dynamic>;
+      final error = json['error'];
+      if (error is Map) {
+        message = error['message'] as String? ?? body;
+      } else if (error is String) {
+        message = error;
+      } else {
+        message = json['message'] as String? ?? body;
+      }
+    } catch (_) {}
+
+    return GenkitException(
+      'Mistral API Error: $message',
+      status: StatusCodes.fromHttpStatus(statusCode),
+    );
+  }
+}
+
+GenerativeLanguageBaseClient mistralApiClient({
+  required String baseUrl,
+  required http.Client client,
+  required String projectId,
+  required String location,
+}) {
+  return GenerativeLanguageBaseClient(
+    baseUrl: baseUrl,
+    client: client,
+    apiUrlPrefix:
+        '$_mistralApiVersion/projects/$projectId/locations/$location/'
+        'publishers/$_mistralPublisher/',
+  );
+}

--- a/packages/genkit_vertexai/lib/src/mistral.dart
+++ b/packages/genkit_vertexai/lib/src/mistral.dart
@@ -262,6 +262,7 @@ Future<ModelResponse> _handleMistralStream(
   ActionFnArg<ModelResponseChunk, ModelRequest, void> ctx,
 ) async {
   final content = StringBuffer();
+  final toolCalls = <int, _MistralStreamToolCall>{};
   Map<String, dynamic>? lastChunk;
   String? finishReason;
 
@@ -271,8 +272,10 @@ Future<ModelResponse> _handleMistralStream(
     if (choices == null || choices.isEmpty) continue;
 
     final choice = choices.first as Map<String, dynamic>;
-    finishReason = choice['finish_reason'] as String?;
+    finishReason = choice['finish_reason'] as String? ?? finishReason;
     final delta = choice['delta'] as Map<String, dynamic>?;
+    _accumulateStreamToolCalls(delta?['tool_calls'], toolCalls);
+
     final deltaContent = delta?['content'];
     final text = _contentToText(deltaContent);
     if (text == null || text.isEmpty) continue;
@@ -283,14 +286,46 @@ Future<ModelResponse> _handleMistralStream(
     );
   }
 
+  final text = '$content';
+  final responseContent = <Part>[
+    if (text.isNotEmpty) TextPart(text: text),
+    ..._streamToolCallsToParts(toolCalls),
+  ];
+  if (responseContent.isEmpty) {
+    responseContent.add(TextPart(text: ''));
+  }
+
   return ModelResponse(
     finishReason: _mapFinishReason(finishReason),
-    message: Message(
-      role: Role.model,
-      content: [TextPart(text: '$content')],
-    ),
+    message: Message(role: Role.model, content: responseContent),
     raw: lastChunk,
   );
+}
+
+void _accumulateStreamToolCalls(
+  Object? toolCalls,
+  Map<int, _MistralStreamToolCall> accumulated,
+) {
+  if (toolCalls is! List) return;
+
+  for (var i = 0; i < toolCalls.length; i++) {
+    final toolCall = toolCalls[i];
+    if (toolCall is! Map) continue;
+    final index = (toolCall['index'] as num?)?.toInt() ?? i;
+    accumulated
+        .putIfAbsent(index, _MistralStreamToolCall.new)
+        .add(toolCall.cast<String, dynamic>());
+  }
+}
+
+List<ToolRequestPart> _streamToolCallsToParts(
+  Map<int, _MistralStreamToolCall> toolCalls,
+) {
+  final orderedIndexes = toolCalls.keys.toList()..sort();
+  return [
+    for (final index in orderedIndexes)
+      _fromMistralToolCall(toolCalls[index]!.toJson()),
+  ];
 }
 
 Map<String, dynamic> _toMistralRequest(
@@ -532,6 +567,53 @@ Map<String, dynamic>? _parseToolArguments(Object? arguments) {
     return jsonDecode(arguments) as Map<String, dynamic>;
   }
   return null;
+}
+
+class _MistralStreamToolCall {
+  String? id;
+  String? type;
+  String? name;
+  final arguments = StringBuffer();
+
+  void add(Map<String, dynamic> toolCall) {
+    final idDelta = toolCall['id'];
+    if (idDelta is String && idDelta.isNotEmpty) {
+      id = _mergeStreamScalar(id, idDelta);
+    }
+
+    final typeDelta = toolCall['type'];
+    if (typeDelta is String && typeDelta.isNotEmpty) {
+      type = _mergeStreamScalar(type, typeDelta);
+    }
+
+    final function = toolCall['function'];
+    if (function is! Map) return;
+
+    final nameDelta = function['name'];
+    if (nameDelta is String && nameDelta.isNotEmpty) {
+      name = _mergeStreamScalar(name, nameDelta);
+    }
+
+    final argumentsDelta = function['arguments'];
+    if (argumentsDelta is String) {
+      arguments.write(argumentsDelta);
+    } else if (argumentsDelta != null) {
+      arguments.write(jsonEncode(argumentsDelta));
+    }
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': type ?? 'function',
+    'function': {'name': name ?? '', 'arguments': '$arguments'},
+  };
+}
+
+String _mergeStreamScalar(String? current, String delta) {
+  if (current == null || current.isEmpty) return delta;
+  if (current == delta || current.endsWith(delta)) return current;
+  if (delta.startsWith(current)) return delta;
+  return '$current$delta';
 }
 
 FinishReason _mapFinishReason(String? reason) {

--- a/packages/genkit_vertexai/lib/src/mistral.dart
+++ b/packages/genkit_vertexai/lib/src/mistral.dart
@@ -64,6 +64,7 @@ Model createMistralModel({
   required String pluginName,
   required String modelName,
   required Future<GenerativeLanguageBaseClient> Function() getApiClient,
+  bool closeClient = true,
 }) {
   final modelInfo = _mistralModelInfoFor(modelName);
 
@@ -102,7 +103,9 @@ Model createMistralModel({
           stackTrace: stack,
         );
       } finally {
-        service.client.close();
+        if (closeClient) {
+          service.client.close();
+        }
       }
     },
   );
@@ -347,7 +350,10 @@ Map<String, dynamic> _toMistralContentPart(Part part) {
       'image_url': {'url': media.url},
     };
   }
-  throw UnimplementedError('Unsupported Mistral content part: $part');
+  throw GenkitException(
+    'Unsupported Mistral content part: $part',
+    status: StatusCodes.INVALID_ARGUMENT,
+  );
 }
 
 bool _isDocumentMedia(Media media) {

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -19,6 +19,8 @@ import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 import 'auth.dart';
+import 'common.dart';
+import 'mistral.dart';
 
 @visibleForTesting
 class VertexAiPluginImpl extends CommonGoogleGenPlugin {
@@ -44,6 +46,25 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([
     String? requestApiKey,
   ]) async {
+    return _getPublisherApiClient(publisher: 'google', apiVersion: 'v1beta1');
+  }
+
+  Future<GenerativeLanguageBaseClient> getMistralApiClient() async {
+    final resolvedLocation = location ?? 'global';
+    if (resolvedLocation == 'global') {
+      throw GenkitException(
+        'Mistral models on Vertex AI require a regional location, such as '
+        'us-central1 or europe-west4.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+    return _getPublisherApiClient(publisher: 'mistralai', apiVersion: 'v1');
+  }
+
+  Future<GenerativeLanguageBaseClient> _getPublisherApiClient({
+    required String publisher,
+    required String apiVersion,
+  }) async {
     final validFormat = RegExp(r'^[a-z0-9-]+$');
     final resolvedProjectId = _getResolvedProjectId;
     final resolvedLocation = location ?? 'global';
@@ -61,7 +82,8 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
         ? 'https://aiplatform.googleapis.com/'
         : 'https://$safeLocation-aiplatform.googleapis.com/';
     final apiUrlPrefix =
-        'v1beta1/projects/$safeProjectId/locations/$safeLocation/publishers/google/';
+        '$apiVersion/projects/$safeProjectId/locations/$safeLocation/'
+        'publishers/$publisher/';
 
     final headers = {'X-Goog-Api-Client': googleApiClientHeaderValue()};
     final customClient = CustomClient(
@@ -86,16 +108,15 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
         projectId: _getResolvedProjectId,
       );
       final publisherModels = (res['publisherModels'] as List?) ?? [];
+      final mistralPublisherModels = await _listMistralPublisherModels(service);
 
       final models = publisherModels
           .where((m) {
-            final modelMap = m as Map<String, dynamic>;
-            final name = modelMap['name'] as String?;
-            return name != null && name.contains('gemini-');
+            final modelName = publisherModelName(m);
+            return modelName != null && modelName.contains('gemini-');
           })
           .map((m) {
-            final modelMap = m as Map<String, dynamic>;
-            final modelName = (modelMap['name'] as String).split('/').last;
+            final modelName = publisherModelName(m)!;
             final isTts = modelName.contains('-tts');
             return modelMetadata(
               '$name/$modelName',
@@ -109,20 +130,22 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
 
       final embedders = publisherModels
           .where((m) {
-            final modelMap = m as Map<String, dynamic>;
-            final name = modelMap['name'] as String?;
-            return name != null &&
-                (name.contains('text-embedding-') ||
-                    name.contains('embedding-'));
+            final modelName = publisherModelName(m);
+            return modelName != null &&
+                (modelName.contains('text-embedding-') ||
+                    modelName.contains('embedding-'));
           })
           .map((m) {
-            final modelMap = m as Map<String, dynamic>;
-            final modelName = (modelMap['name'] as String).split('/').last;
+            final modelName = publisherModelName(m)!;
             return embedderMetadata('$name/$modelName');
           })
           .toList();
 
-      return [...models, ...embedders];
+      return [
+        ...models,
+        ...embedders,
+        ...mistralMetadata(name, mistralPublisherModels),
+      ];
     } catch (e, stack) {
       if (e is GenkitException) rethrow;
       logger.warning('Failed to list models: $e', e, stack);
@@ -131,6 +154,21 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
       if (authClient == null) {
         service.client.close();
       }
+    }
+  }
+
+  Future<List<dynamic>> _listMistralPublisherModels(
+    GenerativeLanguageBaseClient service,
+  ) async {
+    try {
+      final res = await service.listPublisherModels(
+        projectId: _getResolvedProjectId,
+        publisher: 'mistralai',
+      );
+      return (res['publisherModels'] as List?) ?? [];
+    } catch (e, stack) {
+      logger.warning('Failed to list Mistral models: $e', e, stack);
+      return [];
     }
   }
 
@@ -189,5 +227,17 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
         }
       },
     );
+  }
+
+  @override
+  Action? resolve(String actionType, String name) {
+    if (actionType == 'model' && isMistralModelName(name)) {
+      return createMistralModel(
+        pluginName: this.name,
+        modelName: name,
+        getApiClient: getMistralApiClient,
+      );
+    }
+    return super.resolve(actionType, name);
   }
 }

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -236,6 +236,7 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
         pluginName: this.name,
         modelName: name,
         getApiClient: getMistralApiClient,
+        closeClient: authClient == null,
       );
     }
     return super.resolve(actionType, name);

--- a/packages/genkit_vertexai/test/mistral_test.dart
+++ b/packages/genkit_vertexai/test/mistral_test.dart
@@ -144,7 +144,6 @@ void main() {
           'topP': 0.9,
           'maxTokens': 256,
           'stop': 'END',
-          'n': 2,
           'presencePenalty': 0.1,
           'frequencyPenalty': 0.2,
           'randomSeed': 7,
@@ -171,7 +170,6 @@ void main() {
       expect(body, containsPair('top_p', 0.9));
       expect(body, containsPair('max_tokens', 256));
       expect(body, containsPair('stop', 'END'));
-      expect(body, containsPair('n', 2));
       expect(body, containsPair('presence_penalty', 0.1));
       expect(body, containsPair('frequency_penalty', 0.2));
       expect(body, containsPair('random_seed', 7));

--- a/packages/genkit_vertexai/test/mistral_test.dart
+++ b/packages/genkit_vertexai/test/mistral_test.dart
@@ -123,6 +123,82 @@ void main() {
       expect(mockClient.isClosed, isFalse);
     });
 
+    test('passes through supported Mistral chat parameters', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: mockClient,
+      );
+
+      final model = plugin.resolve('model', 'mistral-medium-3') as Action;
+      final req = ModelRequest(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+        config: {
+          'temperature': 0.2,
+          'topP': 0.9,
+          'maxTokens': 256,
+          'stop': 'END',
+          'n': 2,
+          'presencePenalty': 0.1,
+          'frequencyPenalty': 0.2,
+          'randomSeed': 7,
+          'safePrompt': true,
+          'toolChoice': {
+            'type': 'function',
+            'function': {'name': 'lookup'},
+          },
+          'parallelToolCalls': false,
+          'prediction': {'type': 'content', 'content': 'expected completion'},
+          'promptCacheKey': 'shared-prefix',
+          'metadata': {'traceId': 'abc'},
+          'guardrails': ['default'],
+          'promptMode': 'reasoning',
+          'reasoningEffort': 'high',
+          'responseFormat': {'type': 'json_schema'},
+        },
+      );
+
+      await model.run(req);
+
+      final body = jsonDecode(mockClient.lastBody!) as Map<String, dynamic>;
+      expect(body, containsPair('temperature', 0.2));
+      expect(body, containsPair('top_p', 0.9));
+      expect(body, containsPair('max_tokens', 256));
+      expect(body, containsPair('stop', 'END'));
+      expect(body, containsPair('n', 2));
+      expect(body, containsPair('presence_penalty', 0.1));
+      expect(body, containsPair('frequency_penalty', 0.2));
+      expect(body, containsPair('random_seed', 7));
+      expect(body, containsPair('safe_prompt', true));
+      expect(
+        body,
+        containsPair('tool_choice', {
+          'type': 'function',
+          'function': {'name': 'lookup'},
+        }),
+      );
+      expect(body, containsPair('parallel_tool_calls', false));
+      expect(
+        body,
+        containsPair('prediction', {
+          'type': 'content',
+          'content': 'expected completion',
+        }),
+      );
+      expect(body, containsPair('prompt_cache_key', 'shared-prefix'));
+      expect(body, containsPair('metadata', {'traceId': 'abc'}));
+      expect(body, containsPair('guardrails', ['default']));
+      expect(body, containsPair('prompt_mode', 'reasoning'));
+      expect(body, containsPair('reasoning_effort', 'high'));
+      expect(body, containsPair('response_format', {'type': 'json_schema'}));
+    });
+
     test('lists Mistral models dynamically', () async {
       final mockClient = MockHttpClient();
       final plugin = VertexAiPluginImpl(
@@ -135,7 +211,7 @@ void main() {
       final actionNames = actions.map((action) => action.name);
 
       expect(actionNames, contains('vertexai/mistral-small-2503'));
-      expect(actionNames, contains('vertexai/mistral-ocr-2505'));
+      expect(actionNames, isNot(contains('vertexai/mistral-ocr-2505')));
       expect(actionNames, isNot(contains('vertexai/mistral-medium-3')));
     });
   });

--- a/packages/genkit_vertexai/test/mistral_test.dart
+++ b/packages/genkit_vertexai/test/mistral_test.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 
 import 'package:genkit/genkit.dart';
+import 'package:genkit_vertexai/genkit_vertexai.dart';
 import 'package:genkit_vertexai/src/vertex_api_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
@@ -22,6 +23,7 @@ import 'package:test/test.dart';
 class MockHttpClient extends http.BaseClient {
   Uri? lastUrl;
   String? lastBody;
+  final streamRawPredictBodies = <Map<String, dynamic>>[];
   bool isClosed = false;
 
   @override
@@ -68,6 +70,66 @@ class MockHttpClient extends http.BaseClient {
       );
     }
 
+    if (request.url.path.endsWith(':streamRawPredict')) {
+      final body =
+          jsonDecode((request as http.Request).body) as Map<String, dynamic>;
+      streamRawPredictBodies.add(body);
+
+      if (streamRawPredictBodies.length == 1) {
+        return _streamResponse([
+          {
+            'choices': [
+              {
+                'delta': {
+                  'tool_calls': [
+                    {
+                      'index': 0,
+                      'id': 'call_123',
+                      'type': 'function',
+                      'function': {'name': 'calculator', 'arguments': '{"a":'},
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'choices': [
+              {
+                'delta': {
+                  'tool_calls': [
+                    {
+                      'index': 0,
+                      'function': {'arguments': '123,"b":456}'},
+                    },
+                  ],
+                },
+                'finish_reason': 'tool_calls',
+              },
+            ],
+          },
+        ]);
+      }
+
+      return _streamResponse([
+        {
+          'choices': [
+            {
+              'delta': {'content': '560'},
+            },
+          ],
+        },
+        {
+          'choices': [
+            {
+              'delta': {'content': '88'},
+              'finish_reason': 'stop',
+            },
+          ],
+        },
+      ]);
+    }
+
     if (request.url.path.endsWith(':rawPredict')) {
       return http.StreamedResponse(
         Stream.value(
@@ -81,6 +143,18 @@ class MockHttpClient extends http.BaseClient {
     }
 
     return http.StreamedResponse(Stream.value(utf8.encode('{}')), 404);
+  }
+
+  http.StreamedResponse _streamResponse(List<Map<String, dynamic>> chunks) {
+    return http.StreamedResponse(
+      Stream.fromIterable([
+        for (final chunk in chunks)
+          utf8.encode('data: ${jsonEncode(chunk)}\n\n'),
+        utf8.encode('data: [DONE]\n\n'),
+      ]),
+      200,
+      headers: {'content-type': 'text/event-stream'},
+    );
   }
 
   @override
@@ -211,6 +285,70 @@ void main() {
       expect(actionNames, contains('vertexai/mistral-small-2503'));
       expect(actionNames, isNot(contains('vertexai/mistral-ocr-2505')));
       expect(actionNames, isNot(contains('vertexai/mistral-medium-3')));
+    });
+
+    test('streams tool calls through the Genkit tool loop', () async {
+      final mockClient = MockHttpClient();
+      final ai = Genkit(
+        plugins: [
+          vertexAI(
+            projectId: 'my-project',
+            location: 'us-central1',
+            authClient: mockClient,
+          ),
+        ],
+      );
+
+      Map<String, dynamic>? toolInput;
+      final tool = ai.defineTool<Map<String, dynamic>, int>(
+        name: 'calculator',
+        description: 'Multiplies two numbers',
+        fn: (input, _) async {
+          toolInput = input;
+          return (input['a'] as int) * (input['b'] as int);
+        },
+      );
+
+      final stream = ai.generateStream(
+        model: vertexAI.mistral('mistral-small-2503'),
+        prompt: 'What is 123 * 456?',
+        tools: [tool],
+        config: MistralOptions(toolChoice: 'any'),
+        maxTurns: 3,
+      );
+
+      final chunks = await stream.toList();
+      final response = await stream.onResult;
+
+      expect(chunks.map((chunk) => chunk.text).join(), '56088');
+      expect(response.text, '56088');
+      expect(toolInput, {'a': 123, 'b': 456});
+      expect(mockClient.streamRawPredictBodies, hasLength(2));
+
+      final messages = mockClient.streamRawPredictBodies[1]['messages'] as List;
+      expect(messages.map((m) => (m as Map)['role']).toList(), [
+        'user',
+        'assistant',
+        'tool',
+      ]);
+
+      final assistantMessage = messages[1] as Map<String, dynamic>;
+      final toolCalls = assistantMessage['tool_calls'] as List;
+      final toolCall = toolCalls.single as Map<String, dynamic>;
+      expect(toolCall['id'], 'call_123');
+      expect(toolCall['type'], 'function');
+      expect((toolCall['function'] as Map)['name'], 'calculator');
+      expect(jsonDecode((toolCall['function'] as Map)['arguments'] as String), {
+        'a': 123,
+        'b': 456,
+      });
+
+      expect(messages[2], {
+        'role': 'tool',
+        'tool_call_id': 'call_123',
+        'name': 'calculator',
+        'content': '56088',
+      });
     });
   });
 }

--- a/packages/genkit_vertexai/test/mistral_test.dart
+++ b/packages/genkit_vertexai/test/mistral_test.dart
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_vertexai/src/vertex_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+class MockHttpClient extends http.BaseClient {
+  Uri? lastUrl;
+  String? lastBody;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    lastUrl = request.url;
+    if (request is http.Request) {
+      lastBody = request.body;
+    }
+
+    if (request.url.host == 'metadata.google.internal' ||
+        request.url.host == 'oauth2.googleapis.com') {
+      return http.StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            '{"access_token": "ya29.mock", "expires_in": 3600, "token_type": "Bearer"}',
+          ),
+        ),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+
+    if (request.url.path == '/v1beta1/publishers/google/models') {
+      return http.StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            '{"publisherModels": [{"name": "publishers/google/models/gemini-1.5-pro"}]}',
+          ),
+        ),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+
+    if (request.url.path == '/v1beta1/publishers/mistralai/models') {
+      return http.StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            '{"publisherModels": [{"name": "publishers/mistralai/models/mistral-small-2503"}, {"name": "publishers/mistralai/models/mistral-ocr-2505"}]}',
+          ),
+        ),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+
+    if (request.url.path.endsWith(':rawPredict')) {
+      return http.StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            '{"choices": [{"message": {"role": "assistant", "content": "response"}, "finish_reason": "stop"}]}',
+          ),
+        ),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+
+    return http.StreamedResponse(Stream.value(utf8.encode('{}')), 404);
+  }
+}
+
+void main() {
+  group('Mistral Vertex AI support', () {
+    test('uses correct endpoint for Mistral models', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: mockClient,
+      );
+
+      final model = plugin.resolve('model', 'mistral-small-2503') as Action;
+      final req = ModelRequest(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+      );
+
+      await model.run(req);
+
+      expect(mockClient.lastUrl, isNotNull);
+      expect(
+        mockClient.lastUrl.toString(),
+        'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/mistralai/models/mistral-small-2503:rawPredict',
+      );
+      expect(
+        jsonDecode(mockClient.lastBody!) as Map<String, dynamic>,
+        containsPair('model', 'mistral-small-2503'),
+      );
+    });
+
+    test('lists Mistral models dynamically', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: mockClient,
+      );
+
+      final actions = await plugin.list();
+      final actionNames = actions.map((action) => action.name);
+
+      expect(actionNames, contains('vertexai/mistral-small-2503'));
+      expect(actionNames, contains('vertexai/mistral-ocr-2505'));
+      expect(actionNames, isNot(contains('vertexai/mistral-medium-3')));
+    });
+  });
+}

--- a/packages/genkit_vertexai/test/mistral_test.dart
+++ b/packages/genkit_vertexai/test/mistral_test.dart
@@ -22,6 +22,7 @@ import 'package:test/test.dart';
 class MockHttpClient extends http.BaseClient {
   Uri? lastUrl;
   String? lastBody;
+  bool isClosed = false;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
@@ -81,6 +82,11 @@ class MockHttpClient extends http.BaseClient {
 
     return http.StreamedResponse(Stream.value(utf8.encode('{}')), 404);
   }
+
+  @override
+  void close() {
+    isClosed = true;
+  }
 }
 
 void main() {
@@ -114,6 +120,7 @@ void main() {
         jsonDecode(mockClient.lastBody!) as Map<String, dynamic>,
         containsPair('model', 'mistral-small-2503'),
       );
+      expect(mockClient.isClosed, isFalse);
     });
 
     test('lists Mistral models dynamically', () async {

--- a/packages/genkit_vertexai/test/test_live.dart
+++ b/packages/genkit_vertexai/test/test_live.dart
@@ -43,8 +43,10 @@ void main() {
         name: 'Vertex AI',
         plugin: vertexAI(projectId: projectId, location: location),
         gemini: vertexAI.gemini,
+        mistral: vertexAI.mistral,
         textEmbedding: vertexAI.textEmbedding,
         modelName: 'gemini-2.5-flash',
+        mistralModelName: 'mistral-small-2503',
         embedderName: 'gemini-embedding-001',
       ),
   ];
@@ -83,6 +85,22 @@ void main() {
         final response = ai.generateStream(
           model: config.gemini(config.modelName),
           prompt: 'Count to 15',
+        );
+
+        final chunks = await response.toList();
+        expect(chunks.length, greaterThan(1));
+        final fullText = chunks.map((c) => c.text).join();
+        expect(fullText, contains('5'));
+
+        final finalResponse = await response.onResult;
+        expect(finalResponse.text, contains('5'));
+      });
+
+      test('should stream text with Mistral', () async {
+        final response = ai.generateStream(
+          model: config.mistral(config.mistralModelName),
+          prompt: 'Count to 15. Return only the numbers.',
+          config: MistralOptions(temperature: 0),
         );
 
         final chunks = await response.toList();
@@ -135,6 +153,33 @@ void main() {
         );
 
         expect(response.text, contains('56088')); // 123*456 = 56088
+      });
+
+      test('should use tools with Mistral', () async {
+        final tool = ai.defineTool(
+          name: 'calculator',
+          description: 'Multiplies two numbers',
+          inputSchema: CalculatorInput.$schema,
+          outputSchema: .integer(),
+          fn: (CalculatorInput input, _) async => input.a * input.b,
+        );
+
+        final response = await ai.generate(
+          model: config.mistral(config.mistralModelName),
+          prompt: 'Use the calculator tool to multiply 123 by 456.',
+          tools: [tool],
+          config: MistralOptions(temperature: 0, toolChoice: 'any'),
+          maxTurns: 3,
+        );
+
+        final digitsOnly = response.text.replaceAll(RegExp(r'[^0-9]'), '');
+        expect(digitsOnly, contains('56088')); // 123*456 = 56088
+        expect(response.messages.map((m) => m.role), [
+          'user',
+          'model',
+          'tool',
+          'model',
+        ]);
       });
 
       test('should embed text', () async {


### PR DESCRIPTION
Add support for Mistral models in VertexAI plugin.

## Testing

<img width="1379" height="780" alt="Screenshot 2026-04-27 at 17 26 12" src="https://github.com/user-attachments/assets/697de77d-3156-4bb9-9ba8-7fb39c3d5a17" />
|
<img width="1379" height="780" alt="Screenshot 2026-04-27 at 17 26 59" src="https://github.com/user-attachments/assets/bc9136d2-3278-485b-bb3a-7bb093565404" />
|
<img width="1379" height="780" alt="Screenshot 2026-04-27 at 17 37 45" src="https://github.com/user-attachments/assets/f4d048a3-5299-4ffa-b3b7-b96117213655" />

**Note:** Supports more params now than in the screenshots.