### PR TITLE
fix(openai): make plugin name configurable for multiple OpenAI-compatible backends

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -139,13 +139,16 @@ final response = await ai.generate(
 
 ## OpenAI-Compatible APIs
 
-The plugin supports any OpenAI-compatible API by specifying a custom `baseUrl`:
+The plugin supports any OpenAI-compatible API by specifying a custom `baseUrl`.
+Use the `name` parameter to give each backend a unique identity — this is
+required when registering multiple backends in the same `Genkit` instance.
 
 ### Groq
 
 ```dart
 final ai = Genkit(plugins: [
   openAI(
+    name: 'groq',
     apiKey: Platform.environment['GROQ_API_KEY'],
     baseUrl: 'https://api.groq.com/openai/v1',
     models: [
@@ -165,8 +168,37 @@ final ai = Genkit(plugins: [
 ]);
 
 final response = await ai.generate(
-  model: openAI.model('llama-3.3-70b-versatile'),
+  model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
   prompt: 'Hello!',
+);
+```
+
+### Multiple Backends
+
+You can use several OpenAI-compatible providers side by side by giving each a
+unique `name`:
+
+```dart
+final ai = Genkit(plugins: [
+  openAI(apiKey: Platform.environment['OPENAI_API_KEY']),
+  openAI(
+    name: 'openrouter',
+    apiKey: Platform.environment['OPENROUTER_API_KEY'],
+    baseUrl: 'https://openrouter.ai/api/v1',
+    models: [CustomModelDefinition(name: 'gpt-4o')],
+  ),
+]);
+
+// Uses the default OpenAI backend
+final a = await ai.generate(
+  model: openAI.model('gpt-4o'),
+  prompt: 'Hello from OpenAI!',
+);
+
+// Uses the OpenRouter backend
+final b = await ai.generate(
+  model: openAI.model('gpt-4o', namespace: 'openrouter'),
+  prompt: 'Hello from OpenRouter!',
 );
 ```
 

--- a/packages/genkit_openai/lib/genkit_openai.dart
+++ b/packages/genkit_openai/lib/genkit_openai.dart
@@ -31,6 +31,9 @@ export 'src/utils.dart'
         supportsTools,
         supportsVision;
 
+/// Default plugin / namespace name used when no custom name is provided.
+const String defaultOpenAINamespace = 'openai';
+
 /// Custom model definition for registering models from compatible providers
 class CustomModelDefinition {
   final String name;
@@ -52,11 +55,11 @@ class OpenAICompatPluginHandle {
   /// Create the plugin instance.
   ///
   /// The [name] parameter allows uniquely identifying each plugin instance
-  /// (e.g. `'openrouter'`, `'nanogpt'`). It defaults to `'openai'` and is
-  /// used as the namespace prefix for all models registered by this instance
-  /// (e.g. `openrouter/gpt-4o`).
+  /// (e.g. `'openrouter'`, `'nanogpt'`). It defaults to
+  /// [defaultOpenAINamespace] and is used as the namespace prefix for all
+  /// models registered by this instance (e.g. `openrouter/gpt-4o`).
   GenkitPlugin call({
-    String name = 'openai',
+    String name = defaultOpenAINamespace,
     String? apiKey,
     OpenAIApiKeyProvider? apiKeyProvider,
     String? baseUrl,
@@ -77,12 +80,12 @@ class OpenAICompatPluginHandle {
 
   /// Reference to a model.
   ///
-  /// The optional [namespace] defaults to `'openai'` and is the prefix used
-  /// when looking up the model (e.g. `openai/gpt-4o`). Pass a custom value
-  /// when the plugin was created with a custom [name].
+  /// The optional [namespace] defaults to [defaultOpenAINamespace] and is the
+  /// prefix used when looking up the model (e.g. `openai/gpt-4o`). Pass a
+  /// custom value when the plugin was created with a custom name.
   ModelRef<chat.OpenAIChatOptions> model(
     String name, {
-    String namespace = 'openai',
+    String namespace = defaultOpenAINamespace,
   }) {
     return modelRef(
       '$namespace/$name',

--- a/packages/genkit_openai/lib/genkit_openai.dart
+++ b/packages/genkit_openai/lib/genkit_openai.dart
@@ -49,8 +49,14 @@ const OpenAICompatPluginHandle openAI = OpenAICompatPluginHandle();
 class OpenAICompatPluginHandle {
   const OpenAICompatPluginHandle();
 
-  /// Create the plugin instance
+  /// Create the plugin instance.
+  ///
+  /// The [name] parameter allows uniquely identifying each plugin instance
+  /// (e.g. `'openrouter'`, `'nanogpt'`). It defaults to `'openai'` and is
+  /// used as the namespace prefix for all models registered by this instance
+  /// (e.g. `openrouter/gpt-4o`).
   GenkitPlugin call({
+    String name = 'openai',
     String? apiKey,
     OpenAIApiKeyProvider? apiKeyProvider,
     String? baseUrl,
@@ -59,6 +65,7 @@ class OpenAICompatPluginHandle {
     http.Client? httpClient,
   }) {
     return OpenAIPlugin(
+      name: name,
       apiKey: apiKey,
       apiKeyProvider: apiKeyProvider,
       baseUrl: baseUrl,
@@ -68,10 +75,17 @@ class OpenAICompatPluginHandle {
     );
   }
 
-  /// Reference to a model
-  ModelRef<chat.OpenAIChatOptions> model(String name) {
+  /// Reference to a model.
+  ///
+  /// The optional [namespace] defaults to `'openai'` and is the prefix used
+  /// when looking up the model (e.g. `openai/gpt-4o`). Pass a custom value
+  /// when the plugin was created with a custom [name].
+  ModelRef<chat.OpenAIChatOptions> model(
+    String name, {
+    String namespace = 'openai',
+  }) {
     return modelRef(
-      'openai/$name',
+      '$namespace/$name',
       customOptions: chat.chatModelOptionsSchema(),
     );
   }

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -33,7 +33,7 @@ class OpenAIPlugin extends GenkitPlugin {
   final http.Client? httpClient;
 
   OpenAIPlugin({
-    String name = 'openai',
+    String name = defaultOpenAINamespace,
     this.apiKey,
     this.apiKeyProvider,
     this.baseUrl,

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -22,8 +22,9 @@ import 'chat.dart' as chat;
 /// Core plugin implementation
 class OpenAIPlugin extends GenkitPlugin {
   @override
-  String get name => 'openai';
+  String get name => _pluginName;
 
+  final String _pluginName;
   final String? apiKey;
   final OpenAIApiKeyProvider? apiKeyProvider;
   final String? baseUrl;
@@ -32,13 +33,14 @@ class OpenAIPlugin extends GenkitPlugin {
   final http.Client? httpClient;
 
   OpenAIPlugin({
+    String name = 'openai',
     this.apiKey,
     this.apiKeyProvider,
     this.baseUrl,
     this.customModels = const [],
     this.headers,
     this.httpClient,
-  }) {
+  }) : _pluginName = name {
     if (apiKey != null && apiKeyProvider != null) {
       throw GenkitException(
         'Provide either apiKey or apiKeyProvider, not both.',
@@ -150,7 +152,7 @@ class OpenAIPlugin extends GenkitPlugin {
 
         modelMetadataList.add(
           modelMetadata(
-            'openai/$modelId',
+            '$_pluginName/$modelId',
             modelInfo: modelInfoFor(modelId),
             customOptions: chat.chatModelOptionsSchema(),
           ),
@@ -179,7 +181,7 @@ class OpenAIPlugin extends GenkitPlugin {
     final modelInfo = info ?? modelInfoFor(modelName);
 
     return Model(
-      name: 'openai/$modelName',
+      name: '$_pluginName/$modelName',
       customOptions: chat.chatModelOptionsSchema(),
       metadata: {'model': modelInfo.toJson()},
       fn: (req, ctx) async {

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -41,6 +41,12 @@ class OpenAIPlugin extends GenkitPlugin {
     this.headers,
     this.httpClient,
   }) : _pluginName = name {
+    if (name.isEmpty || name.contains('/')) {
+      throw GenkitException(
+        'Plugin name must be non-empty and must not contain "/". Got: "$name"',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
     if (apiKey != null && apiKeyProvider != null) {
       throw GenkitException(
         'Provide either apiKey or apiKeyProvider, not both.',
@@ -70,7 +76,7 @@ class OpenAIPlugin extends GenkitPlugin {
         }
       } catch (e) {
         throw GenkitException(
-          'Error fetching available models from OpenAI: $e',
+          'Error fetching available models from $_pluginName: $e',
           underlyingException: e,
         );
       }
@@ -116,7 +122,7 @@ class OpenAIPlugin extends GenkitPlugin {
     final configuredApiKey = await _resolveApiKey();
     if (configuredApiKey == null || configuredApiKey.trim().isEmpty) {
       throw GenkitException(
-        'API key is required. Provide it via apiKey or apiKeyProvider in the plugin constructor.',
+        '[$_pluginName] API key is required. Provide it via apiKey or apiKeyProvider in the plugin constructor.',
         status: StatusCodes.INVALID_ARGUMENT,
       );
     }
@@ -162,7 +168,7 @@ class OpenAIPlugin extends GenkitPlugin {
       return modelMetadataList;
     } catch (e, stackTrace) {
       throw GenkitException(
-        'Error listing models from OpenAI: $e',
+        'Error listing models from $_pluginName: $e',
         underlyingException: e,
         stackTrace: stackTrace,
       );

--- a/packages/genkit_openai/test/openai_plugin_core_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_core_test.dart
@@ -50,6 +50,52 @@ void main() {
       final ref = openAI.model('gpt-4o');
       expect(ref.name, 'openai/gpt-4o');
     });
+
+    test('creates plugin instance with custom name', () {
+      final plugin = openAI(name: 'openrouter', apiKey: 'test-key');
+      expect(plugin, isNotNull);
+      expect(plugin.name, 'openrouter');
+    });
+
+    test('default plugin name is openai', () {
+      final plugin = openAI(apiKey: 'test-key');
+      expect(plugin.name, 'openai');
+    });
+
+    test('creates model reference with custom namespace', () {
+      final ref = openAI.model('gpt-4o', namespace: 'openrouter');
+      expect(ref.name, 'openrouter/gpt-4o');
+    });
+
+    test('rejects empty plugin name', () {
+      expect(
+        () => openAI(name: '', apiKey: 'test-key'),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('must not contain'),
+              ),
+        ),
+      );
+    });
+
+    test('rejects plugin name with slash', () {
+      expect(
+        () => openAI(name: 'my/provider', apiKey: 'test-key'),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('must not contain "/"'),
+              ),
+        ),
+      );
+    });
   });
 
   group('CustomModelDefinition', () {


### PR DESCRIPTION
## Problem

`OpenAIPlugin.name` is hardcoded to `'openai'`, and all resolved models are named `'openai/<modelId>'`. This means two `OpenAIPlugin` instances with different `apiKey`/`baseUrl` cannot coexist in the same `Genkit` instance — the second plugin overwrites the first since the registry matches plugins by name.

Reported in #271.

## Solution

Add a configurable `name` parameter (defaulting to `'openai'`) that flows through as both the plugin identity and the model namespace prefix. This mirrors the approach used by the JS `compat-oai` plugin, where `PluginOptions.name` is a required field and `compatOaiModelRef` accepts a `namespace` parameter.

### Changes

**`packages/genkit_openai/lib/src/openai_plugin.dart`:**
- Added `String name = 'openai'` constructor parameter stored as `_pluginName`
- Added `String name = 'openai'` parameter to `OpenAICompatPluginHandle.call()`, forwarded to `OpenAIPlugin`
- Added `String namespace = 'openai'` parameter to `OpenAICompatPluginHandle.model()` for model reference creation (mirrors JS `compatOaiModelRef({ namespace })`)

### Usage

```dart
final openrouter = openAI(
  name: 'openrouter',
  apiKey: 'sk-or-...',
  baseUrl: 'https://openrouter.ai/api/v1',
  models: [CustomModelDefinition(name: 'gpt-4o')],
);
final nanogpt = openAI(
  name: 'nanogpt',
  apiKey: 'sk-nano-...',
  baseUrl: 'https://nano-gpt.com/api/v1',
  models: [CustomModelDefinition(name: 'gpt-4o')],
);
```

Fixes #271