### PR TITLE
feat(vertexai): add Virtual Try-On model support

### DIFF
--- a/packages/genkit_vertexai/lib/genkit_vertexai.dart
+++ b/packages/genkit_vertexai/lib/genkit_vertexai.dart
@@ -17,6 +17,7 @@ import 'package:genkit_google_genai/genkit_google_genai.dart';
 import 'package:http/http.dart' as http;
 
 import 'src/vertex_api_client.dart';
+import 'src/virtual_try_on.dart';
 
 export 'package:genkit_google_genai/genkit_google_genai.dart'
     show
@@ -31,6 +32,7 @@ export 'package:genkit_google_genai/genkit_google_genai.dart'
         TextEmbedderOptions,
         ThinkingConfig,
         VoiceConfig;
+export 'src/virtual_try_on.dart';
 
 const VertexAiPluginHandle vertexAI = VertexAiPluginHandle();
 
@@ -58,5 +60,12 @@ class VertexAiPluginHandle {
       'vertexai/$name',
       customOptions: TextEmbedderOptions.$schema,
     );
+  }
+
+  ModelRef<VirtualTryOnOptions> virtualTryOn([
+    String name = 'virtual-try-on-001',
+    VirtualTryOnOptions? config,
+  ]) {
+    return modelRef('vertexai/$name', config: config);
   }
 }

--- a/packages/genkit_vertexai/lib/genkit_vertexai.dart
+++ b/packages/genkit_vertexai/lib/genkit_vertexai.dart
@@ -32,7 +32,7 @@ export 'package:genkit_google_genai/genkit_google_genai.dart'
         TextEmbedderOptions,
         ThinkingConfig,
         VoiceConfig;
-export 'src/virtual_try_on.dart';
+export 'src/virtual_try_on.dart' show VirtualTryOnOptions;
 
 const VertexAiPluginHandle vertexAI = VertexAiPluginHandle();
 
@@ -66,6 +66,10 @@ class VertexAiPluginHandle {
     String name = 'virtual-try-on-001',
     VirtualTryOnOptions? config,
   ]) {
-    return modelRef('vertexai/$name', config: config);
+    return modelRef(
+      'vertexai/$name',
+      config: config,
+      customOptions: VirtualTryOnOptions.$schema,
+    );
   }
 }

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -19,6 +19,7 @@ import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 import 'auth.dart';
+import 'virtual_try_on.dart';
 
 @visibleForTesting
 class VertexAiPluginImpl extends CommonGoogleGenPlugin {
@@ -91,11 +92,16 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
           .where((m) {
             final modelMap = m as Map<String, dynamic>;
             final name = modelMap['name'] as String?;
-            return name != null && name.contains('gemini-');
+            return name != null &&
+                (name.contains('gemini-') ||
+                    name.contains(virtualTryOnModelPrefix));
           })
           .map((m) {
             final modelMap = m as Map<String, dynamic>;
             final modelName = (modelMap['name'] as String).split('/').last;
+            if (isVirtualTryOnModelName(modelName)) {
+              return virtualTryOnModelMetadata(name, modelName);
+            }
             final isTts = modelName.contains('-tts');
             return modelMetadata(
               '$name/$modelName',
@@ -132,6 +138,20 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
         service.client.close();
       }
     }
+  }
+
+  @override
+  Action? resolve(String actionType, String name) {
+    if (actionType == 'model' && isVirtualTryOnModelName(name)) {
+      return createVirtualTryOnModel(
+        pluginName: this.name,
+        modelName: name,
+        getApiClient: getApiClient,
+        handleException: handleException,
+        shouldCloseClient: authClient == null,
+      );
+    }
+    return super.resolve(actionType, name);
   }
 
   @override

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -94,13 +94,13 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
             final name = modelMap['name'] as String?;
             return name != null &&
                 (name.contains('gemini-') ||
-                    name.contains(virtualTryOnModelPrefix));
+                    name.contains(VirtualTryOn.modelPrefix));
           })
           .map((m) {
             final modelMap = m as Map<String, dynamic>;
             final modelName = (modelMap['name'] as String).split('/').last;
-            if (isVirtualTryOnModelName(modelName)) {
-              return virtualTryOnModelMetadata(name, modelName);
+            if (VirtualTryOn.isModelName(modelName)) {
+              return VirtualTryOn.actionMetadata(name, modelName);
             }
             final isTts = modelName.contains('-tts');
             return modelMetadata(
@@ -142,16 +142,20 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
 
   @override
   Action? resolve(String actionType, String name) {
-    if (actionType == 'model' && isVirtualTryOnModelName(name)) {
-      return createVirtualTryOnModel(
-        pluginName: this.name,
-        modelName: name,
-        getApiClient: getApiClient,
-        handleException: handleException,
-        shouldCloseClient: authClient == null,
-      );
+    if (actionType == 'model' && VirtualTryOn.isModelName(name)) {
+      return createVirtualTryOnModel(name);
     }
     return super.resolve(actionType, name);
+  }
+
+  Model createVirtualTryOnModel(String modelName) {
+    return VirtualTryOn.createModel(
+      pluginName: name,
+      modelName: modelName,
+      getApiClient: getApiClient,
+      handleException: handleException,
+      shouldCloseClient: authClient == null,
+    );
   }
 
   @override

--- a/packages/genkit_vertexai/lib/src/virtual_try_on.dart
+++ b/packages/genkit_vertexai/lib/src/virtual_try_on.dart
@@ -1,0 +1,239 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/plugin.dart';
+import 'package:genkit_google_genai/common.dart';
+
+const virtualTryOnModelPrefix = 'virtual-try-on-';
+
+final virtualTryOnModelInfo = ModelInfo(
+  supports: {
+    'media': true,
+    'multiturn': false,
+    'tools': false,
+    'toolChoice': false,
+    'systemRole': true,
+    'output': ['media'],
+  },
+);
+
+class VirtualTryOnOptions {
+  VirtualTryOnOptions({
+    this.outputOptions,
+    this.sampleCount,
+    this.storageUri,
+    this.seed,
+    this.baseSteps,
+    this.safetySetting,
+    this.personGeneration,
+    this.addWatermark,
+    this.enhancePrompt,
+  });
+
+  final Map<String, dynamic>? outputOptions;
+  final int? sampleCount;
+  final String? storageUri;
+  final int? seed;
+  final int? baseSteps;
+  final String? safetySetting;
+  final String? personGeneration;
+  final bool? addWatermark;
+  final bool? enhancePrompt;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'outputOptions': ?outputOptions,
+      'sampleCount': ?sampleCount,
+      'storageUri': ?storageUri,
+      'seed': ?seed,
+      'baseSteps': ?baseSteps,
+      'safetySetting': ?safetySetting,
+      'personGeneration': ?personGeneration,
+      'addWatermark': ?addWatermark,
+      'enhancePrompt': ?enhancePrompt,
+    };
+  }
+}
+
+bool isVirtualTryOnModelName(String modelName) {
+  return modelName.startsWith(virtualTryOnModelPrefix);
+}
+
+ActionMetadata virtualTryOnModelMetadata(String pluginName, String modelName) {
+  return modelMetadata(
+    '$pluginName/$modelName',
+    modelInfo: virtualTryOnModelInfo,
+  );
+}
+
+Model createVirtualTryOnModel({
+  required String pluginName,
+  required String modelName,
+  required Future<GenerativeLanguageBaseClient> Function() getApiClient,
+  required GenkitException Function(Object error, StackTrace stack)
+  handleException,
+  required bool shouldCloseClient,
+}) {
+  return Model(
+    name: '$pluginName/$modelName',
+    metadata: {'model': virtualTryOnModelInfo.toJson()},
+    fn: (req, ctx) async {
+      if (ctx.streamingRequested) {
+        throw GenkitException(
+          'Virtual try-on does not support streaming.',
+          status: StatusCodes.INVALID_ARGUMENT,
+        );
+      }
+
+      final service = await getApiClient();
+      try {
+        final res = await service.predict(
+          _toVirtualTryOnPredictRequest(req!),
+          model: 'models/$modelName',
+        );
+        return _fromVirtualTryOnPredictResponse(res);
+      } catch (e, stack) {
+        throw handleException(e, stack);
+      } finally {
+        if (shouldCloseClient) {
+          service.client.close();
+        }
+      }
+    },
+  );
+}
+
+Map<String, dynamic> _toVirtualTryOnPredictRequest(ModelRequest request) {
+  final mediaParts = request.messages
+      .expand((message) => message.content)
+      .where((part) => part.isMedia)
+      .map((part) => part.mediaPart!)
+      .toList();
+
+  final personImage =
+      _findMediaPartByType(mediaParts, 'personImage') ??
+      (mediaParts.isNotEmpty ? mediaParts.first : null);
+  final productImagesByType = mediaParts
+      .where((part) => part.metadata?['type'] == 'productImage')
+      .toList();
+  final productImages = productImagesByType.isNotEmpty
+      ? productImagesByType
+      : mediaParts.where((part) => part != personImage).toList();
+
+  if (personImage == null || productImages.isEmpty) {
+    throw GenkitException(
+      'Virtual try-on requires a personImage media part and at least one productImage media part.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+
+  return {
+    'instances': [
+      {
+        'personImage': {'image': _toVirtualTryOnImage(personImage.media)},
+        'productImages': productImages
+            .map((part) => {'image': _toVirtualTryOnImage(part.media)})
+            .toList(),
+      },
+    ],
+    if (request.config != null) 'parameters': request.config,
+  };
+}
+
+MediaPart? _findMediaPartByType(List<MediaPart> parts, String type) {
+  for (final part in parts) {
+    if (part.metadata?['type'] == type) {
+      return part;
+    }
+  }
+  return null;
+}
+
+Map<String, dynamic> _toVirtualTryOnImage(Media media) {
+  final image = <String, dynamic>{
+    if (media.contentType != null) 'mimeType': media.contentType,
+  };
+
+  if (media.url.startsWith('data:')) {
+    final uri = Uri.parse(media.url);
+    final data = uri.data;
+    if (data == null) {
+      throw GenkitException(
+        'Invalid data URL for virtual try-on image.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+    image['mimeType'] ??= data.mimeType;
+    image['bytesBase64Encoded'] = base64Encode(data.contentAsBytes());
+    return image;
+  }
+
+  if (media.url.startsWith('gs://')) {
+    image['gcsUri'] = media.url;
+    return image;
+  }
+
+  if (media.url.startsWith('http://') || media.url.startsWith('https://')) {
+    throw GenkitException(
+      'Virtual try-on does not support http(s) image URIs. Use a data URL or a Cloud Storage URI.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+
+  image['bytesBase64Encoded'] = media.url;
+  return image;
+}
+
+ModelResponse _fromVirtualTryOnPredictResponse(Map<String, dynamic> response) {
+  final predictions = response['predictions'] as List?;
+  if (predictions == null || predictions.isEmpty) {
+    throw GenkitException(
+      'Virtual try-on returned no predictions.',
+      status: StatusCodes.INTERNAL,
+    );
+  }
+
+  final content = predictions.map((prediction) {
+    final predictionMap = prediction as Map<String, dynamic>;
+    final mimeType = predictionMap['mimeType'] as String? ?? 'image/png';
+    final bytesBase64Encoded = predictionMap['bytesBase64Encoded'] as String?;
+    final gcsUri = predictionMap['gcsUri'] as String?;
+    if (bytesBase64Encoded == null && gcsUri == null) {
+      throw GenkitException(
+        'Virtual try-on prediction did not include image data.',
+        status: StatusCodes.INTERNAL,
+      );
+    }
+    return MediaPart(
+      media: Media(
+        contentType: mimeType,
+        url: bytesBase64Encoded == null
+            ? gcsUri!
+            : 'data:$mimeType;base64,$bytesBase64Encoded',
+      ),
+    );
+  }).toList();
+
+  return ModelResponse(
+    finishReason: FinishReason.stop,
+    message: Message(role: Role.model, content: content),
+    raw: response,
+    usage: GenerationUsage(
+      outputImages: content.length.toDouble(),
+      custom: {'generations': content.length},
+    ),
+  );
+}

--- a/packages/genkit_vertexai/lib/src/virtual_try_on.dart
+++ b/packages/genkit_vertexai/lib/src/virtual_try_on.dart
@@ -20,19 +20,6 @@ import 'package:schemantic/schemantic.dart';
 
 part 'virtual_try_on.g.dart';
 
-const virtualTryOnModelPrefix = 'virtual-try-on-';
-
-final virtualTryOnModelInfo = ModelInfo(
-  supports: {
-    'media': true,
-    'multiturn': false,
-    'tools': false,
-    'toolChoice': false,
-    'systemRole': false,
-    'output': ['media'],
-  },
-);
-
 @Schema()
 abstract class $VirtualTryOnOptions {
   $VirtualTryOnOutputOptions? get outputOptions;
@@ -52,182 +39,197 @@ abstract class $VirtualTryOnOutputOptions {
   int? get compressionQuality;
 }
 
-bool isVirtualTryOnModelName(String modelName) {
-  return modelName.startsWith(virtualTryOnModelPrefix);
-}
+class VirtualTryOn {
+  static const modelPrefix = 'virtual-try-on-';
 
-ActionMetadata virtualTryOnModelMetadata(String pluginName, String modelName) {
-  return modelMetadata(
-    '$pluginName/$modelName',
-    modelInfo: virtualTryOnModelInfo,
-    customOptions: VirtualTryOnOptions.$schema,
-  );
-}
-
-Model createVirtualTryOnModel({
-  required String pluginName,
-  required String modelName,
-  required Future<GenerativeLanguageBaseClient> Function() getApiClient,
-  required GenkitException Function(Object error, StackTrace stack)
-  handleException,
-  required bool shouldCloseClient,
-}) {
-  return Model(
-    name: '$pluginName/$modelName',
-    customOptions: VirtualTryOnOptions.$schema,
-    metadata: {'model': virtualTryOnModelInfo.toJson()},
-    fn: (req, ctx) async {
-      if (ctx.streamingRequested) {
-        throw GenkitException(
-          'Virtual try-on does not support streaming.',
-          status: StatusCodes.INVALID_ARGUMENT,
-        );
-      }
-
-      final service = await getApiClient();
-      try {
-        final res = await service.predict(
-          _toVirtualTryOnPredictRequest(req!),
-          model: 'models/$modelName',
-        );
-        return _fromVirtualTryOnPredictResponse(res);
-      } catch (e, stack) {
-        throw handleException(e, stack);
-      } finally {
-        if (shouldCloseClient) {
-          service.client.close();
-        }
-      }
+  static final modelInfo = ModelInfo(
+    supports: {
+      'media': true,
+      'multiturn': false,
+      'tools': false,
+      'toolChoice': false,
+      'systemRole': false,
+      'output': ['media'],
     },
   );
-}
 
-Map<String, dynamic> _toVirtualTryOnPredictRequest(ModelRequest request) {
-  final mediaParts = request.messages
-      .expand((message) => message.content)
-      .where((part) => part.isMedia)
-      .map((part) => part.mediaPart!)
-      .toList();
+  static bool isModelName(String modelName) {
+    return modelName.startsWith(modelPrefix);
+  }
 
-  final personImage =
-      _findMediaPartByType(mediaParts, 'personImage') ??
-      (mediaParts.isNotEmpty ? mediaParts.first : null);
-  final productImagesByType = mediaParts
-      .where((part) => part.metadata?['type'] == 'productImage')
-      .toList();
-  final productImages = productImagesByType.isNotEmpty
-      ? productImagesByType
-      : mediaParts.where((part) => part != personImage).toList();
-
-  if (personImage == null || productImages.isEmpty) {
-    throw GenkitException(
-      'Virtual try-on requires a personImage media part and at least one productImage media part.',
-      status: StatusCodes.INVALID_ARGUMENT,
+  static ActionMetadata actionMetadata(String pluginName, String modelName) {
+    return modelMetadata(
+      '$pluginName/$modelName',
+      modelInfo: modelInfo,
+      customOptions: VirtualTryOnOptions.$schema,
     );
   }
 
-  return {
-    'instances': [
-      {
-        'personImage': {'image': _toVirtualTryOnImage(personImage.media)},
-        'productImages': productImages
-            .map((part) => {'image': _toVirtualTryOnImage(part.media)})
-            .toList(),
+  static Model createModel({
+    required String pluginName,
+    required String modelName,
+    required Future<GenerativeLanguageBaseClient> Function() getApiClient,
+    required GenkitException Function(Object error, StackTrace stack)
+    handleException,
+    required bool shouldCloseClient,
+  }) {
+    return Model(
+      name: '$pluginName/$modelName',
+      customOptions: VirtualTryOnOptions.$schema,
+      metadata: {'model': modelInfo.toJson()},
+      fn: (req, ctx) async {
+        if (ctx.streamingRequested) {
+          throw GenkitException(
+            'Virtual try-on does not support streaming.',
+            status: StatusCodes.INVALID_ARGUMENT,
+          );
+        }
+
+        final service = await getApiClient();
+        try {
+          final res = await service.predict(
+            _toPredictRequest(req!),
+            model: 'models/$modelName',
+          );
+          return _fromPredictResponse(res);
+        } catch (e, stack) {
+          throw handleException(e, stack);
+        } finally {
+          if (shouldCloseClient) {
+            service.client.close();
+          }
+        }
       },
-    ],
-    if (request.config != null) 'parameters': request.config,
-  };
-}
-
-MediaPart? _findMediaPartByType(List<MediaPart> parts, String type) {
-  for (final part in parts) {
-    if (part.metadata?['type'] == type) {
-      return part;
-    }
+    );
   }
-  return null;
-}
 
-Map<String, dynamic> _toVirtualTryOnImage(Media media) {
-  final image = <String, dynamic>{
-    if (media.contentType != null) 'mimeType': media.contentType,
-  };
+  static Map<String, dynamic> _toPredictRequest(ModelRequest request) {
+    final mediaParts = request.messages
+        .expand((message) => message.content)
+        .where((part) => part.isMedia)
+        .map((part) => part.mediaPart!)
+        .toList();
 
-  if (media.url.startsWith('data:')) {
-    final uri = Uri.parse(media.url);
-    final data = uri.data;
-    if (data == null) {
+    final personImage =
+        _findMediaPartByType(mediaParts, 'personImage') ??
+        (mediaParts.isNotEmpty ? mediaParts.first : null);
+    final productImagesByType = mediaParts
+        .where((part) => part.metadata?['type'] == 'productImage')
+        .toList();
+    final productImages = productImagesByType.isNotEmpty
+        ? productImagesByType
+        : mediaParts.where((part) => part != personImage).toList();
+
+    if (personImage == null || productImages.isEmpty) {
       throw GenkitException(
-        'Invalid data URL for virtual try-on image.',
+        'Virtual try-on requires a personImage media part and at least one productImage media part.',
         status: StatusCodes.INVALID_ARGUMENT,
       );
     }
-    image['mimeType'] ??= data.mimeType;
-    image['bytesBase64Encoded'] = base64Encode(data.contentAsBytes());
-    return image;
+
+    return {
+      'instances': [
+        {
+          'personImage': {'image': _toImage(personImage.media)},
+          'productImages': productImages
+              .map((part) => {'image': _toImage(part.media)})
+              .toList(),
+        },
+      ],
+      if (request.config != null) 'parameters': request.config,
+    };
   }
 
-  if (media.url.startsWith('gs://')) {
-    image['gcsUri'] = media.url;
-    return image;
+  static MediaPart? _findMediaPartByType(List<MediaPart> parts, String type) {
+    for (final part in parts) {
+      if (part.metadata?['type'] == type) {
+        return part;
+      }
+    }
+    return null;
   }
 
-  if (media.url.startsWith('http://') || media.url.startsWith('https://')) {
-    throw GenkitException(
-      'Virtual try-on does not support http(s) image URIs. Use a data URL or a Cloud Storage URI.',
-      status: StatusCodes.INVALID_ARGUMENT,
-    );
-  }
+  static Map<String, dynamic> _toImage(Media media) {
+    final image = <String, dynamic>{
+      if (media.contentType != null) 'mimeType': media.contentType,
+    };
 
-  final uri = Uri.tryParse(media.url);
-  if (uri != null && uri.hasScheme) {
-    throw GenkitException(
-      'Unsupported URI scheme "${uri.scheme}" for virtual try-on image. Use a data URL or a Cloud Storage URI.',
-      status: StatusCodes.INVALID_ARGUMENT,
-    );
-  }
+    if (media.url.startsWith('data:')) {
+      final uri = Uri.parse(media.url);
+      final data = uri.data;
+      if (data == null) {
+        throw GenkitException(
+          'Invalid data URL for virtual try-on image.',
+          status: StatusCodes.INVALID_ARGUMENT,
+        );
+      }
+      image['mimeType'] ??= data.mimeType;
+      image['bytesBase64Encoded'] = base64Encode(data.contentAsBytes());
+      return image;
+    }
 
-  image['bytesBase64Encoded'] = media.url;
-  return image;
-}
+    if (media.url.startsWith('gs://')) {
+      image['gcsUri'] = media.url;
+      return image;
+    }
 
-ModelResponse _fromVirtualTryOnPredictResponse(Map<String, dynamic> response) {
-  final predictions = response['predictions'] as List?;
-  if (predictions == null || predictions.isEmpty) {
-    throw GenkitException(
-      'Virtual try-on returned no predictions.',
-      status: StatusCodes.INTERNAL,
-    );
-  }
-
-  final content = predictions.map((prediction) {
-    final predictionMap = prediction as Map<String, dynamic>;
-    final mimeType = predictionMap['mimeType'] as String? ?? 'image/png';
-    final bytesBase64Encoded = predictionMap['bytesBase64Encoded'] as String?;
-    final gcsUri = predictionMap['gcsUri'] as String?;
-    if (bytesBase64Encoded == null && gcsUri == null) {
+    if (media.url.startsWith('http://') || media.url.startsWith('https://')) {
       throw GenkitException(
-        'Virtual try-on prediction did not include image data.',
+        'Virtual try-on does not support http(s) image URIs. Use a data URL or a Cloud Storage URI.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+
+    final uri = Uri.tryParse(media.url);
+    if (uri != null && uri.hasScheme) {
+      throw GenkitException(
+        'Unsupported URI scheme "${uri.scheme}" for virtual try-on image. Use a data URL or a Cloud Storage URI.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+
+    image['bytesBase64Encoded'] = media.url;
+    return image;
+  }
+
+  static ModelResponse _fromPredictResponse(Map<String, dynamic> response) {
+    final predictions = response['predictions'] as List?;
+    if (predictions == null || predictions.isEmpty) {
+      throw GenkitException(
+        'Virtual try-on returned no predictions.',
         status: StatusCodes.INTERNAL,
       );
     }
-    return MediaPart(
-      media: Media(
-        contentType: mimeType,
-        url: bytesBase64Encoded == null
-            ? gcsUri!
-            : 'data:$mimeType;base64,$bytesBase64Encoded',
+
+    final content = predictions.map((prediction) {
+      final predictionMap = prediction as Map<String, dynamic>;
+      final mimeType = predictionMap['mimeType'] as String? ?? 'image/png';
+      final bytesBase64Encoded = predictionMap['bytesBase64Encoded'] as String?;
+      final gcsUri = predictionMap['gcsUri'] as String?;
+      if (bytesBase64Encoded == null && gcsUri == null) {
+        throw GenkitException(
+          'Virtual try-on prediction did not include image data.',
+          status: StatusCodes.INTERNAL,
+        );
+      }
+      return MediaPart(
+        media: Media(
+          contentType: mimeType,
+          url: bytesBase64Encoded == null
+              ? gcsUri!
+              : 'data:$mimeType;base64,$bytesBase64Encoded',
+        ),
+      );
+    }).toList();
+
+    return ModelResponse(
+      finishReason: FinishReason.stop,
+      message: Message(role: Role.model, content: content),
+      raw: response,
+      usage: GenerationUsage(
+        outputImages: content.length.toDouble(),
+        custom: {'generations': content.length},
       ),
     );
-  }).toList();
-
-  return ModelResponse(
-    finishReason: FinishReason.stop,
-    message: Message(role: Role.model, content: content),
-    raw: response,
-    usage: GenerationUsage(
-      outputImages: content.length.toDouble(),
-      custom: {'generations': content.length},
-    ),
-  );
+  }
 }

--- a/packages/genkit_vertexai/lib/src/virtual_try_on.dart
+++ b/packages/genkit_vertexai/lib/src/virtual_try_on.dart
@@ -179,6 +179,14 @@ Map<String, dynamic> _toVirtualTryOnImage(Media media) {
     );
   }
 
+  final uri = Uri.tryParse(media.url);
+  if (uri != null && uri.hasScheme) {
+    throw GenkitException(
+      'Unsupported URI scheme "${uri.scheme}" for virtual try-on image. Use a data URL or a Cloud Storage URI.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+
   image['bytesBase64Encoded'] = media.url;
   return image;
 }

--- a/packages/genkit_vertexai/lib/src/virtual_try_on.dart
+++ b/packages/genkit_vertexai/lib/src/virtual_try_on.dart
@@ -16,6 +16,9 @@ import 'dart:convert';
 
 import 'package:genkit/plugin.dart';
 import 'package:genkit_google_genai/common.dart';
+import 'package:schemantic/schemantic.dart';
+
+part 'virtual_try_on.g.dart';
 
 const virtualTryOnModelPrefix = 'virtual-try-on-';
 
@@ -25,47 +28,28 @@ final virtualTryOnModelInfo = ModelInfo(
     'multiturn': false,
     'tools': false,
     'toolChoice': false,
-    'systemRole': true,
+    'systemRole': false,
     'output': ['media'],
   },
 );
 
-class VirtualTryOnOptions {
-  VirtualTryOnOptions({
-    this.outputOptions,
-    this.sampleCount,
-    this.storageUri,
-    this.seed,
-    this.baseSteps,
-    this.safetySetting,
-    this.personGeneration,
-    this.addWatermark,
-    this.enhancePrompt,
-  });
+@Schema()
+abstract class $VirtualTryOnOptions {
+  $VirtualTryOnOutputOptions? get outputOptions;
+  int? get sampleCount;
+  String? get storageUri;
+  int? get seed;
+  int? get baseSteps;
+  String? get safetySetting;
+  String? get personGeneration;
+  bool? get addWatermark;
+  bool? get enhancePrompt;
+}
 
-  final Map<String, dynamic>? outputOptions;
-  final int? sampleCount;
-  final String? storageUri;
-  final int? seed;
-  final int? baseSteps;
-  final String? safetySetting;
-  final String? personGeneration;
-  final bool? addWatermark;
-  final bool? enhancePrompt;
-
-  Map<String, dynamic> toJson() {
-    return {
-      'outputOptions': ?outputOptions,
-      'sampleCount': ?sampleCount,
-      'storageUri': ?storageUri,
-      'seed': ?seed,
-      'baseSteps': ?baseSteps,
-      'safetySetting': ?safetySetting,
-      'personGeneration': ?personGeneration,
-      'addWatermark': ?addWatermark,
-      'enhancePrompt': ?enhancePrompt,
-    };
-  }
+@Schema()
+abstract class $VirtualTryOnOutputOptions {
+  String? get mimeType;
+  int? get compressionQuality;
 }
 
 bool isVirtualTryOnModelName(String modelName) {
@@ -76,6 +60,7 @@ ActionMetadata virtualTryOnModelMetadata(String pluginName, String modelName) {
   return modelMetadata(
     '$pluginName/$modelName',
     modelInfo: virtualTryOnModelInfo,
+    customOptions: VirtualTryOnOptions.$schema,
   );
 }
 
@@ -89,6 +74,7 @@ Model createVirtualTryOnModel({
 }) {
   return Model(
     name: '$pluginName/$modelName',
+    customOptions: VirtualTryOnOptions.$schema,
     metadata: {'model': virtualTryOnModelInfo.toJson()},
     fn: (req, ctx) async {
       if (ctx.streamingRequested) {

--- a/packages/genkit_vertexai/lib/src/virtual_try_on.g.dart
+++ b/packages/genkit_vertexai/lib/src/virtual_try_on.g.dart
@@ -1,0 +1,270 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'virtual_try_on.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+base class VirtualTryOnOptions {
+  factory VirtualTryOnOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  VirtualTryOnOptions._(this._json);
+
+  VirtualTryOnOptions({
+    VirtualTryOnOutputOptions? outputOptions,
+    int? sampleCount,
+    String? storageUri,
+    int? seed,
+    int? baseSteps,
+    String? safetySetting,
+    String? personGeneration,
+    bool? addWatermark,
+    bool? enhancePrompt,
+  }) {
+    _json = {
+      'outputOptions': ?outputOptions?.toJson(),
+      'sampleCount': ?sampleCount,
+      'storageUri': ?storageUri,
+      'seed': ?seed,
+      'baseSteps': ?baseSteps,
+      'safetySetting': ?safetySetting,
+      'personGeneration': ?personGeneration,
+      'addWatermark': ?addWatermark,
+      'enhancePrompt': ?enhancePrompt,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static const SchemanticType<VirtualTryOnOptions> $schema =
+      _VirtualTryOnOptionsTypeFactory();
+
+  VirtualTryOnOutputOptions? get outputOptions {
+    return _json['outputOptions'] == null
+        ? null
+        : VirtualTryOnOutputOptions.fromJson(
+            _json['outputOptions'] as Map<String, dynamic>,
+          );
+  }
+
+  set outputOptions(VirtualTryOnOutputOptions? value) {
+    if (value == null) {
+      _json.remove('outputOptions');
+    } else {
+      _json['outputOptions'] = value;
+    }
+  }
+
+  int? get sampleCount {
+    return _json['sampleCount'] as int?;
+  }
+
+  set sampleCount(int? value) {
+    if (value == null) {
+      _json.remove('sampleCount');
+    } else {
+      _json['sampleCount'] = value;
+    }
+  }
+
+  String? get storageUri {
+    return _json['storageUri'] as String?;
+  }
+
+  set storageUri(String? value) {
+    if (value == null) {
+      _json.remove('storageUri');
+    } else {
+      _json['storageUri'] = value;
+    }
+  }
+
+  int? get seed {
+    return _json['seed'] as int?;
+  }
+
+  set seed(int? value) {
+    if (value == null) {
+      _json.remove('seed');
+    } else {
+      _json['seed'] = value;
+    }
+  }
+
+  int? get baseSteps {
+    return _json['baseSteps'] as int?;
+  }
+
+  set baseSteps(int? value) {
+    if (value == null) {
+      _json.remove('baseSteps');
+    } else {
+      _json['baseSteps'] = value;
+    }
+  }
+
+  String? get safetySetting {
+    return _json['safetySetting'] as String?;
+  }
+
+  set safetySetting(String? value) {
+    if (value == null) {
+      _json.remove('safetySetting');
+    } else {
+      _json['safetySetting'] = value;
+    }
+  }
+
+  String? get personGeneration {
+    return _json['personGeneration'] as String?;
+  }
+
+  set personGeneration(String? value) {
+    if (value == null) {
+      _json.remove('personGeneration');
+    } else {
+      _json['personGeneration'] = value;
+    }
+  }
+
+  bool? get addWatermark {
+    return _json['addWatermark'] as bool?;
+  }
+
+  set addWatermark(bool? value) {
+    if (value == null) {
+      _json.remove('addWatermark');
+    } else {
+      _json['addWatermark'] = value;
+    }
+  }
+
+  bool? get enhancePrompt {
+    return _json['enhancePrompt'] as bool?;
+  }
+
+  set enhancePrompt(bool? value) {
+    if (value == null) {
+      _json.remove('enhancePrompt');
+    } else {
+      _json['enhancePrompt'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _VirtualTryOnOptionsTypeFactory
+    extends SchemanticType<VirtualTryOnOptions> {
+  const _VirtualTryOnOptionsTypeFactory();
+
+  @override
+  VirtualTryOnOptions parse(Object? json) {
+    return VirtualTryOnOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'VirtualTryOnOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'outputOptions': $Schema.fromMap({
+              '\$ref': r'#/$defs/VirtualTryOnOutputOptions',
+            }),
+            'sampleCount': $Schema.integer(),
+            'storageUri': $Schema.string(),
+            'seed': $Schema.integer(),
+            'baseSteps': $Schema.integer(),
+            'safetySetting': $Schema.string(),
+            'personGeneration': $Schema.string(),
+            'addWatermark': $Schema.boolean(),
+            'enhancePrompt': $Schema.boolean(),
+          },
+        )
+        .value,
+    dependencies: [VirtualTryOnOutputOptions.$schema],
+  );
+}
+
+base class VirtualTryOnOutputOptions {
+  factory VirtualTryOnOutputOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  VirtualTryOnOutputOptions._(this._json);
+
+  VirtualTryOnOutputOptions({String? mimeType, int? compressionQuality}) {
+    _json = {'mimeType': ?mimeType, 'compressionQuality': ?compressionQuality};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  static const SchemanticType<VirtualTryOnOutputOptions> $schema =
+      _VirtualTryOnOutputOptionsTypeFactory();
+
+  String? get mimeType {
+    return _json['mimeType'] as String?;
+  }
+
+  set mimeType(String? value) {
+    if (value == null) {
+      _json.remove('mimeType');
+    } else {
+      _json['mimeType'] = value;
+    }
+  }
+
+  int? get compressionQuality {
+    return _json['compressionQuality'] as int?;
+  }
+
+  set compressionQuality(int? value) {
+    if (value == null) {
+      _json.remove('compressionQuality');
+    } else {
+      _json['compressionQuality'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _VirtualTryOnOutputOptionsTypeFactory
+    extends SchemanticType<VirtualTryOnOutputOptions> {
+  const _VirtualTryOnOutputOptionsTypeFactory();
+
+  @override
+  VirtualTryOnOutputOptions parse(Object? json) {
+    return VirtualTryOnOutputOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'VirtualTryOnOutputOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'mimeType': $Schema.string(),
+            'compressionQuality': $Schema.integer(),
+          },
+        )
+        .value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_vertexai/lib/src/virtual_try_on.g.dart
+++ b/packages/genkit_vertexai/lib/src/virtual_try_on.g.dart
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'virtual_try_on.dart';

--- a/packages/genkit_vertexai/pubspec.yaml
+++ b/packages/genkit_vertexai/pubspec.yaml
@@ -17,4 +17,5 @@ dependencies:
   schemantic: ^0.1.1
 
 dev_dependencies:
+  build_runner: ^2.15.0
   test: ^1.29.0

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -15,7 +15,6 @@
 import 'dart:convert';
 
 import 'package:genkit/genkit.dart';
-
 import 'package:genkit_vertexai/src/vertex_api_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';

--- a/packages/genkit_vertexai/test/virtual_try_on_test.dart
+++ b/packages/genkit_vertexai/test/virtual_try_on_test.dart
@@ -59,6 +59,7 @@ void main() {
 
       expect(modelRef.name, 'vertexai/virtual-try-on-001');
       expect(modelRef.config, isNull);
+      expect(modelRef.customOptions, VirtualTryOnOptions.$schema);
     });
 
     test('uses predict endpoint', () async {
@@ -69,7 +70,10 @@ void main() {
         authClient: mockClient,
       );
 
-      final model = plugin.resolve('model', 'virtual-try-on-001') as Action;
+      final model = plugin.resolve('model', 'virtual-try-on-001') as Model;
+      expect(model.customOptions, VirtualTryOnOptions.$schema);
+      expect(model.metadata['model']['supports']['systemRole'], isFalse);
+
       final req = ModelRequest(
         messages: [
           Message(
@@ -100,7 +104,7 @@ void main() {
       );
 
       final result = await model.run(req);
-      final response = result.result as ModelResponse;
+      final response = result.result;
 
       expect(mockClient.lastUrl, isNotNull);
       expect(

--- a/packages/genkit_vertexai/test/virtual_try_on_test.dart
+++ b/packages/genkit_vertexai/test/virtual_try_on_test.dart
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_vertexai/genkit_vertexai.dart';
+import 'package:genkit_vertexai/src/vertex_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+class MockHttpClient extends http.BaseClient {
+  Uri? lastUrl;
+  String? lastBody;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    lastUrl = request.url;
+    lastBody = await request.finalize().bytesToString();
+    if (request.url.host == 'metadata.google.internal' ||
+        request.url.host == 'oauth2.googleapis.com') {
+      return http.StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            '{"access_token": "ya29.mock", "expires_in": 3600, "token_type": "Bearer"}',
+          ),
+        ),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          '{"predictions": [{"mimeType": "image/png", "bytesBase64Encoded": "b3V0cHV0"}]}',
+        ),
+      ),
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+}
+
+void main() {
+  group('Virtual Try-On', () {
+    test('creates a model ref', () {
+      final modelRef = vertexAI.virtualTryOn();
+
+      expect(modelRef.name, 'vertexai/virtual-try-on-001');
+      expect(modelRef.config, isNull);
+    });
+
+    test('uses predict endpoint', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: mockClient,
+      );
+
+      final model = plugin.resolve('model', 'virtual-try-on-001') as Action;
+      final req = ModelRequest(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [
+              TextPart(text: 'Try on this sweater'),
+              MediaPart(
+                media: Media(
+                  contentType: 'image/png',
+                  url: 'data:image/png;base64,cGVyc29u',
+                ),
+                metadata: {'type': 'personImage'},
+              ),
+              MediaPart(
+                media: Media(
+                  contentType: 'image/jpeg',
+                  url: 'data:image/jpeg;base64,cHJvZHVjdA==',
+                ),
+                metadata: {'type': 'productImage'},
+              ),
+            ],
+          ),
+        ],
+        config: VirtualTryOnOptions(
+          sampleCount: 2,
+          storageUri: 'gs://bucket/out',
+        ).toJson(),
+      );
+
+      final result = await model.run(req);
+      final response = result.result as ModelResponse;
+
+      expect(mockClient.lastUrl, isNotNull);
+      expect(
+        mockClient.lastUrl.toString(),
+        'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/publishers/google/models/virtual-try-on-001:predict',
+      );
+      expect(jsonDecode(mockClient.lastBody!), {
+        'instances': [
+          {
+            'personImage': {
+              'image': {
+                'mimeType': 'image/png',
+                'bytesBase64Encoded': 'cGVyc29u',
+              },
+            },
+            'productImages': [
+              {
+                'image': {
+                  'mimeType': 'image/jpeg',
+                  'bytesBase64Encoded': 'cHJvZHVjdA==',
+                },
+              },
+            ],
+          },
+        ],
+        'parameters': {'sampleCount': 2, 'storageUri': 'gs://bucket/out'},
+      });
+      expect(response.media?.url, 'data:image/png;base64,b3V0cHV0');
+      expect(response.usage?.outputImages, 1);
+    });
+  });
+}

--- a/packages/genkit_vertexai/test/virtual_try_on_test.dart
+++ b/packages/genkit_vertexai/test/virtual_try_on_test.dart
@@ -72,7 +72,9 @@ void main() {
 
       final model = plugin.resolve('model', 'virtual-try-on-001') as Model;
       expect(model.customOptions, VirtualTryOnOptions.$schema);
-      expect(model.metadata['model']['supports']['systemRole'], isFalse);
+      final modelInfo = model.metadata['model'] as Map<String, dynamic>;
+      final supports = modelInfo['supports'] as Map<String, dynamic>;
+      expect(supports['systemRole'], isFalse);
 
       final req = ModelRequest(
         messages: [

--- a/packages/genkit_vertexai/test/virtual_try_on_test.dart
+++ b/packages/genkit_vertexai/test/virtual_try_on_test.dart
@@ -137,5 +137,52 @@ void main() {
       expect(response.media?.url, 'data:image/png;base64,b3V0cHV0');
       expect(response.usage?.outputImages, 1);
     });
+
+    test('rejects unsupported image URI schemes', () async {
+      final mockClient = MockHttpClient();
+      final plugin = VertexAiPluginImpl(
+        projectId: 'my-project',
+        location: 'us-central1',
+        authClient: mockClient,
+      );
+
+      final model = plugin.resolve('model', 'virtual-try-on-001') as Model;
+      final req = ModelRequest(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [
+              MediaPart(
+                media: Media(
+                  contentType: 'image/png',
+                  url: 'file:///tmp/person.png',
+                ),
+                metadata: {'type': 'personImage'},
+              ),
+              MediaPart(
+                media: Media(
+                  contentType: 'image/jpeg',
+                  url: 'data:image/jpeg;base64,cHJvZHVjdA==',
+                ),
+                metadata: {'type': 'productImage'},
+              ),
+            ],
+          ),
+        ],
+      );
+
+      await expectLater(
+        model.run(req),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having(
+                (e) => e.message,
+                'message',
+                'Unsupported URI scheme "file" for virtual try-on image. Use a data URL or a Cloud Storage URI.',
+              ),
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
Adds Virtual Try On model to VertexAI plugin.

## Testing
**The following puts a shirt (image A) onto a person (image B):**

Image A
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/d8049125-c1e3-4579-8b9e-8ba1a3e0d89e" />

Image B
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/aa60440e-857a-41f2-a91c-ff8840827907" />

Result
<img width="1377" height="946" alt="image" src="https://github.com/user-attachments/assets/8611b845-8a41-4e3e-b135-f05266c146eb" />

Params
<img width="1249" height="651" alt="image" src="https://github.com/user-attachments/assets/98ee3438-87ac-4261-8617-2c76a2856e88" />