### PR TITLE
feat(vertexai): tuned models (endpoints/YOUR_ENDPOINT_ID)

### DIFF
--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -40,13 +40,19 @@ final commonModelInfo = ModelInfo(
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
 
+  Future<GenerativeLanguageBaseClient> clientForModel(
+    String modelName,
+    String? apiKey, {
+    String? apiModelName,
+  }) {
+    return getApiClient(apiKey);
+  }
+
   Model createModel(
     String modelName,
     SchemanticType customOptions, {
     String? actionName,
     String? apiModelName,
-    Future<GenerativeLanguageBaseClient> Function(String? apiKey)?
-    getApiClientOverride,
   }) {
     return Model(
       name: '$name/${actionName ?? modelName}',
@@ -99,9 +105,12 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         }
 
-        final service =
-            await (getApiClientOverride?.call(apiKey) ?? getApiClient(apiKey));
         final resolvedApiModelName = apiModelName ?? 'models/$modelName';
+        final service = await clientForModel(
+          modelName,
+          apiKey,
+          apiModelName: resolvedApiModelName,
+        );
 
         try {
           final systemMessage = req.messages

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -40,9 +40,16 @@ final commonModelInfo = ModelInfo(
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
 
-  Model createModel(String modelName, SchemanticType customOptions) {
+  Model createModel(
+    String modelName,
+    SchemanticType customOptions, {
+    String? actionName,
+    String? apiModelName,
+    Future<GenerativeLanguageBaseClient> Function(String? apiKey)?
+    getApiClientOverride,
+  }) {
     return Model(
-      name: '$name/$modelName',
+      name: '$name/${actionName ?? modelName}',
       customOptions: customOptions,
       metadata: {'model': commonModelInfo.toJson()},
       fn: (req, ctx) async {
@@ -92,7 +99,9 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         }
 
-        final service = await getApiClient(apiKey);
+        final service =
+            await (getApiClientOverride?.call(apiKey) ?? getApiClient(apiKey));
+        final resolvedApiModelName = apiModelName ?? 'models/$modelName';
 
         try {
           final systemMessage = req.messages
@@ -121,7 +130,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           if (ctx.streamingRequested) {
             final stream = service.streamGenerateContent(
               generateRequest,
-              model: 'models/$modelName',
+              model: resolvedApiModelName,
             );
             final chunks = <gcl.GenerateContentResponse>[];
             await for (final chunk in stream) {
@@ -154,7 +163,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
           } else {
             final response = await service.generateContent(
               generateRequest,
-              model: 'models/$modelName',
+              model: resolvedApiModelName,
             );
             if (response.candidates?.isEmpty ?? true) {
               final blockReason = response.promptFeedback?.blockReason;

--- a/packages/genkit_vertexai/lib/genkit_vertexai.dart
+++ b/packages/genkit_vertexai/lib/genkit_vertexai.dart
@@ -53,6 +53,13 @@ class VertexAiPluginHandle {
     return modelRef('vertexai/$name', customOptions: GeminiOptions.$schema);
   }
 
+  ModelRef<GeminiOptions> tunedModel(String endpointId) {
+    final name = endpointId.startsWith('endpoints/')
+        ? endpointId
+        : 'endpoints/$endpointId';
+    return modelRef('vertexai/$name', customOptions: GeminiOptions.$schema);
+  }
+
   EmbedderRef<TextEmbedderOptions> textEmbedding(String name) {
     return embedderRef(
       'vertexai/$name',

--- a/packages/genkit_vertexai/lib/genkit_vertexai.dart
+++ b/packages/genkit_vertexai/lib/genkit_vertexai.dart
@@ -41,11 +41,13 @@ class VertexAiPluginHandle {
     String? projectId,
     String? location,
     http.Client? authClient,
+    List<String> tunedModelEndpoints = const [],
   }) {
     return VertexAiPluginImpl(
       projectId: projectId,
       location: location,
       authClient: authClient,
+      tunedModelEndpoints: tunedModelEndpoints,
     );
   }
 

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -88,7 +88,7 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   }
 
   Future<GenerativeLanguageBaseClient> getEndpointApiClient() async {
-    return _createVertexApiClient(apiVersion: 'v1');
+    return _createVertexApiClient(apiVersion: 'v1beta1');
   }
 
   @override

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -100,6 +100,18 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   }
 
   @override
+  Future<GenerativeLanguageBaseClient> clientForModel(
+    String modelName,
+    String? apiKey, {
+    String? apiModelName,
+  }) {
+    if (apiModelName?.startsWith('endpoints/') == true) {
+      return getEndpointApiClient();
+    }
+    return getApiClient(apiKey);
+  }
+
+  @override
   Future<List<ActionMetadata<dynamic, dynamic, dynamic, dynamic>>>
   list() async {
     final service = await getApiClient();
@@ -231,7 +243,6 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
       GeminiOptions.$schema,
       actionName: 'endpoints/$endpointId',
       apiModelName: 'endpoints/$safeEndpointId',
-      getApiClientOverride: (_) => getEndpointApiClient(),
     );
   }
 

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -41,7 +41,8 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   String get name => 'vertexai';
 
   Future<GenerativeLanguageBaseClient> _createVertexApiClient({
-    required String apiUrlPrefix,
+    required String apiVersion,
+    String pathSuffix = '',
   }) async {
     final validFormat = RegExp(r'^[a-z0-9-]+$');
     final resolvedProjectId = _getResolvedProjectId;
@@ -52,12 +53,15 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
       throw ArgumentError('Invalid projectId or location format.');
     }
     final safeLocation = Uri.encodeComponent(resolvedLocation);
+    final safeProjectId = Uri.encodeComponent(resolvedProjectId);
 
     final tokenProvider = createAdcAccessTokenProvider(baseClient: authClient);
 
     final baseUrl = safeLocation == 'global'
         ? 'https://aiplatform.googleapis.com/'
         : 'https://$safeLocation-aiplatform.googleapis.com/';
+    final apiUrlPrefix =
+        '$apiVersion/projects/$safeProjectId/locations/$safeLocation/$pathSuffix';
 
     final headers = {'X-Goog-Api-Client': googleApiClientHeaderValue()};
     final customClient = CustomClient(
@@ -77,38 +81,14 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([
     String? requestApiKey,
   ]) async {
-    final validFormat = RegExp(r'^[a-z0-9-]+$');
-    final resolvedProjectId = _getResolvedProjectId;
-    final resolvedLocation = location ?? 'global';
-
-    if (!validFormat.hasMatch(resolvedLocation) ||
-        !validFormat.hasMatch(resolvedProjectId)) {
-      throw ArgumentError('Invalid projectId or location format.');
-    }
-    final safeLocation = Uri.encodeComponent(resolvedLocation);
-    final safeProjectId = Uri.encodeComponent(resolvedProjectId);
-
     return _createVertexApiClient(
-      apiUrlPrefix:
-          'v1beta1/projects/$safeProjectId/locations/$safeLocation/publishers/google/',
+      apiVersion: 'v1beta1',
+      pathSuffix: 'publishers/google/',
     );
   }
 
   Future<GenerativeLanguageBaseClient> getEndpointApiClient() async {
-    final validFormat = RegExp(r'^[a-z0-9-]+$');
-    final resolvedProjectId = _getResolvedProjectId;
-    final resolvedLocation = location ?? 'global';
-
-    if (!validFormat.hasMatch(resolvedLocation) ||
-        !validFormat.hasMatch(resolvedProjectId)) {
-      throw ArgumentError('Invalid projectId or location format.');
-    }
-    final safeLocation = Uri.encodeComponent(resolvedLocation);
-    final safeProjectId = Uri.encodeComponent(resolvedProjectId);
-
-    return _createVertexApiClient(
-      apiUrlPrefix: 'v1/projects/$safeProjectId/locations/$safeLocation/',
-    );
+    return _createVertexApiClient(apiVersion: 'v1');
   }
 
   @override

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -20,6 +20,11 @@ import 'package:meta/meta.dart';
 
 import 'auth.dart';
 
+const _vertexApiVersion = 'v1beta1';
+
+@visibleForTesting
+const vertexApiVersion = _vertexApiVersion;
+
 @visibleForTesting
 class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   String? projectId;
@@ -47,7 +52,7 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   String get name => 'vertexai';
 
   Future<GenerativeLanguageBaseClient> _createVertexApiClient({
-    required String apiVersion,
+    String apiVersion = _vertexApiVersion,
     String pathSuffix = '',
   }) async {
     final validFormat = RegExp(r'^[a-z0-9-]+$');
@@ -87,14 +92,11 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([
     String? requestApiKey,
   ]) async {
-    return _createVertexApiClient(
-      apiVersion: 'v1beta1',
-      pathSuffix: 'publishers/google/',
-    );
+    return _createVertexApiClient(pathSuffix: 'publishers/google/');
   }
 
   Future<GenerativeLanguageBaseClient> getEndpointApiClient() async {
-    return _createVertexApiClient(apiVersion: 'v1beta1');
+    return _createVertexApiClient();
   }
 
   @override

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -40,6 +40,39 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   @override
   String get name => 'vertexai';
 
+  Future<GenerativeLanguageBaseClient> _createVertexApiClient({
+    required String apiUrlPrefix,
+  }) async {
+    final validFormat = RegExp(r'^[a-z0-9-]+$');
+    final resolvedProjectId = _getResolvedProjectId;
+    final resolvedLocation = location ?? 'global';
+
+    if (!validFormat.hasMatch(resolvedLocation) ||
+        !validFormat.hasMatch(resolvedProjectId)) {
+      throw ArgumentError('Invalid projectId or location format.');
+    }
+    final safeLocation = Uri.encodeComponent(resolvedLocation);
+
+    final tokenProvider = createAdcAccessTokenProvider(baseClient: authClient);
+
+    final baseUrl = safeLocation == 'global'
+        ? 'https://aiplatform.googleapis.com/'
+        : 'https://$safeLocation-aiplatform.googleapis.com/';
+
+    final headers = {'X-Goog-Api-Client': googleApiClientHeaderValue()};
+    final customClient = CustomClient(
+      defaultHeaders: headers,
+      inner: authClient,
+    );
+    final client = VertexAuthClient(tokenProvider, inner: customClient);
+
+    return GenerativeLanguageBaseClient(
+      baseUrl: baseUrl,
+      client: client,
+      apiUrlPrefix: apiUrlPrefix,
+    );
+  }
+
   @override
   Future<GenerativeLanguageBaseClient> getApiClient([
     String? requestApiKey,
@@ -55,25 +88,26 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
     final safeLocation = Uri.encodeComponent(resolvedLocation);
     final safeProjectId = Uri.encodeComponent(resolvedProjectId);
 
-    final tokenProvider = createAdcAccessTokenProvider(baseClient: authClient);
-
-    final baseUrl = safeLocation == 'global'
-        ? 'https://aiplatform.googleapis.com/'
-        : 'https://$safeLocation-aiplatform.googleapis.com/';
-    final apiUrlPrefix =
-        'v1beta1/projects/$safeProjectId/locations/$safeLocation/publishers/google/';
-
-    final headers = {'X-Goog-Api-Client': googleApiClientHeaderValue()};
-    final customClient = CustomClient(
-      defaultHeaders: headers,
-      inner: authClient,
+    return _createVertexApiClient(
+      apiUrlPrefix:
+          'v1beta1/projects/$safeProjectId/locations/$safeLocation/publishers/google/',
     );
-    final client = VertexAuthClient(tokenProvider, inner: customClient);
+  }
 
-    return GenerativeLanguageBaseClient(
-      baseUrl: baseUrl,
-      client: client,
-      apiUrlPrefix: apiUrlPrefix,
+  Future<GenerativeLanguageBaseClient> getEndpointApiClient() async {
+    final validFormat = RegExp(r'^[a-z0-9-]+$');
+    final resolvedProjectId = _getResolvedProjectId;
+    final resolvedLocation = location ?? 'global';
+
+    if (!validFormat.hasMatch(resolvedLocation) ||
+        !validFormat.hasMatch(resolvedProjectId)) {
+      throw ArgumentError('Invalid projectId or location format.');
+    }
+    final safeLocation = Uri.encodeComponent(resolvedLocation);
+    final safeProjectId = Uri.encodeComponent(resolvedProjectId);
+
+    return _createVertexApiClient(
+      apiUrlPrefix: 'v1/projects/$safeProjectId/locations/$safeLocation/',
     );
   }
 
@@ -189,5 +223,27 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
         }
       },
     );
+  }
+
+  Model createTunedModel(String endpointName) {
+    final endpointId = endpointName.startsWith('endpoints/')
+        ? endpointName.substring('endpoints/'.length)
+        : endpointName;
+    final safeEndpointId = Uri.encodeComponent(endpointId);
+    return createModel(
+      endpointId,
+      GeminiOptions.$schema,
+      actionName: 'endpoints/$endpointId',
+      apiModelName: 'endpoints/$safeEndpointId',
+      getApiClientOverride: (_) => getEndpointApiClient(),
+    );
+  }
+
+  @override
+  Action? resolve(String actionType, String name) {
+    if (actionType == 'model' && name.startsWith('endpoints/')) {
+      return createTunedModel(name);
+    }
+    return super.resolve(actionType, name);
   }
 }

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -25,8 +25,14 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   String? projectId;
   String? location;
   http.Client? authClient;
+  List<String> tunedModelEndpoints;
 
-  VertexAiPluginImpl({this.projectId, this.location, this.authClient});
+  VertexAiPluginImpl({
+    this.projectId,
+    this.location,
+    this.authClient,
+    this.tunedModelEndpoints = const [],
+  });
 
   String? _resolvedProjectId;
   String get _getResolvedProjectId =>
@@ -136,7 +142,17 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
           })
           .toList();
 
-      return [...models, ...embedders];
+      final tunedModels = tunedModelEndpoints
+          .map(
+            (endpointName) => modelMetadata(
+              _endpointActionName(endpointName),
+              customOptions: GeminiOptions.$schema,
+              modelInfo: commonModelInfo,
+            ),
+          )
+          .toList();
+
+      return [...models, ...tunedModels, ...embedders];
     } catch (e, stack) {
       if (e is GenkitException) rethrow;
       logger.warning('Failed to list models: $e', e, stack);
@@ -206,9 +222,7 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   }
 
   Model createTunedModel(String endpointName) {
-    final endpointId = endpointName.startsWith('endpoints/')
-        ? endpointName.substring('endpoints/'.length)
-        : endpointName;
+    final endpointId = _endpointId(endpointName);
     final safeEndpointId = Uri.encodeComponent(endpointId);
     return createModel(
       endpointId,
@@ -226,4 +240,14 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
     }
     return super.resolve(actionType, name);
   }
+}
+
+String _endpointId(String endpointName) {
+  return endpointName.startsWith('endpoints/')
+      ? endpointName.substring('endpoints/'.length)
+      : endpointName;
+}
+
+String _endpointActionName(String endpointName) {
+  return 'vertexai/endpoints/${_endpointId(endpointName)}';
 }

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 
 import 'package:genkit/genkit.dart';
+import 'package:genkit_vertexai/genkit_vertexai.dart';
 
 import 'package:genkit_vertexai/src/vertex_api_client.dart';
 import 'package:http/http.dart' as http;
@@ -103,6 +104,44 @@ void main() {
       expect(
         mockClient.lastUrl.toString(),
         'https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-1.5-pro:generateContent',
+      );
+    });
+
+    test('uses tuned model endpoint path', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: mockClient,
+      );
+
+      final model = plugin.resolve('model', 'endpoints/123456789') as Action;
+      final req = ModelRequest(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hello')],
+          ),
+        ],
+      );
+
+      await model.run(req);
+
+      expect(mockClient.lastUrl, isNotNull);
+      expect(
+        mockClient.lastUrl.toString(),
+        'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/endpoints/123456789:generateContent',
+      );
+    });
+
+    test('creates tuned model refs under endpoints path', () {
+      expect(
+        vertexAI.tunedModel('123456789').name,
+        'vertexai/endpoints/123456789',
+      );
+      expect(
+        vertexAI.tunedModel('endpoints/123456789').name,
+        'vertexai/endpoints/123456789',
       );
     });
   });

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -144,5 +144,23 @@ void main() {
         'vertexai/endpoints/123456789',
       );
     });
+
+    test('lists configured tuned model endpoint refs', () async {
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: MockHttpClient(),
+        tunedModelEndpoints: ['123456789', 'endpoints/987654321'],
+      );
+
+      final actions = await plugin.list();
+      final modelNames = actions
+          .where((action) => action.actionType == 'model')
+          .map((action) => action.name)
+          .toList();
+
+      expect(modelNames, contains('vertexai/endpoints/123456789'));
+      expect(modelNames, contains('vertexai/endpoints/987654321'));
+    });
   });
 }

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -130,7 +130,7 @@ void main() {
       expect(mockClient.lastUrl, isNotNull);
       expect(
         mockClient.lastUrl.toString(),
-        'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/endpoints/123456789:generateContent',
+        'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/123456789:generateContent',
       );
     });
 

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(mockClient.lastUrl, isNotNull);
       expect(
         mockClient.lastUrl.toString(),
-        'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent',
+        'https://us-central1-aiplatform.googleapis.com/$vertexApiVersion/projects/my-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent',
       );
     });
 
@@ -103,7 +103,7 @@ void main() {
       expect(mockClient.lastUrl, isNotNull);
       expect(
         mockClient.lastUrl.toString(),
-        'https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-1.5-pro:generateContent',
+        'https://aiplatform.googleapis.com/$vertexApiVersion/projects/my-project/locations/global/publishers/google/models/gemini-1.5-pro:generateContent',
       );
     });
 
@@ -130,7 +130,7 @@ void main() {
       expect(mockClient.lastUrl, isNotNull);
       expect(
         mockClient.lastUrl.toString(),
-        'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/123456789:generateContent',
+        'https://us-central1-aiplatform.googleapis.com/$vertexApiVersion/projects/my-project/locations/us-central1/endpoints/123456789:generateContent',
       );
     });
 

--- a/testapps/gemini/bin/vertexai.dart
+++ b/testapps/gemini/bin/vertexai.dart
@@ -20,6 +20,26 @@ import 'package:genkit_vertexai/genkit_vertexai.dart';
 
 import 'src/model.dart';
 
+const _vertexAiTunedModelEndpointIdEnvVar = 'VERTEX_AI_TUNED_MODEL_ENDPOINT_ID';
+
+String _vertexAiTunedModelEndpointId() {
+  final endpointId = Platform.environment[_vertexAiTunedModelEndpointIdEnvVar];
+  if (endpointId == null || endpointId.isEmpty) {
+    throw StateError(
+      'Set $_vertexAiTunedModelEndpointIdEnvVar to an endpoint ID or '
+      'endpoints/ENDPOINT_ID to test Vertex AI tuned model flows.',
+    );
+  }
+  return endpointId;
+}
+
+String _vertexAiTunedModelName() {
+  final endpointId = _vertexAiTunedModelEndpointId();
+  return endpointId.startsWith('endpoints/')
+      ? endpointId
+      : 'endpoints/$endpointId';
+}
+
 void main(List<String> args) async {
   final ai = Genkit(
     plugins: [
@@ -39,6 +59,150 @@ void main(List<String> args) async {
       final response = await ai.generate(
         model: vertexAI.gemini('gemini-2.5-flash'),
         prompt: input,
+      );
+      return response.text;
+    },
+  );
+
+  // --- Tuned Model Flow ---
+  ai.defineFlow(
+    name: 'tunedModelGenerate',
+    inputSchema: .string(defaultValue: 'Hello from a Vertex AI tuned model!'),
+    outputSchema: .string(),
+    fn: (prompt, _) async {
+      final response = await ai.generate(
+        model: vertexAI.tunedModel(_vertexAiTunedModelEndpointId()),
+        prompt: prompt,
+        config: GeminiOptions(maxOutputTokens: 256, temperature: 0.2),
+      );
+      return response.text;
+    },
+  );
+
+  // --- Tuned Model Resolution Flow ---
+  ai.defineFlow(
+    name: 'tunedModelResolveGenerate',
+    inputSchema: .string(
+      defaultValue:
+          'Confirm this endpoint resolves through the model registry.',
+    ),
+    outputSchema: .string(),
+    fn: (prompt, _) async {
+      final response = await ai.generate(
+        model: modelRef(
+          'vertexai/${_vertexAiTunedModelName()}',
+          customOptions: GeminiOptions.$schema,
+        ),
+        prompt: prompt,
+        config: GeminiOptions(maxOutputTokens: 256, temperature: 0.2),
+      );
+      return response.text;
+    },
+  );
+
+  // --- Tuned Model Streaming Flow ---
+  ai.defineFlow(
+    name: 'tunedModelStreaming',
+    inputSchema: .string(
+      defaultValue: 'Stream a short greeting from this tuned model.',
+    ),
+    outputSchema: .string(),
+    streamSchema: .string(),
+    fn: (prompt, ctx) async {
+      final stream = ai.generateStream(
+        model: vertexAI.tunedModel(_vertexAiTunedModelEndpointId()),
+        prompt: prompt,
+        config: GeminiOptions(maxOutputTokens: 256, temperature: 0.2),
+      );
+
+      await for (final chunk in stream) {
+        if (ctx.streamingRequested) {
+          ctx.sendChunk(chunk.text);
+        }
+      }
+
+      return (await stream.onResult).text;
+    },
+  );
+
+  // --- Tuned Model Summarization Flow ---
+  ai.defineFlow(
+    name: 'tunedModelSummarize',
+    inputSchema: .string(
+      defaultValue:
+          'Genkit helps developers build AI-powered applications by providing '
+          'model plugins, flows, tools, streaming, and structured output in a '
+          'single framework. Summarize this for a teammate.',
+    ),
+    outputSchema: .string(),
+    fn: (prompt, _) async {
+      final response = await ai.generate(
+        model: vertexAI.tunedModel(_vertexAiTunedModelEndpointId()),
+        prompt: 'Summarize this in 3 concise bullets:\n\n$prompt',
+        config: GeminiOptions(maxOutputTokens: 256, temperature: 0.2),
+      );
+      return response.text;
+    },
+  );
+
+  // --- Tuned Model Comparison Flow ---
+  ai.defineFlow(
+    name: 'tunedModelCompareBase',
+    inputSchema: .string(
+      defaultValue:
+          'Explain why endpoint support matters for Vertex AI tuned models.',
+    ),
+    outputSchema: .map(.string(), .string()),
+    fn: (prompt, _) async {
+      final baseResponse = await ai.generate(
+        model: vertexAI.gemini('gemini-2.5-flash-lite'),
+        prompt: prompt,
+        config: GeminiOptions(maxOutputTokens: 256, temperature: 0.2),
+      );
+      final tunedResponse = await ai.generate(
+        model: vertexAI.tunedModel(_vertexAiTunedModelEndpointId()),
+        prompt: prompt,
+        config: GeminiOptions(maxOutputTokens: 256, temperature: 0.2),
+      );
+      return {'base': baseResponse.text, 'tuned': tunedResponse.text};
+    },
+  );
+
+  // --- Tuned Model Multi-turn Flow ---
+  ai.defineFlow(
+    name: 'tunedModelMultiTurn',
+    inputSchema: .string(defaultValue: 'Now make that answer more concise.'),
+    outputSchema: .string(),
+    fn: (followUp, _) async {
+      final response = await ai.generate(
+        model: vertexAI.tunedModel(_vertexAiTunedModelEndpointId()),
+        messages: [
+          Message(
+            role: Role.user,
+            content: [
+              TextPart(
+                text:
+                    'Summarize why Genkit flows are useful for testing model '
+                    'integrations.',
+              ),
+            ],
+          ),
+          Message(
+            role: Role.model,
+            content: [
+              TextPart(
+                text:
+                    'Genkit flows provide repeatable entry points for manual '
+                    'and automated model testing.',
+              ),
+            ],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: followUp)],
+          ),
+        ],
+        config: GeminiOptions(maxOutputTokens: 256, temperature: 0.2),
       );
       return response.text;
     },


### PR DESCRIPTION
This pull request adds support for Vertex AI tuned models (custom endpoints) in the `genkit_vertexai` package, allowing users to call models deployed to Vertex AI endpoints. It introduces new methods for creating and resolving tuned model actions, refactors API client creation for flexibility, and includes tests to validate the new functionality.

## Testing
<img width="1299" height="886" alt="image" src="https://github.com/user-attachments/assets/2fa1b280-9421-47ea-8fe6-ad28654acfa1" />