### PR TITLE
feat(core)!: introduce GenerateTurnState to middleware generate hook and improve chunk indexing

### DIFF
--- a/packages/genkit/lib/plugin.dart
+++ b/packages/genkit/lib/plugin.dart
@@ -27,6 +27,7 @@ export 'package:genkit/src/ai/generate_middleware.dart'
         GenerateMiddleware,
         GenerateMiddlewareDef,
         GenerateMiddlewareRef,
+        GenerateTurnState,
         defineMiddleware,
         middlewareRef;
 export 'package:genkit/src/ai/generate_types.dart'

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -218,12 +218,10 @@ Future<GenerateResponseHelper> _runGenerateLoop(
   GenerateActionOptions options,
   ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx, {
   required List<GenerateMiddleware> resolvedMiddleware,
-  required Future<GenerateResponseHelper> Function(
-    GenerateActionOptions opts,
-    int currentTurn,
-  )
+  required Future<GenerateResponseHelper> Function(GenerateTurnState envelope)
   composedGenerate,
   int currentTurn = 0,
+  int messageIndex = 0,
 }) async {
   if (options.model == null) {
     throw GenkitException(
@@ -315,15 +313,26 @@ Future<GenerateResponseHelper> _runGenerateLoop(
     currentRequest = resumed.request!;
   }
 
+  var currentChunkRole = Role.model;
+  var modelHasSentChunks = false;
+
   // Execute model with middleware
   var response = await composedModel(currentRequest, (
     streamingRequested: ctx.streamingRequested,
     sendChunk: (chunk) {
+      final currentRole = chunk.role ?? Role.model;
+      if (currentRole != currentChunkRole &&
+          (messageIndex > 0 || modelHasSentChunks)) {
+        messageIndex++;
+      }
+      currentChunkRole = currentRole;
+      modelHasSentChunks = true;
+
       ctx.sendChunk(
         ModelResponseChunk(
-          index: currentTurn, // Use currentTurn to indicate the loop iteration
+          index: chunk.index ?? messageIndex,
           content: chunk.content,
-          role: chunk.role,
+          role: currentChunkRole,
           custom: chunk.custom,
           aggregated: chunk.aggregated,
         ),
@@ -402,7 +411,11 @@ Future<GenerateResponseHelper> _runGenerateLoop(
   );
 
   // Recursively call composedGenerate for the next turn
-  return composedGenerate(nextOptions, currentTurn + 1);
+  return composedGenerate((
+    request: nextOptions,
+    currentTurn: currentTurn + 1,
+    messageIndex: messageIndex + 2,
+  ));
 }
 
 Future<GenerateResponseHelper> runGenerateAction(
@@ -458,17 +471,17 @@ Future<GenerateResponseHelper> _runGenerateAction(
   final resolvedMiddleware = resolved.middleware;
 
   late Future<GenerateResponseHelper> Function(
-    GenerateActionOptions opts,
+    GenerateTurnState envelope,
     ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> c,
-    int currentTurn,
   )
   composedGenerate;
 
   Future<GenerateResponseHelper> coreGenerate(
-    GenerateActionOptions opts,
+    GenerateTurnState envelope,
     ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> c,
-    int currentTurn,
   ) async {
+    var opts = envelope.request;
+    final currentTurn = envelope.currentTurn;
     final resumeRestart = opts.resume?.restart ?? [];
     final toolStatus = <String, _ToolStatus>{};
 
@@ -532,7 +545,11 @@ Future<GenerateResponseHelper> _runGenerateAction(
         ),
       );
 
-      return composedGenerate(opts, c, currentTurn);
+      return composedGenerate((
+        request: opts,
+        currentTurn: currentTurn,
+        messageIndex: envelope.messageIndex,
+      ), c);
     }
 
     return _runGenerateLoop(
@@ -540,19 +557,23 @@ Future<GenerateResponseHelper> _runGenerateAction(
       opts,
       c,
       resolvedMiddleware: resolvedMiddleware,
-      composedGenerate: (opt, ct) => composedGenerate(opt, c, ct),
+      composedGenerate: (env) => composedGenerate(env, c),
       currentTurn: currentTurn,
+      messageIndex: envelope.messageIndex,
     );
   }
 
   composedGenerate = resolvedMiddleware.reversed.fold(
     coreGenerate,
-    // Add currentTurn here since GenerateMiddleware.generate doesn't take it!
     (next, mw) =>
-        (o, c, ct) => mw.generate(o, c, (no, nctx) => next(no, nctx, ct)),
+        (env, c) => mw.generate(env, c, (nenv, nctx) => next(nenv, nctx)),
   );
 
-  return composedGenerate(options, ctx, 0);
+  return composedGenerate((
+    request: options,
+    currentTurn: 0,
+    messageIndex: 0,
+  ), ctx);
 }
 
 typedef GenerateMiddlewareOneof = ({

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -321,10 +321,7 @@ Future<GenerateResponseHelper> _runGenerateLoop(
     streamingRequested: ctx.streamingRequested,
     sendChunk: (chunk) {
       final currentRole = chunk.role ?? Role.model;
-      if (currentRole != currentChunkRole &&
-          (messageIndex > 0 || modelHasSentChunks)) {
-        messageIndex++;
-      }
+      if (currentRole != currentChunkRole && modelHasSentChunks) messageIndex++;
       currentChunkRole = currentRole;
       modelHasSentChunks = true;
 

--- a/packages/genkit/lib/src/ai/generate_middleware.dart
+++ b/packages/genkit/lib/src/ai/generate_middleware.dart
@@ -19,6 +19,13 @@ import '../types.dart';
 import 'generate_types.dart';
 import 'tool.dart';
 
+/// Envelope for the processing of a Generation request in middleware.
+typedef GenerateTurnState = ({
+  GenerateActionOptions request,
+  int currentTurn,
+  int messageIndex,
+});
+
 /// Middleware for the processing of a Generation request.
 abstract class GenerateMiddleware {
   /// Middleware can act as a "kit" by providing tools directly.
@@ -31,15 +38,15 @@ abstract class GenerateMiddleware {
   ///
   /// [next] is the function to call to proceed with the generation.
   Future<GenerateResponseHelper> generate(
-    GenerateActionOptions options,
+    GenerateTurnState envelope,
     ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     Future<GenerateResponseHelper> Function(
-      GenerateActionOptions options,
+      GenerateTurnState envelope,
       ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     )
     next,
   ) {
-    return next(options, ctx);
+    return next(envelope, ctx);
   }
 
   /// Middleware for the raw model call.

--- a/packages/genkit/test/ai/generate_stream_test.dart
+++ b/packages/genkit/test/ai/generate_stream_test.dart
@@ -116,6 +116,100 @@ void main() {
       expect(chunks[2].index, 2, reason: 'Chunk of second turn should be 2');
     });
 
+    test(
+      'should not increment messageIndex on first chunk of a turn even if role differs',
+      () async {
+        const modelName = 'multiTurnRoleModel';
+        const toolName = 'dummyTool';
+
+        genkit.defineModel(
+          name: modelName,
+          fn: (request, context) async {
+            if (request.messages.length == 1) {
+              context.sendChunk(
+                ModelResponseChunk(
+                  content: [
+                    ToolRequestPart(
+                      toolRequest: ToolRequest(name: toolName, input: {}),
+                    ),
+                  ],
+                ),
+              );
+
+              return ModelResponse(
+                finishReason: FinishReason.stop,
+                message: Message(
+                  role: Role.model,
+                  content: [
+                    ToolRequestPart(
+                      toolRequest: ToolRequest(name: toolName, input: {}),
+                    ),
+                  ],
+                ),
+              );
+            } else {
+              // Second turn: messageIndex should be 2.
+              // If we send a chunk with a role other than Role.model,
+              // it should NOT increment messageIndex if it's the first chunk of the turn.
+              context.sendChunk(
+                ModelResponseChunk(
+                  role: Role.tool,
+                  content: [TextPart(text: 'Injected tool chunk')],
+                ),
+              );
+              context.sendChunk(
+                ModelResponseChunk(
+                  role: Role.model,
+                  content: [TextPart(text: 'Done')],
+                ),
+              );
+
+              return ModelResponse(
+                finishReason: FinishReason.stop,
+                message: Message(
+                  role: Role.model,
+                  content: [TextPart(text: 'Done')],
+                ),
+              );
+            }
+          },
+        );
+
+        genkit.defineTool(
+          name: toolName,
+          description: 'Dummy tool',
+          inputSchema: .map(.string(), .dynamicSchema()),
+          fn: (input, context) async {
+            return 'tool output';
+          },
+        );
+
+        final chunks = <GenerateResponseChunk>[];
+        await genkit.generate(
+          model: modelRef(modelName),
+          prompt: 'Start',
+          toolNames: [toolName],
+          onChunk: chunks.add,
+        );
+
+        expect(chunks.length, 3);
+
+        expect(chunks[0].index, 0, reason: 'Turn 1, Chunk 1 should be 0');
+        // Turn 2: messageIndex starts at 2
+        expect(
+          chunks[1].index,
+          2,
+          reason: 'Turn 2, Chunk 1 (Role.tool) should be 2',
+        );
+        // Then role changes to Role.model for the next chunk in the same turn -> modelHasSentChunks is true
+        expect(
+          chunks[2].index,
+          3,
+          reason: 'Turn 2, Chunk 2 (Role.model) should be 3',
+        );
+      },
+    );
+
     test('generateStream() without model uses defaultModel', () async {
       var defaultModelCalled = false;
       genkit = Genkit(

--- a/packages/genkit/test/ai/generate_stream_test.dart
+++ b/packages/genkit/test/ai/generate_stream_test.dart
@@ -37,9 +37,7 @@ void main() {
           // If first turn, return tool request
           if (request.messages.length == 1) {
             context.sendChunk(
-              ModelResponseChunk(
-                content: [TextPart(text: 'Calling tool...')],
-              ),
+              ModelResponseChunk(content: [TextPart(text: 'Calling tool...')]),
             );
             context.sendChunk(
               ModelResponseChunk(

--- a/packages/genkit/test/ai/generate_stream_test.dart
+++ b/packages/genkit/test/ai/generate_stream_test.dart
@@ -38,13 +38,11 @@ void main() {
           if (request.messages.length == 1) {
             context.sendChunk(
               ModelResponseChunk(
-                index: 0,
                 content: [TextPart(text: 'Calling tool...')],
               ),
             );
             context.sendChunk(
               ModelResponseChunk(
-                index: 0,
                 content: [
                   ToolRequestPart(
                     toolRequest: ToolRequest(
@@ -74,7 +72,7 @@ void main() {
           } else {
             // Second turn (after tool)
             context.sendChunk(
-              ModelResponseChunk(index: 0, content: [TextPart(text: 'Done')]),
+              ModelResponseChunk(content: [TextPart(text: 'Done')]),
             );
 
             return ModelResponse(
@@ -117,7 +115,7 @@ void main() {
         0,
         reason: 'Second chunk of first turn should be 0',
       );
-      expect(chunks[2].index, 1, reason: 'Chunk of second turn should be 1');
+      expect(chunks[2].index, 2, reason: 'Chunk of second turn should be 2');
     });
 
     test('generateStream() without model uses defaultModel', () async {

--- a/packages/genkit/test/ai/middleware_test.dart
+++ b/packages/genkit/test/ai/middleware_test.dart
@@ -32,16 +32,16 @@ class TestMiddleware extends GenerateMiddleware {
 
   @override
   Future<GenerateResponseHelper> generate(
-    GenerateActionOptions options,
+    GenerateTurnState envelope,
     ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     Future<GenerateResponseHelper> Function(
-      GenerateActionOptions options,
+      GenerateTurnState envelope,
       ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     )
     next,
   ) async {
     log.add('$name:generate:start');
-    final result = await next(options, ctx);
+    final result = await next(envelope, ctx);
     log.add('$name:generate:end');
     return result;
   }
@@ -492,7 +492,108 @@ void main() {
         ]),
       );
     });
+
+    test(
+      'should pass and respect envelope updates in generate middleware',
+      () async {
+        var receivedIndex = -1;
+        var receivedTurn = -1;
+
+        final envChecker = defineMiddleware(
+          name: 'env-checker',
+          create: ([_]) => FunctionMiddleware(
+            generateFn: (envelope, ctx, next) async {
+              receivedIndex = envelope.messageIndex;
+              receivedTurn = envelope.currentTurn;
+              return next((
+                request: envelope.request,
+                currentTurn: envelope.currentTurn + 2,
+                messageIndex: envelope.messageIndex + 5,
+              ), ctx);
+            },
+          ),
+        );
+
+        var checkIndex = -1;
+        var checkTurn = -1;
+        final envValidator = defineMiddleware(
+          name: 'env-validator',
+          create: ([_]) => FunctionMiddleware(
+            generateFn: (envelope, ctx, next) async {
+              checkIndex = envelope.messageIndex;
+              checkTurn = envelope.currentTurn;
+              return next(envelope, ctx);
+            },
+          ),
+        );
+
+        genkit = Genkit(
+          isDevEnv: false,
+          plugins: [
+            MiddlewarePlugin([envChecker, envValidator]),
+          ],
+        );
+
+        genkit.defineModel(
+          name: 'test-model',
+          fn: (req, ctx) async {
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'done')],
+              ),
+            );
+          },
+        );
+
+        await genkit.generate(
+          model: modelRef('test-model'),
+          prompt: 'hi',
+          use: [
+            middlewareRef(name: 'env-checker'),
+            middlewareRef(name: 'env-validator'),
+          ],
+        );
+
+        expect(receivedIndex, 0);
+        expect(receivedTurn, 0);
+        expect(checkIndex, 5);
+        expect(checkTurn, 2);
+      },
+    );
   });
+}
+
+class FunctionMiddleware extends GenerateMiddleware {
+  final Future<GenerateResponseHelper> Function(
+    GenerateTurnState envelope,
+    ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    Future<GenerateResponseHelper> Function(
+      GenerateTurnState envelope,
+      ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    )
+    next,
+  )?
+  generateFn;
+
+  FunctionMiddleware({this.generateFn});
+
+  @override
+  Future<GenerateResponseHelper> generate(
+    GenerateTurnState envelope,
+    ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    Future<GenerateResponseHelper> Function(
+      GenerateTurnState envelope,
+      ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    )
+    next,
+  ) {
+    if (generateFn != null) {
+      return generateFn!(envelope, ctx, next);
+    }
+    return super.generate(envelope, ctx, next);
+  }
 }
 
 class ToolInjectingMiddleware extends GenerateMiddleware {

--- a/packages/genkit_middleware/lib/src/filesystem_middleware.dart
+++ b/packages/genkit_middleware/lib/src/filesystem_middleware.dart
@@ -188,6 +188,10 @@ class FilesystemMiddleware extends GenerateMiddleware {
             TextPart(
               text:
                   '<read_file path="${input.filePath}">\n$content\n</read_file>',
+              metadata: {
+                'filePath': input.filePath,
+                'filesystemMiddlewareTool': 'read_file',
+              },
             ),
           );
         }
@@ -199,9 +203,21 @@ class FilesystemMiddleware extends GenerateMiddleware {
           // Modifying content of existing message is tricky with immutable structures
           // But we are managing _messageQueue ourselves
           final newContent = [...lastMsg.content, ...parts];
-          _messageQueue.add(Message(role: Role.user, content: newContent));
+          _messageQueue.add(
+            Message(
+              role: Role.user,
+              content: newContent,
+              metadata: {'filesystemMiddlewareTool': 'read_file'},
+            ),
+          );
         } else {
-          _messageQueue.add(Message(role: Role.user, content: parts));
+          _messageQueue.add(
+            Message(
+              role: Role.user,
+              content: parts,
+              metadata: {'filesystemMiddlewareTool': 'read_file'},
+            ),
+          );
         }
 
         return 'File ${input.filePath} read successfully, see contents below';
@@ -302,16 +318,32 @@ class FilesystemMiddleware extends GenerateMiddleware {
 
   @override
   Future<GenerateResponseHelper> generate(
-    GenerateActionOptions options,
+    GenerateTurnState envelope,
     ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     Future<GenerateResponseHelper> Function(
-      GenerateActionOptions options,
+      GenerateTurnState envelope,
       ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     )
     next,
   ) async {
+    final options = envelope.request;
+    var messageIndex = envelope.messageIndex;
+
     if (_messageQueue.isNotEmpty) {
       final messages = List<Message>.from(options.messages);
+
+      if (ctx.streamingRequested) {
+        for (final msg in _messageQueue) {
+          ctx.sendChunk(
+            ModelResponseChunk(
+              index: messageIndex++,
+              content: msg.content,
+              role: msg.role,
+            ),
+          );
+        }
+      }
+
       messages.addAll(_messageQueue);
       _messageQueue.clear();
 
@@ -328,9 +360,13 @@ class FilesystemMiddleware extends GenerateMiddleware {
         maxTurns: options.maxTurns,
         stepName: options.stepName,
       );
-      return next(newOptions, ctx);
+      return next((
+        request: newOptions,
+        currentTurn: envelope.currentTurn,
+        messageIndex: messageIndex,
+      ), ctx);
     }
-    return next(options, ctx);
+    return next(envelope, ctx);
   }
 
   @override

--- a/packages/genkit_middleware/lib/src/skills_middleware.dart
+++ b/packages/genkit_middleware/lib/src/skills_middleware.dart
@@ -168,14 +168,15 @@ class SkillsMiddleware extends GenerateMiddleware {
 
   @override
   Future<GenerateResponseHelper> generate(
-    GenerateActionOptions options,
+    GenerateTurnState envelope,
     ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     Future<GenerateResponseHelper> Function(
-      GenerateActionOptions options,
+      GenerateTurnState envelope,
       ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
     )
     next,
   ) async {
+    final options = envelope.request;
     await _ensureSkillsScanned();
     // TS impl: if (skillsList.length > 0)
     // Here we check _skillCache which corresponds to skillsList
@@ -293,9 +294,13 @@ class SkillsMiddleware extends GenerateMiddleware {
         stepName: options.stepName,
       );
 
-      return next(newOptions, ctx);
+      return next((
+        request: newOptions,
+        currentTurn: envelope.currentTurn,
+        messageIndex: envelope.messageIndex,
+      ), ctx);
     }
 
-    return next(options, ctx);
+    return next(envelope, ctx);
   }
 }

--- a/packages/genkit_middleware/test/filesystem_middleware_test.dart
+++ b/packages/genkit_middleware/test/filesystem_middleware_test.dart
@@ -123,6 +123,85 @@ void main() {
       expect(result.text, 'Content read');
     });
 
+    test('should stream file contents when reading a file', () async {
+      final file = File(p.join(tempDir.path, 'file1.txt'));
+      await file.writeAsString('hello world');
+
+      final mw = filesystem(rootDirectory: tempDir.path);
+
+      var turn = 0;
+      genkit.defineModel(
+        name: 'stream-read-model',
+        fn: (req, ctx) async {
+          turn++;
+          if (turn == 1) {
+            final content = [
+              ToolRequestPart(
+                toolRequest: ToolRequest(
+                  name: 'read_file',
+                  input: {'filePath': 'file1.txt'},
+                ),
+              ),
+            ];
+            if (ctx.streamingRequested) {
+              ctx.sendChunk(ModelResponseChunk(content: content));
+            }
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(role: Role.model, content: content),
+            );
+          }
+          final content = [TextPart(text: 'done')];
+          if (ctx.streamingRequested) {
+            ctx.sendChunk(ModelResponseChunk(content: content));
+          }
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(role: Role.model, content: content),
+          );
+        },
+      );
+
+      final result = genkit.generateStream(
+        model: modelRef('stream-read-model'),
+        prompt: 'test',
+        use: [mw],
+      );
+
+      final chunks = <GenerateResponseChunk>[];
+      await for (final chunk in result) {
+        chunks.add(chunk);
+      }
+
+      await result.onResult;
+
+      final indices = chunks.map((c) => c.index).toSet().toList();
+      // Expect indices 0, 2, 3
+      // 0: Model tool request
+      // 1: Tool response string (Not streamed in Dart)
+      // 2: Injected file content
+      // 3: Final model response
+      expect(indices, [
+        0,
+        2,
+        3,
+      ], reason: 'Should have expected message indices');
+
+      final fileContentChunk = chunks
+          .where((c) => c.text.contains('hello world'))
+          .firstOrNull;
+      expect(
+        fileContentChunk,
+        isNotNull,
+        reason: 'Stream should contain file content',
+      );
+      expect(
+        fileContentChunk!.index,
+        2,
+        reason: 'File content should have index 2',
+      );
+    });
+
     test('should NOT allow access outside root', () async {
       final mw = FilesystemMiddleware(tempDir.path);
       final readTool = mw.tools.firstWhere((t) => t.name == 'read_file');


### PR DESCRIPTION
BREAKING: changes the generate hook signature in generate middleware

Introduces GenerateTurnState to encapsulate state variables like request, currentTurn, and messageIndex during the generate loop. The GenerateMiddleware signature and composedGenerate functions are updated to use this new state envelope.

Additionally, this improves the streaming chunk indexing logic to accurately track messageIndex across multiple turns and role changes, ensuring correct chunk indices for multi-turn and tool responses. Tests are updated to align with the dynamic chunk indexing behavior.