### PR TITLE
feat!: add dotprompt integration with executable prompts and folder loading

### DIFF
--- a/packages/genkit/lib/genkit.dart
+++ b/packages/genkit/lib/genkit.dart
@@ -40,7 +40,13 @@ export 'src/ai/middleware/retry.dart'
     show RetryMiddleware, RetryOptions, RetryPlugin, retry;
 export 'src/ai/model.dart'
     show BidiModel, Model, ModelRef, modelMetadata, modelRef;
-export 'src/ai/prompt.dart' show PromptAction, PromptFn;
+export 'src/ai/prompt.dart'
+    show
+        ExecutablePrompt,
+        PromptAction,
+        PromptConfig,
+        PromptFn,
+        PromptGenerateOptions;
 export 'src/ai/resource.dart'
     show
         ResourceAction,

--- a/packages/genkit/lib/genkit.dart
+++ b/packages/genkit/lib/genkit.dart
@@ -54,6 +54,8 @@ export 'src/ai/resource.dart'
         ResourceInput,
         ResourceOutput,
         createResourceMatcher;
+export 'src/ai/template_helper.dart'
+    show TemplateHelperFn, TemplateHelperOptions;
 export 'src/ai/tool.dart' show Tool, ToolFn, ToolFnArgs;
 export 'src/core/action.dart' show Action, ActionFnArg, ActionMetadata;
 export 'src/core/dynamic_action_provider.dart' show DynamicActionProvider;

--- a/packages/genkit/lib/src/ai/dotprompt_registry.dart
+++ b/packages/genkit/lib/src/ai/dotprompt_registry.dart
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import 'package:dotprompt/dotprompt.dart' as dp;
-import 'package:handlebars_dart/handlebars_dart.dart' show HelperFunction;
+
+import 'template_helper.dart';
 
 /// A wrapper around the dotprompt [dp.Dotprompt] instance for integration
 /// with the Genkit registry.
@@ -54,7 +55,7 @@ class DotpromptRegistry {
   }
 
   /// Defines a custom helper function.
-  void defineHelper(String name, HelperFunction helper) {
-    _dotprompt.defineHelper(name, helper);
+  void defineHelper(String name, TemplateHelperFn helper) {
+    _dotprompt.defineHelper(name, wrapTemplateHelper(helper));
   }
 }

--- a/packages/genkit/lib/src/ai/dotprompt_registry.dart
+++ b/packages/genkit/lib/src/ai/dotprompt_registry.dart
@@ -16,17 +16,38 @@ import 'package:dotprompt/dotprompt.dart' as dp;
 
 import 'template_helper.dart';
 
+/// Callback type for resolving named schemas.
+///
+/// Given a schema [name], returns the JSON Schema map if found,
+/// or `null` if the schema is not registered.
+typedef SchemaResolver = Future<Map<String, dynamic>?> Function(String name);
+
 /// A wrapper around the dotprompt [dp.Dotprompt] instance for integration
 /// with the Genkit registry.
 ///
 /// This class manages the lifecycle of the Dotprompt instance, providing
 /// methods for parsing, compiling, and rendering prompt templates, as well
-/// as registering partials and helpers.
+/// as registering partials, helpers, and schemas.
 class DotpromptRegistry {
   final dp.Dotprompt _dotprompt;
 
-  DotpromptRegistry([dp.DotpromptOptions? options])
-    : _dotprompt = dp.Dotprompt(options);
+  DotpromptRegistry({
+    dp.DotpromptOptions? options,
+    SchemaResolver? schemaResolver,
+  }) : _dotprompt = dp.Dotprompt(
+          dp.DotpromptOptions(
+            defaultModel: options?.defaultModel,
+            modelConfigs: options?.modelConfigs,
+            helpers: options?.helpers,
+            partials: options?.partials,
+            tools: options?.tools,
+            schemas: options?.schemas,
+            partialResolver: options?.partialResolver,
+            toolResolver: options?.toolResolver,
+            schemaResolver: schemaResolver ?? options?.schemaResolver,
+            store: options?.store,
+          ),
+        );
 
   /// The underlying [dp.Dotprompt] instance.
   dp.Dotprompt get dotprompt => _dotprompt;
@@ -57,5 +78,14 @@ class DotpromptRegistry {
   /// Defines a custom helper function.
   void defineHelper(String name, TemplateHelperFn helper) {
     _dotprompt.defineHelper(name, wrapTemplateHelper(helper));
+  }
+
+  /// Registers a named schema for use in prompt templates.
+  ///
+  /// Named schemas can be referenced by name in Picoschema definitions
+  /// within prompt templates (e.g., in `input.schema` or `output.schema`
+  /// frontmatter fields).
+  void defineSchema(String name, Map<String, dynamic> schema) {
+    _dotprompt.defineSchema(name, schema);
   }
 }

--- a/packages/genkit/lib/src/ai/dotprompt_registry.dart
+++ b/packages/genkit/lib/src/ai/dotprompt_registry.dart
@@ -35,19 +35,19 @@ class DotpromptRegistry {
     dp.DotpromptOptions? options,
     SchemaResolver? schemaResolver,
   }) : _dotprompt = dp.Dotprompt(
-          dp.DotpromptOptions(
-            defaultModel: options?.defaultModel,
-            modelConfigs: options?.modelConfigs,
-            helpers: options?.helpers,
-            partials: options?.partials,
-            tools: options?.tools,
-            schemas: options?.schemas,
-            partialResolver: options?.partialResolver,
-            toolResolver: options?.toolResolver,
-            schemaResolver: schemaResolver ?? options?.schemaResolver,
-            store: options?.store,
-          ),
-        );
+         dp.DotpromptOptions(
+           defaultModel: options?.defaultModel,
+           modelConfigs: options?.modelConfigs,
+           helpers: options?.helpers,
+           partials: options?.partials,
+           tools: options?.tools,
+           schemas: options?.schemas,
+           partialResolver: options?.partialResolver,
+           toolResolver: options?.toolResolver,
+           schemaResolver: schemaResolver ?? options?.schemaResolver,
+           store: options?.store,
+         ),
+       );
 
   /// The underlying [dp.Dotprompt] instance.
   dp.Dotprompt get dotprompt => _dotprompt;

--- a/packages/genkit/lib/src/ai/dotprompt_registry.dart
+++ b/packages/genkit/lib/src/ai/dotprompt_registry.dart
@@ -1,0 +1,61 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:dotprompt/dotprompt.dart' as dp;
+import 'package:handlebars_dart/handlebars_dart.dart' show HelperFunction;
+
+/// A wrapper around the dotprompt [dp.Dotprompt] instance for integration
+/// with the Genkit registry.
+///
+/// This class manages the lifecycle of the Dotprompt instance, providing
+/// methods for parsing, compiling, and rendering prompt templates, as well
+/// as registering partials and helpers.
+class DotpromptRegistry {
+  final dp.Dotprompt _dotprompt;
+
+  DotpromptRegistry([dp.DotpromptOptions? options])
+      : _dotprompt = dp.Dotprompt(options);
+
+  /// The underlying [dp.Dotprompt] instance.
+  dp.Dotprompt get dotprompt => _dotprompt;
+
+  /// Parses a prompt template source into a [dp.ParsedPrompt].
+  dp.ParsedPrompt parse(String source) => _dotprompt.parse(source);
+
+  /// Compiles a template for repeated rendering.
+  Future<dp.PromptFunction> compile(String source) =>
+      _dotprompt.compile(source);
+
+  /// Renders a prompt template with the provided data.
+  Future<dp.RenderedPrompt> render(
+    String source,
+    dp.DataArgument data, [
+    Map<String, dynamic>? options,
+  ]) =>
+      _dotprompt.render(source, data, options);
+
+  /// Renders metadata for a template without rendering the full template.
+  Future<dp.PromptMetadata> renderMetadata(String source) =>
+      _dotprompt.renderMetadata(source);
+
+  /// Defines a partial template.
+  void definePartial(String name, String source) {
+    _dotprompt.definePartial(name, source);
+  }
+
+  /// Defines a custom helper function.
+  void defineHelper(String name, HelperFunction helper) {
+    _dotprompt.defineHelper(name, helper);
+  }
+}

--- a/packages/genkit/lib/src/ai/dotprompt_registry.dart
+++ b/packages/genkit/lib/src/ai/dotprompt_registry.dart
@@ -25,7 +25,7 @@ class DotpromptRegistry {
   final dp.Dotprompt _dotprompt;
 
   DotpromptRegistry([dp.DotpromptOptions? options])
-      : _dotprompt = dp.Dotprompt(options);
+    : _dotprompt = dp.Dotprompt(options);
 
   /// The underlying [dp.Dotprompt] instance.
   dp.Dotprompt get dotprompt => _dotprompt;
@@ -42,8 +42,7 @@ class DotpromptRegistry {
     String source,
     dp.DataArgument data, [
     Map<String, dynamic>? options,
-  ]) =>
-      _dotprompt.render(source, data, options);
+  ]) => _dotprompt.render(source, data, options);
 
   /// Renders metadata for a template without rendering the full template.
   Future<dp.PromptMetadata> renderMetadata(String source) =>

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -401,8 +401,9 @@ Map<String, dynamic>? _configToMap(dynamic config) {
 
 /// Defines an executable prompt and registers it in the registry.
 ///
-/// This creates both a `PromptAction` (registered as actionType 'prompt')
-/// and returns an [ExecutablePrompt] that can be called directly.
+/// This creates both a `PromptAction` (registered as actionType
+/// 'executable-prompt') and returns an [ExecutablePrompt] that can be called
+/// directly.
 ExecutablePrompt<Input> definePromptAction<CustomOptions, Input>(
   Registry registry,
   DotpromptRegistry dotpromptRegistry,
@@ -468,7 +469,7 @@ class PromptAction<Input>
     Map<String, dynamic>? metadata,
   }) : _executablePrompt = executablePrompt,
        super(
-         actionType: 'prompt',
+         actionType: 'executable-prompt',
          outputSchema: GenerateActionOptions.$schema,
          metadata: _promptActionMetadata(description, metadata),
          fn: (input, ctx) async {
@@ -517,7 +518,7 @@ Future<ExecutablePrompt> lookupPrompt(
   String? variant,
 }) async {
   final lookupName = variant != null ? '$name.$variant' : name;
-  final action = await registry.lookupAction('prompt', lookupName);
+  final action = await registry.lookupAction('executable-prompt', lookupName);
   if (action != null && action is PromptAction) {
     final ep = action.executablePrompt;
     if (ep != null) return ep;

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -20,6 +20,7 @@ import 'package:schemantic/schemantic.dart';
 import '../core/action.dart';
 import '../core/registry.dart';
 import '../exception.dart';
+import '../o11y/instrumentation.dart';
 import '../types.dart';
 import 'dotprompt_registry.dart';
 import 'generate.dart';
@@ -183,43 +184,53 @@ class ExecutablePrompt<Input> {
     Input? input, [
     PromptGenerateOptions? opts,
   ]) async {
-    final messages = <Message>[];
+    return runInNewSpan(
+      'render',
+      (telemetryContext) async {
+        final messages = <Message>[];
 
-    // 1. Render system prompt
-    await _renderSystem(input, messages);
+        // 1. Render system prompt
+        await _renderSystem(input, messages);
 
-    // 2. Render history / messages
-    await _renderMessages(input, messages, opts);
+        // 2. Render history / messages
+        await _renderMessages(input, messages, opts);
 
-    // 3. Render user prompt
-    await _renderUserPrompt(input, messages);
+        // 3. Render user prompt
+        await _renderUserPrompt(input, messages);
 
-    // Resolve model
-    final resolvedModel = opts?.model ?? _config.model;
+        // Resolve model
+        final resolvedModel = opts?.model ?? _config.model;
 
-    // Resolve config — merge config maps
-    final configMap = _configToMap(_config.config);
-    final optsConfigMap = _configToMap(opts?.config);
-    final resolvedConfig = <String, dynamic>{...?configMap, ...?optsConfigMap};
+        // Resolve config — merge config maps
+        final configMap = _configToMap(_config.config);
+        final optsConfigMap = _configToMap(opts?.config);
+        final resolvedConfig = <String, dynamic>{
+          ...?configMap,
+          ...?optsConfigMap,
+        };
 
-    // Resolve tools
-    final resolvedToolNames = <String>{
-      ...?_config.toolNames,
-      ...?opts?.toolNames,
-      ...?_config.tools?.map((t) => t.name),
-      ...?opts?.tools?.map((t) => t.name),
-    }.toList();
+        // Resolve tools
+        final resolvedToolNames = <String>{
+          ...?_config.toolNames,
+          ...?opts?.toolNames,
+          ...?_config.tools?.map((t) => t.name),
+          ...?opts?.tools?.map((t) => t.name),
+        }.toList();
 
-    return GenerateActionOptions(
-      model: resolvedModel?.name,
-      messages: messages,
-      config: resolvedConfig.isNotEmpty ? resolvedConfig : null,
-      tools: resolvedToolNames.isNotEmpty ? resolvedToolNames : null,
-      toolChoice: opts?.toolChoice ?? _config.toolChoice,
-      returnToolRequests:
-          opts?.returnToolRequests ?? _config.returnToolRequests,
-      maxTurns: opts?.maxTurns ?? _config.maxTurns,
-      output: opts?.output ?? _config.output,
+        return GenerateActionOptions(
+          model: resolvedModel?.name,
+          messages: messages,
+          config: resolvedConfig.isNotEmpty ? resolvedConfig : null,
+          tools: resolvedToolNames.isNotEmpty ? resolvedToolNames : null,
+          toolChoice: opts?.toolChoice ?? _config.toolChoice,
+          returnToolRequests:
+              opts?.returnToolRequests ?? _config.returnToolRequests,
+          maxTurns: opts?.maxTurns ?? _config.maxTurns,
+          output: opts?.output ?? _config.output,
+        );
+      },
+      input: input,
+      actionType: 'promptTemplate',
     );
   }
 
@@ -273,39 +284,48 @@ class ExecutablePrompt<Input> {
     PromptGenerateOptions? opts, {
     StreamingCallback<GenerateResponseChunk>? onChunk,
   }) async {
-    final options = await render(input, opts);
+    return runInNewSpan(
+      ref.name,
+      (telemetryContext) async {
+        final options = await render(input, opts);
 
-    // Resolve tools from both config and opts into a child registry
-    final allTools = <Tool>[...?_config.tools, ...?opts?.tools];
+        // Resolve tools from both config and opts into a child registry
+        final allTools = <Tool>[...?_config.tools, ...?opts?.tools];
 
-    final middleware = <GenerateMiddlewareOneof>[
-      ...?_config.use?.map(
-        (mw) => (middlewareRef: mw, middlewareInstance: null),
-      ),
-      ...?opts?.use?.map((mw) => (middlewareRef: mw, middlewareInstance: null)),
-    ];
+        final middleware = <GenerateMiddlewareOneof>[
+          ...?_config.use?.map(
+            (mw) => (middlewareRef: mw, middlewareInstance: null),
+          ),
+          ...?opts?.use?.map(
+            (mw) => (middlewareRef: mw, middlewareInstance: null),
+          ),
+        ];
 
-    var registry = _registry;
-    if (allTools.isNotEmpty) {
-      registry = Registry.childOf(_registry);
-      for (final tool in allTools) {
-        registry.register(tool);
-      }
-    }
+        var registry = _registry;
+        if (allTools.isNotEmpty) {
+          registry = Registry.childOf(_registry);
+          for (final tool in allTools) {
+            registry.register(tool);
+          }
+        }
 
-    return generateHelper(
-      registry,
-      messages: options.messages,
-      model: options.model != null ? modelRef(options.model!) : null,
-      config: options.config,
-      tools: options.tools,
-      toolChoice: options.toolChoice,
-      returnToolRequests: options.returnToolRequests,
-      maxTurns: options.maxTurns,
-      output: options.output,
-      context: opts?.context,
-      middleware: middleware.isNotEmpty ? middleware : null,
-      onChunk: onChunk,
+        return generateHelper(
+          registry,
+          messages: options.messages,
+          model: options.model != null ? modelRef(options.model!) : null,
+          config: options.config,
+          tools: options.tools,
+          toolChoice: options.toolChoice,
+          returnToolRequests: options.returnToolRequests,
+          maxTurns: options.maxTurns,
+          output: options.output,
+          context: opts?.context,
+          middleware: middleware.isNotEmpty ? middleware : null,
+          onChunk: onChunk,
+        );
+      },
+      input: input,
+      actionType: 'dotprompt',
     );
   }
 
@@ -448,6 +468,8 @@ Map<String, dynamic> _buildPromptMetadata<CustomOptions, Input>(
       if (config.config != null) 'config': _configToMap(config.config),
       if (config.toolNames != null) 'tools': config.toolNames,
       if (config.toolChoice != null) 'toolChoice': config.toolChoice,
+      if (config.messagesTemplate != null) 'template': config.messagesTemplate,
+      // TODO: Add middleware metadata when middleware support is added.
     },
   };
 }

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -162,10 +162,10 @@ class ExecutablePrompt<Input> {
   final DotpromptRegistry _dotpromptRegistry;
   final PromptConfig<dynamic, Input> _config;
 
-  // Memoized compiled templates
-  dp.PromptFunction? _compiledSystem;
-  dp.PromptFunction? _compiledPrompt;
-  dp.PromptFunction? _compiledMessages;
+  // Memoized compiled template futures (Future-based for concurrency safety).
+  Future<dp.PromptFunction>? _compiledSystem;
+  Future<dp.PromptFunction>? _compiledPrompt;
+  Future<dp.PromptFunction>? _compiledMessages;
 
   ExecutablePrompt._({
     required Registry registry,
@@ -239,7 +239,52 @@ class ExecutablePrompt<Input> {
   Future<GenerateResponseHelper> call(
     Input? input, [
     PromptGenerateOptions? opts,
-  ]) async {
+  ]) => _generate(input, opts);
+
+  /// Streams a response by rendering the prompt and calling the model.
+  ActionStream<GenerateResponseChunk, GenerateResponseHelper> stream(
+    Input? input, [
+    PromptGenerateOptions? opts,
+  ]) {
+    final streamController = StreamController<GenerateResponseChunk>();
+    final actionStream =
+        ActionStream<GenerateResponseChunk, GenerateResponseHelper>(
+          streamController.stream,
+        );
+
+    _generate(
+      input,
+      opts,
+      onChunk: (chunk) {
+        if (!streamController.isClosed) {
+          streamController.add(chunk);
+        }
+      },
+    ).then(
+      (result) {
+        actionStream.setResult(result);
+        if (!streamController.isClosed) {
+          streamController.close();
+        }
+      },
+      onError: (Object e, StackTrace s) {
+        actionStream.setError(e, s);
+        if (!streamController.isClosed) {
+          streamController.addError(e, s);
+          streamController.close();
+        }
+      },
+    );
+
+    return actionStream;
+  }
+
+  /// Internal generate implementation shared by [call] and [stream].
+  Future<GenerateResponseHelper> _generate(
+    Input? input,
+    PromptGenerateOptions? opts, {
+    StreamingCallback<GenerateResponseChunk>? onChunk,
+  }) async {
     final options = await render(input, opts);
 
     // Resolve tools from both config and opts into a child registry
@@ -263,7 +308,7 @@ class ExecutablePrompt<Input> {
     return generateHelper(
       registry,
       messages: options.messages,
-      model: options.model != null ? _SimpleModelRef(options.model!) : null,
+      model: options.model != null ? modelRef(options.model!) : null,
       config: options.config,
       tools: options.tools,
       toolChoice: options.toolChoice,
@@ -272,46 +317,18 @@ class ExecutablePrompt<Input> {
       output: options.output,
       context: opts?.context,
       middleware: middleware.isNotEmpty ? middleware : null,
+      onChunk: onChunk,
     );
-  }
-
-  /// Streams a response by rendering the prompt and calling the model.
-  ActionStream<GenerateResponseChunk, GenerateResponseHelper> stream(
-    Input? input, [
-    PromptGenerateOptions? opts,
-  ]) {
-    final streamController = StreamController<GenerateResponseChunk>();
-    final actionStream =
-        ActionStream<GenerateResponseChunk, GenerateResponseHelper>(
-          streamController.stream,
-        );
-
-    call(input, opts).then(
-      (result) {
-        actionStream.setResult(result);
-        if (!streamController.isClosed) {
-          streamController.close();
-        }
-      },
-      onError: (Object e, StackTrace s) {
-        actionStream.setError(e, s);
-        if (!streamController.isClosed) {
-          streamController.addError(e, s);
-          streamController.close();
-        }
-      },
-    );
-
-    return actionStream;
   }
 
   // --- Internal rendering methods ---
 
   Future<void> _renderSystem(Input? input, List<Message> messages) async {
     if (_config.system != null) {
-      // Handlebars template
-      _compiledSystem ??= await _dotpromptRegistry.compile(_config.system!);
-      final rendered = await _compiledSystem!.render(
+      // Handlebars template (Future-based memoization for concurrency safety)
+      _compiledSystem ??= _dotpromptRegistry.compile(_config.system!);
+      final compiled = await _compiledSystem!;
+      final rendered = await compiled.render(
         dp.DataArgument(input: _inputToMap(input)),
       );
       messages.addAll(rendered.messages.map(dpMessageToGenkitMessage));
@@ -332,10 +349,11 @@ class ExecutablePrompt<Input> {
   ) async {
     if (_config.messagesTemplate != null) {
       // Handlebars template for messages
-      _compiledMessages ??= await _dotpromptRegistry.compile(
+      _compiledMessages ??= _dotpromptRegistry.compile(
         _config.messagesTemplate!,
       );
-      final rendered = await _compiledMessages!.render(
+      final compiled = await _compiledMessages!;
+      final rendered = await compiled.render(
         dp.DataArgument(
           input: _inputToMap(input),
           messages: opts?.messages?.map(genkitMessageToDpMessage).toList(),
@@ -354,9 +372,10 @@ class ExecutablePrompt<Input> {
 
   Future<void> _renderUserPrompt(Input? input, List<Message> messages) async {
     if (_config.prompt != null) {
-      // Handlebars template
-      _compiledPrompt ??= await _dotpromptRegistry.compile(_config.prompt!);
-      final rendered = await _compiledPrompt!.render(
+      // Handlebars template (Future-based memoization for concurrency safety)
+      _compiledPrompt ??= _dotpromptRegistry.compile(_config.prompt!);
+      final compiled = await _compiledPrompt!;
+      final rendered = await compiled.render(
         dp.DataArgument(input: _inputToMap(input)),
       );
       // The dotprompt render may produce multiple messages; add all as user
@@ -388,21 +407,8 @@ class ExecutablePrompt<Input> {
 /// Converts a config value to a Map. Follows the same pattern as generate.dart.
 Map<String, dynamic>? _configToMap(dynamic config) {
   if (config == null) return null;
-  return config is Map
-      ? config as Map<String, dynamic>
-      : (config as dynamic)?.toJson() as Map<String, dynamic>?;
-}
-
-/// Private ModelRef implementation for internal use.
-class _SimpleModelRef implements ModelRef<dynamic> {
-  @override
-  final String name;
-  @override
-  final dynamic config = null;
-  @override
-  final SchemanticType<dynamic>? customOptions = null;
-
-  _SimpleModelRef(this.name);
+  if (config is Map) return config as Map<String, dynamic>;
+  return (config as dynamic).toJson() as Map<String, dynamic>;
 }
 
 /// Defines an executable prompt and registers it in the registry.

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -12,37 +12,511 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import '../core/action.dart';
-import '../types.dart';
+import 'dart:async';
 
-typedef PromptFn<Input> =
-    Future<GenerateActionOptions> Function(
-      Input input,
-      ActionFnArg<void, Input, void> ctx,
+import 'package:dotprompt/dotprompt.dart' as dp;
+import 'package:schemantic/schemantic.dart';
+
+import '../core/action.dart';
+import '../core/registry.dart';
+import '../exception.dart';
+import '../types.dart';
+import 'dotprompt_registry.dart';
+import 'generate.dart';
+import 'generate_middleware.dart';
+import 'generate_types.dart';
+import 'model.dart';
+import 'prompt_types.dart';
+import 'tool.dart';
+
+/// Configuration for defining a prompt.
+///
+/// This holds all the metadata needed to define an executable prompt action.
+class PromptConfig<CustomOptions, Input> {
+  /// The name of the prompt.
+  final String name;
+
+  /// An optional variant identifier.
+  final String? variant;
+
+  /// The model to use.
+  final ModelRef<CustomOptions>? model;
+
+  /// Model configuration (temperature, etc.).
+  final CustomOptions? config;
+
+  /// A human-readable description.
+  final String? description;
+
+  /// Input schema for the prompt.
+  final SchemanticType<Input>? inputSchema;
+
+  /// System prompt as a Handlebars template string.
+  final String? system;
+
+  /// System prompt as literal parts.
+  final List<Part>? systemParts;
+
+  /// User prompt as a Handlebars template string.
+  final String? prompt;
+
+  /// User prompt as literal parts.
+  final List<Part>? promptParts;
+
+  /// Literal message history.
+  final List<Message>? messages;
+
+  /// Messages as a Handlebars template string (e.g. loaded from .prompt files).
+  final String? messagesTemplate;
+
+  /// Output format configuration.
+  final GenerateActionOutputConfig? output;
+
+  /// Maximum number of tool-call turns.
+  final int? maxTurns;
+
+  /// Whether to return tool requests instead of executing them.
+  final bool? returnToolRequests;
+
+  /// Additional metadata.
+  final Map<String, dynamic>? metadata;
+
+  /// Tools available to the prompt.
+  final List<Tool>? tools;
+
+  /// Tool names (for tools already registered in the registry).
+  final List<String>? toolNames;
+
+  /// Tool choice strategy.
+  final String? toolChoice;
+
+  /// Middleware references.
+  final List<GenerateMiddlewareRef>? use;
+
+  PromptConfig({
+    required this.name,
+    this.variant,
+    this.model,
+    this.config,
+    this.description,
+    this.inputSchema,
+    this.system,
+    this.systemParts,
+    this.prompt,
+    this.promptParts,
+    this.messages,
+    this.messagesTemplate,
+    this.output,
+    this.maxTurns,
+    this.returnToolRequests,
+    this.metadata,
+    this.tools,
+    this.toolNames,
+    this.toolChoice,
+    this.use,
+  });
+
+  /// The full name including variant.
+  String get fullName => variant != null ? '$name.$variant' : name;
+}
+
+/// Options for generating from a prompt (everything except prompt/system
+/// content, which is defined by the prompt itself).
+class PromptGenerateOptions<CustomOptions> {
+  final ModelRef<CustomOptions>? model;
+  final CustomOptions? config;
+  final List<Tool>? tools;
+  final List<String>? toolNames;
+  final String? toolChoice;
+  final bool? returnToolRequests;
+  final int? maxTurns;
+  final GenerateActionOutputConfig? output;
+  final Map<String, dynamic>? context;
+  final List<GenerateMiddlewareRef>? use;
+  final List<Message>? messages;
+
+  PromptGenerateOptions({
+    this.model,
+    this.config,
+    this.tools,
+    this.toolNames,
+    this.toolChoice,
+    this.returnToolRequests,
+    this.maxTurns,
+    this.output,
+    this.context,
+    this.use,
+    this.messages,
+  });
+}
+
+/// An executable prompt that can render, generate, and stream.
+///
+/// It acts as a callable that invokes `generate` with the rendered prompt
+/// template, and also provides `.render()` and `.stream()` methods.
+class ExecutablePrompt<Input> {
+  /// A reference to the prompt (name + optional metadata).
+  final ({String name, Map<String, dynamic>? metadata}) ref;
+
+  final Registry _registry;
+  final DotpromptRegistry _dotpromptRegistry;
+  final PromptConfig<dynamic, Input> _config;
+
+  // Memoized compiled templates
+  dp.PromptFunction? _compiledSystem;
+  dp.PromptFunction? _compiledPrompt;
+  dp.PromptFunction? _compiledMessages;
+
+  ExecutablePrompt._({
+    required Registry registry,
+    required DotpromptRegistry dotpromptRegistry,
+    required PromptConfig<dynamic, Input> config,
+    Map<String, dynamic>? metadata,
+  })  : _registry = registry,
+        _dotpromptRegistry = dotpromptRegistry,
+        _config = config,
+        ref = (name: config.fullName, metadata: metadata);
+
+  /// Renders the prompt template with the given input, producing
+  /// [GenerateActionOptions] suitable for the `generate` action.
+  Future<GenerateActionOptions> render(
+    Input? input, [
+    PromptGenerateOptions? opts,
+  ]) async {
+    final messages = <Message>[];
+
+    // 1. Render system prompt
+    await _renderSystem(input, messages);
+
+    // 2. Render history / messages
+    await _renderMessages(input, messages, opts);
+
+    // 3. Render user prompt
+    await _renderUserPrompt(input, messages);
+
+    // Resolve model
+    final resolvedModel = opts?.model ?? _config.model;
+
+    // Resolve config — merge config maps
+    final configMap = _configToMap(_config.config);
+    final optsConfigMap = _configToMap(opts?.config);
+    final resolvedConfig = <String, dynamic>{
+      ...?configMap,
+      ...?optsConfigMap,
+    };
+
+    // Resolve tools
+    final resolvedToolNames = <String>[
+      ...?_config.toolNames,
+      ...?opts?.toolNames,
+    ];
+    if (_config.tools != null) {
+      for (final tool in _config.tools!) {
+        if (!resolvedToolNames.contains(tool.name)) {
+          resolvedToolNames.add(tool.name);
+        }
+      }
+    }
+    if (opts?.tools != null) {
+      for (final tool in opts!.tools!) {
+        if (!resolvedToolNames.contains(tool.name)) {
+          resolvedToolNames.add(tool.name);
+        }
+      }
+    }
+
+    return GenerateActionOptions(
+      model: resolvedModel?.name,
+      messages: messages,
+      config: resolvedConfig.isNotEmpty ? resolvedConfig : null,
+      tools: resolvedToolNames.isNotEmpty ? resolvedToolNames : null,
+      toolChoice: opts?.toolChoice ?? _config.toolChoice,
+      returnToolRequests:
+          opts?.returnToolRequests ?? _config.returnToolRequests,
+      maxTurns: opts?.maxTurns ?? _config.maxTurns,
+      output: opts?.output ?? _config.output,
+    );
+  }
+
+  /// Generates a response by rendering the prompt and calling the model.
+  Future<GenerateResponseHelper> call(
+    Input? input, [
+    PromptGenerateOptions? opts,
+  ]) async {
+    final options = await render(input, opts);
+
+    // Resolve tools from both config and opts into a child registry
+    final allTools = <Tool>[
+      ...?_config.tools,
+      ...?opts?.tools,
+    ];
+
+    final middleware = <GenerateMiddlewareOneof>[
+      ...?_config.use?.map(
+        (mw) => (middlewareRef: mw, middlewareInstance: null),
+      ),
+      ...?opts?.use?.map(
+        (mw) => (middlewareRef: mw, middlewareInstance: null),
+      ),
+    ];
+
+    var registry = _registry;
+    if (allTools.isNotEmpty) {
+      registry = Registry.childOf(_registry);
+      for (final tool in allTools) {
+        registry.register(tool);
+      }
+    }
+
+    return generateHelper(
+      registry,
+      messages: options.messages,
+      model: options.model != null ? _SimpleModelRef(options.model!) : null,
+      config: options.config,
+      tools: options.tools,
+      toolChoice: options.toolChoice,
+      returnToolRequests: options.returnToolRequests,
+      maxTurns: options.maxTurns,
+      output: options.output,
+      context: opts?.context,
+      middleware: middleware.isNotEmpty ? middleware : null,
+    );
+  }
+
+  /// Streams a response by rendering the prompt and calling the model.
+  ActionStream<GenerateResponseChunk, GenerateResponseHelper> stream(
+    Input? input, [
+    PromptGenerateOptions? opts,
+  ]) {
+    final streamController = StreamController<GenerateResponseChunk>();
+    final actionStream =
+        ActionStream<GenerateResponseChunk, GenerateResponseHelper>(
+      streamController.stream,
     );
 
+    call(input, opts).then(
+      (result) {
+        actionStream.setResult(result);
+        if (!streamController.isClosed) {
+          streamController.close();
+        }
+      },
+      onError: (Object e, StackTrace s) {
+        actionStream.setError(e, s);
+        if (!streamController.isClosed) {
+          streamController.addError(e, s);
+          streamController.close();
+        }
+      },
+    );
+
+    return actionStream;
+  }
+
+  // --- Internal rendering methods ---
+
+  Future<void> _renderSystem(
+    Input? input,
+    List<Message> messages,
+  ) async {
+    if (_config.system != null) {
+      // Handlebars template
+      _compiledSystem ??= await _dotpromptRegistry.compile(_config.system!);
+      final rendered = await _compiledSystem!.render(
+        dp.DataArgument(input: _inputToMap(input)),
+      );
+      messages.addAll(rendered.messages.map(dpMessageToGenkitMessage));
+      // If dotprompt rendered it as a user message, change role to system
+      if (messages.isNotEmpty && messages.last.role != Role.system) {
+        final last = messages.removeLast();
+        messages.add(Message(role: Role.system, content: last.content));
+      }
+    } else if (_config.systemParts != null) {
+      messages.add(Message(role: Role.system, content: _config.systemParts!));
+    }
+  }
+
+  Future<void> _renderMessages(
+    Input? input,
+    List<Message> messages,
+    PromptGenerateOptions? opts,
+  ) async {
+    if (_config.messagesTemplate != null) {
+      // Handlebars template for messages
+      _compiledMessages ??=
+          await _dotpromptRegistry.compile(_config.messagesTemplate!);
+      final rendered = await _compiledMessages!.render(
+        dp.DataArgument(
+          input: _inputToMap(input),
+          messages: opts?.messages?.map(genkitMessageToDpMessage).toList(),
+        ),
+      );
+      messages.addAll(rendered.messages.map(dpMessageToGenkitMessage));
+    } else if (_config.messages != null) {
+      messages.addAll(_config.messages!);
+    } else {
+      // If no messages config, add history from opts
+      if (opts?.messages != null) {
+        messages.addAll(opts!.messages!);
+      }
+    }
+  }
+
+  Future<void> _renderUserPrompt(
+    Input? input,
+    List<Message> messages,
+  ) async {
+    if (_config.prompt != null) {
+      // Handlebars template
+      _compiledPrompt ??= await _dotpromptRegistry.compile(_config.prompt!);
+      final rendered = await _compiledPrompt!.render(
+        dp.DataArgument(input: _inputToMap(input)),
+      );
+      // The dotprompt render may produce multiple messages; add all as user
+      for (final msg in rendered.messages) {
+        final genkitMsg = dpMessageToGenkitMessage(msg);
+        if (genkitMsg.role == Role.user) {
+          messages.add(genkitMsg);
+        } else {
+          messages.add(Message(role: Role.user, content: genkitMsg.content));
+        }
+      }
+    } else if (_config.promptParts != null) {
+      messages.add(Message(role: Role.user, content: _config.promptParts!));
+    }
+  }
+
+  Map<String, dynamic>? _inputToMap(Input? input) {
+    if (input == null) return null;
+    if (input is Map<String, dynamic>) return input;
+    // Try to serialize via toJson
+    try {
+      return (input as dynamic).toJson() as Map<String, dynamic>;
+    } catch (_) {
+      return {'input': input};
+    }
+  }
+}
+
+/// Converts a config value to a Map. Follows the same pattern as generate.dart.
+Map<String, dynamic>? _configToMap(dynamic config) {
+  if (config == null) return null;
+  return config is Map
+      ? config as Map<String, dynamic>
+      : (config as dynamic)?.toJson() as Map<String, dynamic>?;
+}
+
+/// Private ModelRef implementation for internal use.
+class _SimpleModelRef implements ModelRef<dynamic> {
+  @override
+  final String name;
+  @override
+  final dynamic config = null;
+  @override
+  final SchemanticType<dynamic>? customOptions = null;
+
+  _SimpleModelRef(this.name);
+}
+
+/// Defines an executable prompt and registers it in the registry.
+///
+/// This creates both a `PromptAction` (registered as actionType 'prompt')
+/// and returns an [ExecutablePrompt] that can be called directly.
+ExecutablePrompt<Input> definePromptAction<CustomOptions, Input>(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry,
+  PromptConfig<CustomOptions, Input> config, {
+  Map<String, dynamic>? metadata,
+}) {
+  final promptMetadata = _buildPromptMetadata(config, metadata);
+
+  final executablePrompt = ExecutablePrompt<Input>._(
+    registry: registry,
+    dotpromptRegistry: dotpromptRegistry,
+    config: config,
+    metadata: promptMetadata,
+  );
+
+  // Register a PromptAction in the registry
+  final action = PromptAction<Input>(
+    name: config.fullName,
+    description: config.description,
+    inputSchema: config.inputSchema,
+    executablePrompt: executablePrompt,
+    metadata: promptMetadata,
+  );
+  registry.register(action);
+
+  return executablePrompt;
+}
+
+/// Builds prompt metadata for registry/reflection purposes.
+Map<String, dynamic> _buildPromptMetadata<CustomOptions, Input>(
+  PromptConfig<CustomOptions, Input> config,
+  Map<String, dynamic>? extraMetadata,
+) {
+  return {
+    ...?extraMetadata,
+    ...?config.metadata,
+    'type': 'prompt',
+    'prompt': {
+      'name': config.name,
+      if (config.variant != null) 'variant': config.variant,
+      if (config.model != null) 'model': config.model!.name,
+      if (config.config != null) 'config': _configToMap(config.config),
+      if (config.toolNames != null) 'tools': config.toolNames,
+      if (config.toolChoice != null) 'toolChoice': config.toolChoice,
+    },
+  };
+}
+
+/// The registered action for a prompt.
+///
+/// When invoked, it renders the prompt template and returns
+/// [GenerateActionOptions] (i.e., the generate request).
 class PromptAction<Input>
     extends Action<Input, GenerateActionOptions, void, void> {
+  final ExecutablePrompt<Input>? _executablePrompt;
+
   PromptAction({
     required super.name,
-    required PromptFn<Input> fn,
+    ExecutablePrompt<Input>? executablePrompt,
+    PromptFn<Input>? fn,
     super.inputSchema,
     super.description,
     Map<String, dynamic>? metadata,
-  }) : super(
-         actionType: 'prompt',
-         outputSchema: GenerateActionOptions.$schema,
-         metadata: _promptMetadata(description, metadata),
-         fn: (input, ctx) {
-           if (input == null && inputSchema != null && null is! Input) {
-             throw ArgumentError('Prompt "$name" requires a non-null input.');
-           }
-           return fn(input as Input, ctx);
-         },
-       );
+  })  : _executablePrompt = executablePrompt,
+        super(
+          actionType: 'prompt',
+          outputSchema: GenerateActionOptions.$schema,
+          metadata: _promptActionMetadata(description, metadata),
+          fn: (input, ctx) async {
+            if (executablePrompt != null) {
+              return executablePrompt.render(input);
+            }
+            if (fn != null) {
+              if (input == null && inputSchema != null && null is! Input) {
+                throw ArgumentError(
+                    'Prompt "$name" requires a non-null input.');
+              }
+              return fn(input as Input, ctx);
+            }
+            throw StateError('PromptAction has no executable prompt or fn');
+          },
+        );
+
+  /// The executable prompt instance, if this action was created via
+  /// [definePromptAction].
+  ExecutablePrompt<Input>? get executablePrompt => _executablePrompt;
 }
 
-Map<String, dynamic> _promptMetadata(
+/// Legacy prompt function type for backwards compatibility.
+typedef PromptFn<Input> = Future<GenerateActionOptions> Function(
+  Input input,
+  ActionFnArg<void, Input, void> ctx,
+);
+
+Map<String, dynamic> _promptActionMetadata(
   String? description,
   Map<String, dynamic>? metadata,
 ) {
@@ -52,4 +526,23 @@ Map<String, dynamic> _promptMetadata(
     result['description'] = description;
   }
   return result;
+}
+
+/// Looks up a prompt by name in the registry and returns its
+/// [ExecutablePrompt].
+Future<ExecutablePrompt> lookupPrompt(
+  Registry registry,
+  String name, {
+  String? variant,
+}) async {
+  final lookupName = variant != null ? '$name.$variant' : name;
+  final action = await registry.lookupAction('prompt', lookupName);
+  if (action != null && action is PromptAction) {
+    final ep = action.executablePrompt;
+    if (ep != null) return ep;
+  }
+  throw GenkitException(
+    'Prompt $name${variant != null ? ' (variant $variant)' : ''} not found',
+    status: StatusCodes.NOT_FOUND,
+  );
 }

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -203,24 +203,12 @@ class ExecutablePrompt<Input> {
     final resolvedConfig = <String, dynamic>{...?configMap, ...?optsConfigMap};
 
     // Resolve tools
-    final resolvedToolNames = <String>[
+    final resolvedToolNames = <String>{
       ...?_config.toolNames,
       ...?opts?.toolNames,
-    ];
-    if (_config.tools != null) {
-      for (final tool in _config.tools!) {
-        if (!resolvedToolNames.contains(tool.name)) {
-          resolvedToolNames.add(tool.name);
-        }
-      }
-    }
-    if (opts?.tools != null) {
-      for (final tool in opts!.tools!) {
-        if (!resolvedToolNames.contains(tool.name)) {
-          resolvedToolNames.add(tool.name);
-        }
-      }
-    }
+      ...?_config.tools?.map((t) => t.name),
+      ...?opts?.tools?.map((t) => t.name),
+    }.toList();
 
     return GenerateActionOptions(
       model: resolvedModel?.name,

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -172,10 +172,10 @@ class ExecutablePrompt<Input> {
     required DotpromptRegistry dotpromptRegistry,
     required PromptConfig<dynamic, Input> config,
     Map<String, dynamic>? metadata,
-  })  : _registry = registry,
-        _dotpromptRegistry = dotpromptRegistry,
-        _config = config,
-        ref = (name: config.fullName, metadata: metadata);
+  }) : _registry = registry,
+       _dotpromptRegistry = dotpromptRegistry,
+       _config = config,
+       ref = (name: config.fullName, metadata: metadata);
 
   /// Renders the prompt template with the given input, producing
   /// [GenerateActionOptions] suitable for the `generate` action.
@@ -200,10 +200,7 @@ class ExecutablePrompt<Input> {
     // Resolve config — merge config maps
     final configMap = _configToMap(_config.config);
     final optsConfigMap = _configToMap(opts?.config);
-    final resolvedConfig = <String, dynamic>{
-      ...?configMap,
-      ...?optsConfigMap,
-    };
+    final resolvedConfig = <String, dynamic>{...?configMap, ...?optsConfigMap};
 
     // Resolve tools
     final resolvedToolNames = <String>[
@@ -246,18 +243,13 @@ class ExecutablePrompt<Input> {
     final options = await render(input, opts);
 
     // Resolve tools from both config and opts into a child registry
-    final allTools = <Tool>[
-      ...?_config.tools,
-      ...?opts?.tools,
-    ];
+    final allTools = <Tool>[...?_config.tools, ...?opts?.tools];
 
     final middleware = <GenerateMiddlewareOneof>[
       ...?_config.use?.map(
         (mw) => (middlewareRef: mw, middlewareInstance: null),
       ),
-      ...?opts?.use?.map(
-        (mw) => (middlewareRef: mw, middlewareInstance: null),
-      ),
+      ...?opts?.use?.map((mw) => (middlewareRef: mw, middlewareInstance: null)),
     ];
 
     var registry = _registry;
@@ -291,8 +283,8 @@ class ExecutablePrompt<Input> {
     final streamController = StreamController<GenerateResponseChunk>();
     final actionStream =
         ActionStream<GenerateResponseChunk, GenerateResponseHelper>(
-      streamController.stream,
-    );
+          streamController.stream,
+        );
 
     call(input, opts).then(
       (result) {
@@ -315,10 +307,7 @@ class ExecutablePrompt<Input> {
 
   // --- Internal rendering methods ---
 
-  Future<void> _renderSystem(
-    Input? input,
-    List<Message> messages,
-  ) async {
+  Future<void> _renderSystem(Input? input, List<Message> messages) async {
     if (_config.system != null) {
       // Handlebars template
       _compiledSystem ??= await _dotpromptRegistry.compile(_config.system!);
@@ -343,8 +332,9 @@ class ExecutablePrompt<Input> {
   ) async {
     if (_config.messagesTemplate != null) {
       // Handlebars template for messages
-      _compiledMessages ??=
-          await _dotpromptRegistry.compile(_config.messagesTemplate!);
+      _compiledMessages ??= await _dotpromptRegistry.compile(
+        _config.messagesTemplate!,
+      );
       final rendered = await _compiledMessages!.render(
         dp.DataArgument(
           input: _inputToMap(input),
@@ -362,10 +352,7 @@ class ExecutablePrompt<Input> {
     }
   }
 
-  Future<void> _renderUserPrompt(
-    Input? input,
-    List<Message> messages,
-  ) async {
+  Future<void> _renderUserPrompt(Input? input, List<Message> messages) async {
     if (_config.prompt != null) {
       // Handlebars template
       _compiledPrompt ??= await _dotpromptRegistry.compile(_config.prompt!);
@@ -485,25 +472,24 @@ class PromptAction<Input>
     super.inputSchema,
     super.description,
     Map<String, dynamic>? metadata,
-  })  : _executablePrompt = executablePrompt,
-        super(
-          actionType: 'prompt',
-          outputSchema: GenerateActionOptions.$schema,
-          metadata: _promptActionMetadata(description, metadata),
-          fn: (input, ctx) async {
-            if (executablePrompt != null) {
-              return executablePrompt.render(input);
-            }
-            if (fn != null) {
-              if (input == null && inputSchema != null && null is! Input) {
-                throw ArgumentError(
-                    'Prompt "$name" requires a non-null input.');
-              }
-              return fn(input as Input, ctx);
-            }
-            throw StateError('PromptAction has no executable prompt or fn');
-          },
-        );
+  }) : _executablePrompt = executablePrompt,
+       super(
+         actionType: 'prompt',
+         outputSchema: GenerateActionOptions.$schema,
+         metadata: _promptActionMetadata(description, metadata),
+         fn: (input, ctx) async {
+           if (executablePrompt != null) {
+             return executablePrompt.render(input);
+           }
+           if (fn != null) {
+             if (input == null && inputSchema != null && null is! Input) {
+               throw ArgumentError('Prompt "$name" requires a non-null input.');
+             }
+             return fn(input as Input, ctx);
+           }
+           throw StateError('PromptAction has no executable prompt or fn');
+         },
+       );
 
   /// The executable prompt instance, if this action was created via
   /// [definePromptAction].
@@ -511,10 +497,11 @@ class PromptAction<Input>
 }
 
 /// Legacy prompt function type for backwards compatibility.
-typedef PromptFn<Input> = Future<GenerateActionOptions> Function(
-  Input input,
-  ActionFnArg<void, Input, void> ctx,
-);
+typedef PromptFn<Input> =
+    Future<GenerateActionOptions> Function(
+      Input input,
+      ActionFnArg<void, Input, void> ctx,
+    );
 
 Map<String, dynamic> _promptActionMetadata(
   String? description,

--- a/packages/genkit/lib/src/ai/prompt_loader.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader.dart
@@ -1,0 +1,205 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:schemantic/schemantic.dart';
+
+import '../core/registry.dart';
+import '../types.dart' show GenerateActionOutputConfig;
+import 'dotprompt_registry.dart';
+import 'model.dart';
+import 'prompt.dart';
+
+final _logger = Logger('genkit.prompt_loader');
+
+/// Loads all `.prompt` files from the given directory and registers them
+/// as prompt actions.
+///
+/// Files starting with `_` are registered as partials.
+/// Files with a dot in the name (e.g., `name.variant.prompt`) are
+/// treated as variants.
+///
+/// This mirrors the JS `loadPromptFolder` function.
+void loadPromptFolder(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry, {
+  String dir = './prompts',
+  String ns = '',
+}) {
+  final promptsPath = p.normalize(p.absolute(dir));
+  final directory = Directory(promptsPath);
+  if (directory.existsSync()) {
+    _loadPromptFolderRecursively(
+      registry,
+      dotpromptRegistry,
+      promptsPath,
+      ns,
+      '',
+    );
+  }
+}
+
+void _loadPromptFolderRecursively(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry,
+  String basePath,
+  String ns,
+  String subDir,
+) {
+  final dirPath = subDir.isEmpty ? basePath : p.join(basePath, subDir);
+  final directory = Directory(dirPath);
+  final entities = directory.listSync();
+
+  for (final entity in entities) {
+    final fileName = p.basename(entity.path);
+
+    if (entity is File && fileName.endsWith('.prompt')) {
+      if (fileName.startsWith('_')) {
+        // Partial: register with dotprompt
+        final partialName = fileName.substring(1, fileName.length - 7);
+        final content = entity.readAsStringSync();
+        dotpromptRegistry.definePartial(partialName, content);
+        _logger.fine(
+          'Registered Dotprompt partial "$partialName" '
+          'from "${entity.path}"',
+        );
+      } else {
+        // Regular prompt: load and register
+        final prefix = subDir.isNotEmpty ? '$subDir/' : '';
+        _loadPrompt(
+          registry,
+          dotpromptRegistry,
+          basePath,
+          fileName,
+          prefix,
+          ns,
+        );
+      }
+    } else if (entity is Directory) {
+      // Recurse into subdirectories
+      final childSubDir =
+          subDir.isEmpty ? fileName : p.join(subDir, fileName);
+      _loadPromptFolderRecursively(
+        registry,
+        dotpromptRegistry,
+        basePath,
+        ns,
+        childSubDir,
+      );
+    }
+  }
+}
+
+void _loadPrompt(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry,
+  String basePath,
+  String filename,
+  String prefix,
+  String ns,
+) {
+  // Parse name and variant from filename
+  var name = '$prefix${p.basenameWithoutExtension(filename)}';
+  String? variant;
+
+  if (name.contains('.')) {
+    final parts = name.split('.');
+    name = parts[0];
+    variant = parts[1];
+  }
+
+  final filePath = p.join(basePath, prefix, filename);
+  final source = File(filePath).readAsStringSync();
+  final parsedPrompt = dotpromptRegistry.parse(source);
+
+  // Build the registry key
+  final registryName = _registryDefinitionKey(name, variant, ns);
+
+  // Extract metadata from the parsed prompt
+  final metadata = parsedPrompt.metadata;
+
+  // Determine model, tools, config from frontmatter
+  final model = metadata.model;
+  final config = metadata.config;
+  final tools = metadata.tools;
+
+  // Build output config from parsed metadata
+  GenerateActionOutputConfig? outputConfig;
+  if (metadata.output != null) {
+    outputConfig = GenerateActionOutputConfig.fromJson({
+      if (metadata.output!.format != null)
+        'format': metadata.output!.format,
+      if (metadata.output!.schema != null)
+        'jsonSchema': metadata.output!.schema,
+    });
+  }
+
+  // Build prompt metadata for the registry
+  final promptMeta = <String, dynamic>{
+    'type': 'prompt',
+    'prompt': {
+      'name': name,
+      if (variant != null) 'variant': variant, // ignore: use_null_aware_elements
+      if (model != null) 'model': model, // ignore: use_null_aware_elements
+      if (config != null) 'config': config, // ignore: use_null_aware_elements
+      if (tools != null) 'tools': tools, // ignore: use_null_aware_elements
+      'template': parsedPrompt.template,
+    },
+  };
+
+  // Create the prompt config
+  final promptConfig = PromptConfig<Map<String, dynamic>, Map<String, dynamic>>(
+    name: registryName,
+    variant: null, // variant is already baked into the name
+    model: model != null ? _SimpleModelRefImpl(model) : null,
+    config: config,
+    toolNames: tools,
+    messagesTemplate: parsedPrompt.template,
+    output: outputConfig,
+    metadata: promptMeta,
+  );
+
+  definePromptAction<Map<String, dynamic>, Map<String, dynamic>>(
+    registry,
+    dotpromptRegistry,
+    promptConfig,
+    metadata: promptMeta,
+  );
+
+  _logger.fine(
+    'Registered prompt "$registryName" from "$filePath"',
+  );
+}
+
+String _registryDefinitionKey(String name, String? variant, String? ns) {
+  final prefix = ns != null && ns.isNotEmpty ? '$ns/' : '';
+  final suffix = variant != null ? '.$variant' : '';
+  return '$prefix$name$suffix';
+}
+
+/// Simple ModelRef implementation used when loading prompts from files.
+class _SimpleModelRefImpl implements ModelRef<Map<String, dynamic>> {
+  @override
+  final String name;
+  @override
+  final Map<String, dynamic>? config = null;
+  @override
+  final SchemanticType<Map<String, dynamic>>? customOptions = null;
+
+  _SimpleModelRefImpl(this.name);
+}

--- a/packages/genkit/lib/src/ai/prompt_loader.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader.dart
@@ -152,11 +152,10 @@ void _loadPrompt(
     'type': 'prompt',
     'prompt': {
       'name': name,
-      if (variant != null)
-        'variant': variant, // ignore: use_null_aware_elements
-      if (model != null) 'model': model, // ignore: use_null_aware_elements
-      if (config != null) 'config': config, // ignore: use_null_aware_elements
-      if (tools != null) 'tools': tools, // ignore: use_null_aware_elements
+      'variant': ?variant,
+      'model': ?model,
+      'config': ?config,
+      'tools': ?tools,
       'template': parsedPrompt.template,
     },
   };

--- a/packages/genkit/lib/src/ai/prompt_loader.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader.dart
@@ -92,8 +92,7 @@ void _loadPromptFolderRecursively(
       }
     } else if (entity is Directory) {
       // Recurse into subdirectories
-      final childSubDir =
-          subDir.isEmpty ? fileName : p.join(subDir, fileName);
+      final childSubDir = subDir.isEmpty ? fileName : p.join(subDir, fileName);
       _loadPromptFolderRecursively(
         registry,
         dotpromptRegistry,
@@ -142,8 +141,7 @@ void _loadPrompt(
   GenerateActionOutputConfig? outputConfig;
   if (metadata.output != null) {
     outputConfig = GenerateActionOutputConfig.fromJson({
-      if (metadata.output!.format != null)
-        'format': metadata.output!.format,
+      if (metadata.output!.format != null) 'format': metadata.output!.format,
       if (metadata.output!.schema != null)
         'jsonSchema': metadata.output!.schema,
     });
@@ -154,7 +152,8 @@ void _loadPrompt(
     'type': 'prompt',
     'prompt': {
       'name': name,
-      if (variant != null) 'variant': variant, // ignore: use_null_aware_elements
+      if (variant != null)
+        'variant': variant, // ignore: use_null_aware_elements
       if (model != null) 'model': model, // ignore: use_null_aware_elements
       if (config != null) 'config': config, // ignore: use_null_aware_elements
       if (tools != null) 'tools': tools, // ignore: use_null_aware_elements
@@ -181,9 +180,7 @@ void _loadPrompt(
     metadata: promptMeta,
   );
 
-  _logger.fine(
-    'Registered prompt "$registryName" from "$filePath"',
-  );
+  _logger.fine('Registered prompt "$registryName" from "$filePath"');
 }
 
 String _registryDefinitionKey(String name, String? variant, String? ns) {

--- a/packages/genkit/lib/src/ai/prompt_loader_io.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_io.dart
@@ -17,8 +17,6 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
-import 'package:schemantic/schemantic.dart';
-
 import '../core/registry.dart';
 import '../types.dart' show GenerateActionOutputConfig;
 import 'dotprompt_registry.dart';
@@ -80,13 +78,12 @@ void _loadPromptFolderRecursively(
         );
       } else {
         // Regular prompt: load and register
-        final prefix = subDir.isNotEmpty ? '$subDir/' : '';
         _loadPrompt(
           registry,
           dotpromptRegistry,
           basePath,
           fileName,
-          prefix,
+          subDir,
           ns,
         );
       }
@@ -109,10 +106,11 @@ void _loadPrompt(
   DotpromptRegistry dotpromptRegistry,
   String basePath,
   String filename,
-  String prefix,
+  String subDir,
   String ns,
 ) {
   // Parse name and variant from filename
+  final prefix = subDir.isNotEmpty ? '$subDir/' : '';
   var name = '$prefix${p.basenameWithoutExtension(filename)}';
   String? variant;
 
@@ -122,7 +120,7 @@ void _loadPrompt(
     variant = parts[1];
   }
 
-  final filePath = p.join(basePath, prefix, filename);
+  final filePath = p.join(basePath, subDir, filename);
   final source = File(filePath).readAsStringSync();
   final parsedPrompt = dotpromptRegistry.parse(source);
 
@@ -164,7 +162,7 @@ void _loadPrompt(
   final promptConfig = PromptConfig<Map<String, dynamic>, Map<String, dynamic>>(
     name: registryName,
     variant: null, // variant is already baked into the name
-    model: model != null ? _SimpleModelRefImpl(model) : null,
+    model: model != null ? modelRef(model) : null,
     config: config,
     toolNames: tools,
     messagesTemplate: parsedPrompt.template,
@@ -186,16 +184,4 @@ String _registryDefinitionKey(String name, String? variant, String? ns) {
   final prefix = ns != null && ns.isNotEmpty ? '$ns/' : '';
   final suffix = variant != null ? '.$variant' : '';
   return '$prefix$name$suffix';
-}
-
-/// Simple ModelRef implementation used when loading prompts from files.
-class _SimpleModelRefImpl implements ModelRef<Map<String, dynamic>> {
-  @override
-  final String name;
-  @override
-  final Map<String, dynamic>? config = null;
-  @override
-  final SchemanticType<Map<String, dynamic>>? customOptions = null;
-
-  _SimpleModelRefImpl(this.name);
 }

--- a/packages/genkit/lib/src/ai/prompt_loader_io.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_io.dart
@@ -1,0 +1,201 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:schemantic/schemantic.dart';
+
+import '../core/registry.dart';
+import '../types.dart' show GenerateActionOutputConfig;
+import 'dotprompt_registry.dart';
+import 'model.dart';
+import 'prompt.dart';
+
+final _logger = Logger('genkit.prompt_loader');
+
+/// Loads all `.prompt` files from the given directory and registers them
+/// as prompt actions.
+///
+/// Files starting with `_` are registered as partials.
+/// Files with a dot in the name (e.g., `name.variant.prompt`) are
+/// treated as variants.
+///
+/// This mirrors the JS `loadPromptFolder` function.
+void loadPromptFolder(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry, {
+  String dir = './prompts',
+  String ns = '',
+}) {
+  final promptsPath = p.normalize(p.absolute(dir));
+  final directory = Directory(promptsPath);
+  if (directory.existsSync()) {
+    _loadPromptFolderRecursively(
+      registry,
+      dotpromptRegistry,
+      promptsPath,
+      ns,
+      '',
+    );
+  }
+}
+
+void _loadPromptFolderRecursively(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry,
+  String basePath,
+  String ns,
+  String subDir,
+) {
+  final dirPath = subDir.isEmpty ? basePath : p.join(basePath, subDir);
+  final directory = Directory(dirPath);
+  final entities = directory.listSync();
+
+  for (final entity in entities) {
+    final fileName = p.basename(entity.path);
+
+    if (entity is File && fileName.endsWith('.prompt')) {
+      if (fileName.startsWith('_')) {
+        // Partial: register with dotprompt
+        final partialName = fileName.substring(1, fileName.length - 7);
+        final content = entity.readAsStringSync();
+        dotpromptRegistry.definePartial(partialName, content);
+        _logger.fine(
+          'Registered Dotprompt partial "$partialName" '
+          'from "${entity.path}"',
+        );
+      } else {
+        // Regular prompt: load and register
+        final prefix = subDir.isNotEmpty ? '$subDir/' : '';
+        _loadPrompt(
+          registry,
+          dotpromptRegistry,
+          basePath,
+          fileName,
+          prefix,
+          ns,
+        );
+      }
+    } else if (entity is Directory) {
+      // Recurse into subdirectories
+      final childSubDir = subDir.isEmpty ? fileName : p.join(subDir, fileName);
+      _loadPromptFolderRecursively(
+        registry,
+        dotpromptRegistry,
+        basePath,
+        ns,
+        childSubDir,
+      );
+    }
+  }
+}
+
+void _loadPrompt(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry,
+  String basePath,
+  String filename,
+  String prefix,
+  String ns,
+) {
+  // Parse name and variant from filename
+  var name = '$prefix${p.basenameWithoutExtension(filename)}';
+  String? variant;
+
+  if (name.contains('.')) {
+    final parts = name.split('.');
+    name = parts[0];
+    variant = parts[1];
+  }
+
+  final filePath = p.join(basePath, prefix, filename);
+  final source = File(filePath).readAsStringSync();
+  final parsedPrompt = dotpromptRegistry.parse(source);
+
+  // Build the registry key
+  final registryName = _registryDefinitionKey(name, variant, ns);
+
+  // Extract metadata from the parsed prompt
+  final metadata = parsedPrompt.metadata;
+
+  // Determine model, tools, config from frontmatter
+  final model = metadata.model;
+  final config = metadata.config;
+  final tools = metadata.tools;
+
+  // Build output config from parsed metadata
+  GenerateActionOutputConfig? outputConfig;
+  if (metadata.output != null) {
+    outputConfig = GenerateActionOutputConfig.fromJson({
+      if (metadata.output!.format != null) 'format': metadata.output!.format,
+      if (metadata.output!.schema != null)
+        'jsonSchema': metadata.output!.schema,
+    });
+  }
+
+  // Build prompt metadata for the registry
+  final promptMeta = <String, dynamic>{
+    'type': 'prompt',
+    'prompt': {
+      'name': name,
+      'variant': ?variant,
+      'model': ?model,
+      'config': ?config,
+      'tools': ?tools,
+      'template': parsedPrompt.template,
+    },
+  };
+
+  // Create the prompt config
+  final promptConfig = PromptConfig<Map<String, dynamic>, Map<String, dynamic>>(
+    name: registryName,
+    variant: null, // variant is already baked into the name
+    model: model != null ? _SimpleModelRefImpl(model) : null,
+    config: config,
+    toolNames: tools,
+    messagesTemplate: parsedPrompt.template,
+    output: outputConfig,
+    metadata: promptMeta,
+  );
+
+  definePromptAction<Map<String, dynamic>, Map<String, dynamic>>(
+    registry,
+    dotpromptRegistry,
+    promptConfig,
+    metadata: promptMeta,
+  );
+
+  _logger.fine('Registered prompt "$registryName" from "$filePath"');
+}
+
+String _registryDefinitionKey(String name, String? variant, String? ns) {
+  final prefix = ns != null && ns.isNotEmpty ? '$ns/' : '';
+  final suffix = variant != null ? '.$variant' : '';
+  return '$prefix$name$suffix';
+}
+
+/// Simple ModelRef implementation used when loading prompts from files.
+class _SimpleModelRefImpl implements ModelRef<Map<String, dynamic>> {
+  @override
+  final String name;
+  @override
+  final Map<String, dynamic>? config = null;
+  @override
+  final SchemanticType<Map<String, dynamic>>? customOptions = null;
+
+  _SimpleModelRefImpl(this.name);
+}

--- a/packages/genkit/lib/src/ai/prompt_loader_io.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_io.dart
@@ -160,8 +160,8 @@ void _loadPrompt(
 
   // Create the prompt config
   final promptConfig = PromptConfig<Map<String, dynamic>, Map<String, dynamic>>(
-    name: registryName,
-    variant: null, // variant is already baked into the name
+    name: _registryDefinitionKey(name, null, ns),
+    variant: variant,
     model: model != null ? modelRef(model) : null,
     config: config,
     toolNames: tools,

--- a/packages/genkit/lib/src/ai/prompt_loader_stub.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_stub.dart
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export 'prompt_loader_stub.dart'
-    if (dart.library.io) 'prompt_loader_io.dart'
-    if (dart.library.js_interop) 'prompt_loader_web.dart';
+import '../core/registry.dart';
+import 'dotprompt_registry.dart';
+
+/// Stub implementation of [loadPromptFolder].
+///
+/// This is the default fallback used when neither `dart:io` nor
+/// `dart:js_interop` is available. It throws [UnimplementedError] because
+/// prompt loading from the filesystem is not supported on this platform.
+void loadPromptFolder(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry, {
+  String dir = './prompts',
+  String ns = '',
+}) {
+  throw UnimplementedError(
+    'loadPromptFolder is not supported on this platform.',
+  );
+}

--- a/packages/genkit/lib/src/ai/prompt_loader_stub.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_stub.dart
@@ -18,15 +18,14 @@ import 'dotprompt_registry.dart';
 /// Stub implementation of [loadPromptFolder].
 ///
 /// This is the default fallback used when neither `dart:io` nor
-/// `dart:js_interop` is available. It throws [UnimplementedError] because
-/// prompt loading from the filesystem is not supported on this platform.
+/// `dart:js_interop` is available. Filesystem-based prompt loading is not
+/// supported on this platform, so this is a silent no-op. Prompts can
+/// still be defined programmatically using `Genkit.definePrompt`.
 void loadPromptFolder(
   Registry registry,
   DotpromptRegistry dotpromptRegistry, {
   String dir = './prompts',
   String ns = '',
 }) {
-  throw UnimplementedError(
-    'loadPromptFolder is not supported on this platform.',
-  );
+  // No-op: filesystem-based prompt loading is not available on this platform.
 }

--- a/packages/genkit/lib/src/ai/prompt_loader_web.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_web.dart
@@ -12,6 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export 'prompt_loader_stub.dart'
-    if (dart.library.io) 'prompt_loader_io.dart'
-    if (dart.library.js_interop) 'prompt_loader_web.dart';
+import '../core/registry.dart';
+import 'dotprompt_registry.dart';
+
+/// Web implementation of [loadPromptFolder].
+///
+/// Loading `.prompt` files from the filesystem is not supported in browser
+/// environments, so this is a silent no-op. Prompts can still be defined
+/// programmatically using `Genkit.definePrompt`.
+void loadPromptFolder(
+  Registry registry,
+  DotpromptRegistry dotpromptRegistry, {
+  String dir = './prompts',
+  String ns = '',
+}) {
+  // No-op: filesystem-based prompt loading is not available on the web.
+}

--- a/packages/genkit/lib/src/ai/prompt_types.dart
+++ b/packages/genkit/lib/src/ai/prompt_types.dart
@@ -88,10 +88,13 @@ dp.Role genkitRoleToDpRole(genkit.Role role) {
   if (role == genkit.Role.model) return dp.Role.model;
   if (role == genkit.Role.system) return dp.Role.system;
   if (role == genkit.Role.tool) return dp.Role.tool;
-  return dp.Role.user; // fallback
+  throw ArgumentError('Unknown Genkit role: $role');
 }
 
 /// Converts a Genkit [genkit.Part] to a dotprompt [dp.Part].
+///
+/// Uses JSON-based dispatch because Genkit Part types are JSON-backed
+/// and may not preserve subtype identity when accessed from a Message.
 dp.Part genkitPartToDpPart(genkit.Part part) {
   final json = part.toJson();
   if (json.containsKey('text')) {
@@ -126,6 +129,9 @@ dp.Part genkitPartToDpPart(genkit.Part part) {
       ),
     );
   }
-  // Fallback: text part
+  if (json.containsKey('data')) {
+    return dp.DataPart(data: json['data'] as Map<String, dynamic>? ?? {});
+  }
+  // Fallback
   return dp.TextPart(text: json.toString());
 }

--- a/packages/genkit/lib/src/ai/prompt_types.dart
+++ b/packages/genkit/lib/src/ai/prompt_types.dart
@@ -30,11 +30,11 @@ genkit.Message dpMessageToGenkitMessage(dp.Message msg) {
 
 /// Converts a dotprompt [dp.Role] to a Genkit [genkit.Role].
 genkit.Role dpRoleToGenkitRole(dp.Role role) => switch (role) {
-      dp.Role.user => genkit.Role.user,
-      dp.Role.model => genkit.Role.model,
-      dp.Role.system => genkit.Role.system,
-      dp.Role.tool => genkit.Role.tool,
-    };
+  dp.Role.user => genkit.Role.user,
+  dp.Role.model => genkit.Role.model,
+  dp.Role.system => genkit.Role.system,
+  dp.Role.tool => genkit.Role.tool,
+};
 
 /// Converts a dotprompt [dp.Part] to a Genkit [genkit.Part].
 genkit.Part dpPartToGenkitPart(dp.Part part) {

--- a/packages/genkit/lib/src/ai/prompt_types.dart
+++ b/packages/genkit/lib/src/ai/prompt_types.dart
@@ -1,0 +1,131 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Utilities for converting between `dotprompt` types and Genkit types.
+library;
+
+import 'package:dotprompt/dotprompt.dart' as dp;
+
+import '../types.dart' as genkit;
+
+/// Converts a dotprompt [dp.Message] to a Genkit [genkit.Message].
+genkit.Message dpMessageToGenkitMessage(dp.Message msg) {
+  return genkit.Message(
+    role: dpRoleToGenkitRole(msg.role),
+    content: msg.content.map(dpPartToGenkitPart).toList(),
+    metadata: msg.metadata,
+  );
+}
+
+/// Converts a dotprompt [dp.Role] to a Genkit [genkit.Role].
+genkit.Role dpRoleToGenkitRole(dp.Role role) {
+  switch (role) {
+    case dp.Role.user:
+      return genkit.Role.user;
+    case dp.Role.model:
+      return genkit.Role.model;
+    case dp.Role.system:
+      return genkit.Role.system;
+    case dp.Role.tool:
+      return genkit.Role.tool;
+  }
+}
+
+/// Converts a dotprompt [dp.Part] to a Genkit [genkit.Part].
+genkit.Part dpPartToGenkitPart(dp.Part part) {
+  return switch (part) {
+    dp.TextPart(:final text) => genkit.TextPart(text: text),
+    dp.MediaPart(:final media) => genkit.MediaPart(
+        media: genkit.Media(
+          contentType: media.contentType,
+          url: media.url ?? media.data ?? '',
+        ),
+      ),
+    dp.ToolRequestPart(:final toolRequest) => genkit.ToolRequestPart(
+        toolRequest: genkit.ToolRequest(
+          ref: toolRequest.ref,
+          name: toolRequest.name,
+          input: toolRequest.input,
+        ),
+      ),
+    dp.ToolResponsePart(:final toolResponse) => genkit.ToolResponsePart(
+        toolResponse: genkit.ToolResponse(
+          ref: toolResponse.ref,
+          name: toolResponse.name,
+          output: toolResponse.output,
+        ),
+      ),
+    dp.DataPart(:final data) => genkit.DataPart(data: data),
+    // For PendingPart and MetadataPart, convert to DataPart with metadata
+    dp.PendingPart() => genkit.DataPart(data: part.toJson()),
+    dp.MetadataPart(:final metadata) => genkit.DataPart(data: metadata),
+  };
+}
+
+/// Converts a Genkit [genkit.Message] to a dotprompt [dp.Message].
+dp.Message genkitMessageToDpMessage(genkit.Message msg) {
+  return dp.Message(
+    role: genkitRoleToDpRole(msg.role),
+    content: msg.content.map(genkitPartToDpPart).toList(),
+    metadata: msg.metadata,
+  );
+}
+
+/// Converts a Genkit [genkit.Role] to a dotprompt [dp.Role].
+dp.Role genkitRoleToDpRole(genkit.Role role) {
+  if (role == genkit.Role.user) return dp.Role.user;
+  if (role == genkit.Role.model) return dp.Role.model;
+  if (role == genkit.Role.system) return dp.Role.system;
+  if (role == genkit.Role.tool) return dp.Role.tool;
+  return dp.Role.user; // fallback
+}
+
+/// Converts a Genkit [genkit.Part] to a dotprompt [dp.Part].
+dp.Part genkitPartToDpPart(genkit.Part part) {
+  final json = part.toJson();
+  if (json.containsKey('text')) {
+    return dp.TextPart(text: json['text'] as String);
+  }
+  if (json.containsKey('media')) {
+    final media = json['media'] as Map<String, dynamic>;
+    return dp.MediaPart(
+      media: dp.MediaContent(
+        contentType: media['contentType'] as String? ?? '',
+        url: media['url'] as String?,
+      ),
+    );
+  }
+  if (json.containsKey('toolRequest')) {
+    final tr = json['toolRequest'] as Map<String, dynamic>;
+    return dp.ToolRequestPart(
+      toolRequest: dp.ToolRequest(
+        name: tr['name'] as String,
+        ref: tr['ref'] as String? ?? '',
+        input: tr['input'] as Map<String, dynamic>?,
+      ),
+    );
+  }
+  if (json.containsKey('toolResponse')) {
+    final tr = json['toolResponse'] as Map<String, dynamic>;
+    return dp.ToolResponsePart(
+      toolResponse: dp.ToolResponse(
+        name: tr['name'] as String,
+        ref: tr['ref'] as String? ?? '',
+        output: tr['output'],
+      ),
+    );
+  }
+  // Fallback: text part
+  return dp.TextPart(text: json.toString());
+}

--- a/packages/genkit/lib/src/ai/prompt_types.dart
+++ b/packages/genkit/lib/src/ai/prompt_types.dart
@@ -29,18 +29,12 @@ genkit.Message dpMessageToGenkitMessage(dp.Message msg) {
 }
 
 /// Converts a dotprompt [dp.Role] to a Genkit [genkit.Role].
-genkit.Role dpRoleToGenkitRole(dp.Role role) {
-  switch (role) {
-    case dp.Role.user:
-      return genkit.Role.user;
-    case dp.Role.model:
-      return genkit.Role.model;
-    case dp.Role.system:
-      return genkit.Role.system;
-    case dp.Role.tool:
-      return genkit.Role.tool;
-  }
-}
+genkit.Role dpRoleToGenkitRole(dp.Role role) => switch (role) {
+      dp.Role.user => genkit.Role.user,
+      dp.Role.model => genkit.Role.model,
+      dp.Role.system => genkit.Role.system,
+      dp.Role.tool => genkit.Role.tool,
+    };
 
 /// Converts a dotprompt [dp.Part] to a Genkit [genkit.Part].
 genkit.Part dpPartToGenkitPart(dp.Part part) {

--- a/packages/genkit/lib/src/ai/prompt_types.dart
+++ b/packages/genkit/lib/src/ai/prompt_types.dart
@@ -47,25 +47,25 @@ genkit.Part dpPartToGenkitPart(dp.Part part) {
   return switch (part) {
     dp.TextPart(:final text) => genkit.TextPart(text: text),
     dp.MediaPart(:final media) => genkit.MediaPart(
-        media: genkit.Media(
-          contentType: media.contentType,
-          url: media.url ?? media.data ?? '',
-        ),
+      media: genkit.Media(
+        contentType: media.contentType,
+        url: media.url ?? media.data ?? '',
       ),
+    ),
     dp.ToolRequestPart(:final toolRequest) => genkit.ToolRequestPart(
-        toolRequest: genkit.ToolRequest(
-          ref: toolRequest.ref,
-          name: toolRequest.name,
-          input: toolRequest.input,
-        ),
+      toolRequest: genkit.ToolRequest(
+        ref: toolRequest.ref,
+        name: toolRequest.name,
+        input: toolRequest.input,
       ),
+    ),
     dp.ToolResponsePart(:final toolResponse) => genkit.ToolResponsePart(
-        toolResponse: genkit.ToolResponse(
-          ref: toolResponse.ref,
-          name: toolResponse.name,
-          output: toolResponse.output,
-        ),
+      toolResponse: genkit.ToolResponse(
+        ref: toolResponse.ref,
+        name: toolResponse.name,
+        output: toolResponse.output,
       ),
+    ),
     dp.DataPart(:final data) => genkit.DataPart(data: data),
     // For PendingPart and MetadataPart, convert to DataPart with metadata
     dp.PendingPart() => genkit.DataPart(data: part.toJson()),

--- a/packages/genkit/lib/src/ai/template_helper.dart
+++ b/packages/genkit/lib/src/ai/template_helper.dart
@@ -1,0 +1,110 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:handlebars_dart/handlebars_dart.dart' as hb;
+
+/// Options passed to template helper functions during rendering.
+///
+/// Contains hash arguments, block content functions, and context data
+/// available to helpers.
+///
+/// ## Block Helper Example
+///
+/// ```dart
+/// ai.defineHelper('list', (args, options) {
+///   final items = args[0] as List;
+///   final buffer = StringBuffer('<ul>');
+///   for (final item in items) {
+///     buffer.write('<li>${options.fn(item)}</li>');
+///   }
+///   buffer.write('</ul>');
+///   return buffer.toString();
+/// });
+/// ```
+class TemplateHelperOptions {
+  /// Named hash arguments: `{{helper key="value" other=123}}`.
+  ///
+  /// Accessed as `options.hash['key']` and `options.hash['other']`.
+  final Map<String, dynamic> hash;
+
+  /// The block content function for block helpers.
+  ///
+  /// Call `fn(context)` to render the block content with a given context.
+  /// For non-block helpers, this returns an empty string.
+  ///
+  /// Example: `{{#each items}}...{{/each}}`
+  final String Function(dynamic context) fn;
+
+  /// The inverse/else block content function.
+  ///
+  /// Call `inverse(context)` to render the `{{else}}` content.
+  /// Returns empty string if no else block is present.
+  ///
+  /// Example: `{{#if condition}}...{{else}}...{{/if}}`
+  final String Function(dynamic context) inverse;
+
+  /// Private data for the current rendering frame.
+  ///
+  /// Contains special variables like `@root`, `@first`, `@last`, `@index`.
+  final Map<String, dynamic> data;
+
+  /// The current context (this) value for the helper.
+  final dynamic context;
+
+  /// Creates template helper options.
+  TemplateHelperOptions({
+    required this.hash,
+    required this.fn,
+    required this.inverse,
+    required this.data,
+    required this.context,
+  });
+
+  /// Creates a [TemplateHelperOptions] from the internal
+  /// [hb.HelperOptions] type.
+  TemplateHelperOptions._fromHandlebars(hb.HelperOptions options)
+    : hash = options.hash,
+      fn = options.fn,
+      inverse = options.inverse,
+      data = options.data,
+      context = options.context;
+}
+
+/// Function signature for custom Handlebars helper functions.
+///
+/// Helpers receive:
+/// - [args]: Positional arguments from the template
+/// - [options]: Hash arguments, block functions, and context
+///
+/// Helpers should return a value that will be inserted into the template
+/// output.
+///
+/// ## Example
+///
+/// ```dart
+/// ai.defineHelper('loud', (args, options) {
+///   return args[0].toString().toUpperCase();
+/// });
+/// // Usage in template: {{loud name}}
+/// ```
+typedef TemplateHelperFn =
+    dynamic Function(List<dynamic> args, TemplateHelperOptions options);
+
+/// Wraps a Genkit-owned [TemplateHelperFn] into the internal
+/// [hb.HelperFunction] type expected by the Handlebars engine.
+hb.HelperFunction wrapTemplateHelper(TemplateHelperFn helper) {
+  return (List<dynamic> args, hb.HelperOptions options) {
+    return helper(args, TemplateHelperOptions._fromHandlebars(options));
+  };
+}

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -210,7 +210,7 @@ final class Genkit {
   /// ```dart
   /// final hi = ai.definePrompt(
   ///   name: 'hi',
-  ///   model: modelRef('googleai/gemini-2.0-flash'),
+  ///   model: modelRef('googleai/gemini-flash-latest'),
   ///   prompt: 'Say hi to {{name}}',
   /// );
   ///

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -264,11 +264,11 @@ final class Genkit {
     );
   }
 
-  /// Defines a prompt using the legacy function-based API.
+  /// Defines a prompt with a custom function for programmatic message building.
   ///
-  /// This is provided for backwards compatibility. Prefer [definePrompt]
-  /// with named parameters for new code.
-  PromptAction<Input> defineLegacyPrompt<Input>({
+  /// Use this when you need full control over how the prompt messages are
+  /// constructed at runtime. For template-based prompts, use [definePrompt].
+  PromptAction<Input> defineCustomPrompt<Input>({
     required String name,
     String? description,
     SchemanticType<Input>? inputSchema,

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -14,7 +14,6 @@
 
 import 'dart:async';
 
-import 'package:handlebars_dart/handlebars_dart.dart' show HelperFunction;
 import 'package:http/http.dart' as http;
 import 'package:schemantic/schemantic.dart';
 
@@ -31,6 +30,7 @@ import 'ai/prompt.dart';
 import 'ai/prompt_loader.dart';
 import 'ai/remote_model.dart';
 import 'ai/resource.dart';
+import 'ai/template_helper.dart';
 import 'ai/tool.dart';
 import 'core/action.dart';
 import 'core/dynamic_action_provider.dart';
@@ -310,7 +310,7 @@ final class Genkit {
   /// Registers a custom Handlebars helper function for use in prompts.
   ///
   /// Helpers can be referenced in prompt templates using `{{helperName arg}}`.
-  void defineHelper(String name, HelperFunction helper) {
+  void defineHelper(String name, TemplateHelperFn helper) {
     _dotpromptRegistry.defineHelper(name, helper);
   }
 

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -76,8 +76,12 @@ final class Genkit {
   }) {
     configureCollectorExporter();
 
-    // Initialize dotprompt registry
-    _dotpromptRegistry = DotpromptRegistry();
+    // Initialize dotprompt registry with schema resolver wired to the registry
+    _dotpromptRegistry = DotpromptRegistry(
+      schemaResolver: (name) async {
+        return registry.lookupValue<Map<String, dynamic>>('schema', name);
+      },
+    );
 
     // Register plugins
     for (final plugin in plugins) {
@@ -312,6 +316,29 @@ final class Genkit {
   /// Helpers can be referenced in prompt templates using `{{helperName arg}}`.
   void defineHelper(String name, TemplateHelperFn helper) {
     _dotpromptRegistry.defineHelper(name, helper);
+  }
+
+  /// Registers a named JSON Schema for use in prompt templates.
+  ///
+  /// Named schemas can be referenced by name in Picoschema definitions
+  /// within `.prompt` files or inline prompt templates. This is useful for
+  /// sharing common data structures across multiple prompts.
+  ///
+  /// Example:
+  /// ```dart
+  /// ai.defineSchema('MyAddress', {
+  ///   'type': 'object',
+  ///   'properties': {
+  ///     'street': {'type': 'string'},
+  ///     'city': {'type': 'string'},
+  ///     'zip': {'type': 'string'},
+  ///   },
+  ///   'required': ['street', 'city', 'zip'],
+  /// });
+  /// ```
+  void defineSchema(String name, Map<String, dynamic> jsonSchema) {
+    registry.registerValue('schema', name, jsonSchema);
+    _dotpromptRegistry.defineSchema(name, jsonSchema);
   }
 
   /// Defines a Genkit resource.

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -14,9 +14,11 @@
 
 import 'dart:async';
 
+import 'package:handlebars_dart/handlebars_dart.dart' show HelperFunction;
 import 'package:http/http.dart' as http;
 import 'package:schemantic/schemantic.dart';
 
+import 'ai/dotprompt_registry.dart';
 import 'ai/embedder.dart';
 import 'ai/evaluator.dart';
 import 'ai/formatters/formatters.dart';
@@ -26,6 +28,7 @@ import 'ai/generate_middleware.dart';
 import 'ai/generate_types.dart';
 import 'ai/model.dart';
 import 'ai/prompt.dart';
+import 'ai/prompt_loader.dart';
 import 'ai/remote_model.dart';
 import 'ai/resource.dart';
 import 'ai/tool.dart';
@@ -57,14 +60,24 @@ final class Genkit {
   ReflectionServerHandle? _reflectionServer;
 
   late final GenerateAction _generateAction;
+  late final DotpromptRegistry _dotpromptRegistry;
 
   Genkit({
     List<GenkitPlugin> plugins = const [],
     ModelRef? model,
     bool? isDevEnv,
     int? reflectionPort,
+
+    /// Directory to load `.prompt` files from.
+    ///
+    /// Defaults to `'./prompts'`. Set to `null` to disable automatic
+    /// prompt loading.
+    String? promptDir = './prompts',
   }) {
     configureCollectorExporter();
+
+    // Initialize dotprompt registry
+    _dotpromptRegistry = DotpromptRegistry();
 
     // Register plugins
     for (final plugin in plugins) {
@@ -88,6 +101,11 @@ final class Genkit {
     _generateAction = defineGenerateAction(registry);
 
     registry.register(_generateAction);
+
+    // Load .prompt files from the prompt directory
+    if (promptDir != null) {
+      loadPromptFolder(registry, _dotpromptRegistry, dir: promptDir);
+    }
   }
 
   /// Shuts down the Genkit instance, stopping the reflection server if it is running.
@@ -178,23 +196,125 @@ final class Genkit {
     return tool;
   }
 
-  /// Defines an executable prompt.
-  PromptAction<Input> definePrompt<Input>({
+  /// Defines an executable prompt with Handlebars template support.
+  ///
+  /// The prompt is registered in the registry and can be looked up by name.
+  /// Returns an [ExecutablePrompt] that can be called directly, rendered,
+  /// or streamed.
+  ///
+  /// Example:
+  /// ```dart
+  /// final hi = ai.definePrompt(
+  ///   name: 'hi',
+  ///   model: modelRef('googleai/gemini-2.0-flash'),
+  ///   prompt: 'Say hi to {{name}}',
+  /// );
+  ///
+  /// final response = await hi({'name': 'Sparky'});
+  /// ```
+  ExecutablePrompt<Input> definePrompt<CustomOptions, Input>({
+    required String name,
+    String? variant,
+    ModelRef<CustomOptions>? model,
+    CustomOptions? config,
+    String? description,
+    SchemanticType<Input>? inputSchema,
+    String? system,
+    List<Part>? systemParts,
+    String? prompt,
+    List<Part>? promptParts,
+    List<Message>? messages,
+    String? messagesTemplate,
+    GenerateActionOutputConfig? output,
+    int? maxTurns,
+    bool? returnToolRequests,
+    Map<String, dynamic>? metadata,
+    List<Tool>? tools,
+    List<String>? toolNames,
+    String? toolChoice,
+    List<GenerateMiddlewareRef>? use,
+  }) {
+    final promptConfig = PromptConfig<CustomOptions, Input>(
+      name: name,
+      variant: variant,
+      model: model,
+      config: config,
+      description: description,
+      inputSchema: inputSchema,
+      system: system,
+      systemParts: systemParts,
+      prompt: prompt,
+      promptParts: promptParts,
+      messages: messages,
+      messagesTemplate: messagesTemplate,
+      output: output,
+      maxTurns: maxTurns,
+      returnToolRequests: returnToolRequests,
+      metadata: metadata,
+      tools: tools,
+      toolNames: toolNames,
+      toolChoice: toolChoice,
+      use: use,
+    );
+    return definePromptAction<CustomOptions, Input>(
+      registry,
+      _dotpromptRegistry,
+      promptConfig,
+      metadata: metadata,
+    );
+  }
+
+  /// Defines a prompt using the legacy function-based API.
+  ///
+  /// This is provided for backwards compatibility. Prefer [definePrompt]
+  /// with named parameters for new code.
+  PromptAction<Input> defineLegacyPrompt<Input>({
     required String name,
     String? description,
     SchemanticType<Input>? inputSchema,
     required PromptFn<Input> fn,
     Map<String, dynamic>? metadata,
   }) {
-    final prompt = PromptAction<Input>(
+    final promptAction = PromptAction<Input>(
       name: name,
       description: description,
       inputSchema: inputSchema,
       fn: fn,
       metadata: metadata,
     );
-    registry.register(prompt);
-    return prompt;
+    registry.register(promptAction);
+    return promptAction;
+  }
+
+  /// Looks up a previously defined prompt by name.
+  ///
+  /// Returns the [ExecutablePrompt] registered under the given name
+  /// and optional variant.
+  ///
+  /// Example:
+  /// ```dart
+  /// final hi = await ai.prompt('hi');
+  /// final response = await hi({'name': 'Sparky'});
+  /// ```
+  Future<ExecutablePrompt> prompt(
+    String name, {
+    String? variant,
+  }) {
+    return lookupPrompt(registry, name, variant: variant);
+  }
+
+  /// Registers a Handlebars partial template for use in prompts.
+  ///
+  /// Partials can be referenced in prompt templates using `{{> name}}`.
+  void definePartial(String name, String source) {
+    _dotpromptRegistry.definePartial(name, source);
+  }
+
+  /// Registers a custom Handlebars helper function for use in prompts.
+  ///
+  /// Helpers can be referenced in prompt templates using `{{helperName arg}}`.
+  void defineHelper(String name, HelperFunction helper) {
+    _dotpromptRegistry.defineHelper(name, helper);
   }
 
   /// Defines a Genkit resource.

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -296,10 +296,7 @@ final class Genkit {
   /// final hi = await ai.prompt('hi');
   /// final response = await hi({'name': 'Sparky'});
   /// ```
-  Future<ExecutablePrompt> prompt(
-    String name, {
-    String? variant,
-  }) {
+  Future<ExecutablePrompt> prompt(String name, {String? variant}) {
     return lookupPrompt(registry, name, variant: variant);
   }
 

--- a/packages/genkit/pubspec.yaml
+++ b/packages/genkit/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
+  dotprompt: ^0.0.1
+  handlebars_dart: ^0.0.1
   http: ^1.6.0
   json_annotation: ^4.9.0
   json_schema_builder: ^0.1.3

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -1,0 +1,1018 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:dotprompt/dotprompt.dart' as dp;
+import 'package:genkit/genkit.dart';
+import 'package:genkit/src/ai/dotprompt_registry.dart';
+import 'package:genkit/src/ai/prompt.dart';
+import 'package:genkit/src/ai/prompt_loader.dart';
+import 'package:genkit/src/core/registry.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('PromptConfig', () {
+    test('creates with required name', () {
+      final config = PromptConfig(name: 'test');
+      expect(config.name, equals('test'));
+      expect(config.variant, isNull);
+      expect(config.fullName, equals('test'));
+    });
+
+    test('fullName includes variant', () {
+      final config = PromptConfig(
+        name: 'test',
+        variant: 'v2',
+      );
+      expect(config.fullName, equals('test.v2'));
+    });
+
+    test('stores all config fields', () {
+      final config = PromptConfig(
+        name: 'test',
+        variant: 'formal',
+        model: modelRef('test-model'),
+        config: {'temperature': 0.7},
+        description: 'A test prompt',
+        system: 'You are helpful',
+        prompt: 'Say {{greeting}}',
+        maxTurns: 5,
+        returnToolRequests: true,
+        toolNames: ['tool1'],
+        toolChoice: 'auto',
+      );
+
+      expect(config.name, equals('test'));
+      expect(config.variant, equals('formal'));
+      expect(config.model!.name, equals('test-model'));
+      expect(config.config, equals({'temperature': 0.7}));
+      expect(config.description, equals('A test prompt'));
+      expect(config.system, equals('You are helpful'));
+      expect(config.prompt, equals('Say {{greeting}}'));
+      expect(config.maxTurns, equals(5));
+      expect(config.returnToolRequests, isTrue);
+      expect(config.toolNames, equals(['tool1']));
+      expect(config.toolChoice, equals('auto'));
+    });
+  });
+
+  group('PromptGenerateOptions', () {
+    test('creates with all optional fields', () {
+      final opts = PromptGenerateOptions(
+        model: modelRef('override-model'),
+        config: {'temperature': 0.5},
+        toolChoice: 'required',
+        returnToolRequests: false,
+        maxTurns: 3,
+        context: {'user': 'test'},
+      );
+
+      expect(opts.model!.name, equals('override-model'));
+      expect(opts.config, equals({'temperature': 0.5}));
+      expect(opts.toolChoice, equals('required'));
+      expect(opts.returnToolRequests, isFalse);
+      expect(opts.maxTurns, equals(3));
+      expect(opts.context, equals({'user': 'test'}));
+    });
+
+    test('creates with no fields', () {
+      final opts = PromptGenerateOptions();
+      expect(opts.model, isNull);
+      expect(opts.config, isNull);
+      expect(opts.tools, isNull);
+    });
+  });
+
+  group('definePromptAction', () {
+    late Registry registry;
+    late DotpromptRegistry dpRegistry;
+
+    setUp(() {
+      registry = Registry();
+      dpRegistry = DotpromptRegistry();
+    });
+
+    test('returns an ExecutablePrompt', () {
+      final config = PromptConfig(
+        name: 'greet',
+        prompt: 'Hello {{name}}',
+      );
+
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        config,
+      );
+
+      expect(ep, isA<ExecutablePrompt>());
+      expect(ep.ref.name, equals('greet'));
+    });
+
+    test('registers a PromptAction in the registry', () async {
+      final config = PromptConfig(
+        name: 'greet',
+        prompt: 'Hello {{name}}',
+      );
+
+      definePromptAction(registry, dpRegistry, config);
+
+      final action = await registry.lookupAction('prompt', 'greet');
+      expect(action, isNotNull);
+      expect(action, isA<PromptAction>());
+    });
+
+    test('registers with variant in name', () async {
+      final config = PromptConfig(
+        name: 'greet',
+        variant: 'formal',
+        prompt: 'Good day, {{name}}',
+      );
+
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        config,
+      );
+
+      expect(ep.ref.name, equals('greet.formal'));
+
+      final action = await registry.lookupAction('prompt', 'greet.formal');
+      expect(action, isNotNull);
+    });
+
+    test('includes metadata in registration', () async {
+      final config = PromptConfig(
+        name: 'greet',
+        model: modelRef('test-model'),
+        prompt: 'Hello {{name}}',
+        toolNames: ['tool1'],
+      );
+
+      definePromptAction(registry, dpRegistry, config);
+
+      final action = await registry.lookupAction('prompt', 'greet');
+      expect(action, isNotNull);
+      final pa = action as PromptAction;
+      expect(pa.metadata['type'], equals('prompt'));
+      expect(pa.metadata['prompt']['model'], equals('test-model'));
+      expect(pa.metadata['prompt']['tools'], equals(['tool1']));
+    });
+  });
+
+  group('ExecutablePrompt.render', () {
+    late Registry registry;
+    late DotpromptRegistry dpRegistry;
+
+    setUp(() {
+      registry = Registry();
+      dpRegistry = DotpromptRegistry();
+    });
+
+    test('renders a simple string template', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', prompt: 'Hello {{name}}'),
+      );
+
+      final options = await ep.render({'name': 'World'});
+
+      expect(options.messages, isNotEmpty);
+      final lastMsg = options.messages!.last;
+      expect(lastMsg.role, equals(Role.user));
+      final text = lastMsg.content[0].toJson()['text'];
+      expect(text, contains('Hello World'));
+    });
+
+    test('renders system template', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          system: 'You are a {{kind}} assistant',
+          prompt: 'Help me',
+        ),
+      );
+
+      final options = await ep.render({'kind': 'helpful'});
+
+      // System message should be first
+      expect(options.messages!.first.role, equals(Role.system));
+      final sysText = options.messages!.first.content[0].toJson()['text'];
+      expect(sysText, contains('helpful'));
+    });
+
+    test('renders with literal Part system', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          systemParts: [TextPart(text: 'Be helpful')],
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.messages!.first.role, equals(Role.system));
+      final sysText = options.messages!.first.content[0].toJson()['text'];
+      expect(sysText, equals('Be helpful'));
+    });
+
+    test('renders with literal messages', () async {
+      final history = [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'Previous question')],
+        ),
+        Message(
+          role: Role.model,
+          content: [TextPart(text: 'Previous answer')],
+        ),
+      ];
+
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          messages: history,
+          prompt: 'New question',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      // Should have history + new prompt
+      expect(options.messages!.length, equals(3));
+      expect(options.messages![0].role, equals(Role.user));
+      expect(options.messages![1].role, equals(Role.model));
+      expect(options.messages![2].role, equals(Role.user));
+    });
+
+    test('resolves model from config', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          model: modelRef('my-model'),
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.model, equals('my-model'));
+    });
+
+    test('opts model overrides config model', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          model: modelRef('default-model'),
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render(
+        {},
+        PromptGenerateOptions(model: modelRef('override-model')),
+      );
+
+      expect(options.model, equals('override-model'));
+    });
+
+    test('merges config from both config and opts', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          config: {'temperature': 0.7, 'topK': 40},
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render(
+        {},
+        PromptGenerateOptions(config: {'temperature': 0.5, 'topP': 0.9}),
+      );
+
+      // opts should override config's temperature
+      expect(options.config!['temperature'], equals(0.5));
+      expect(options.config!['topK'], equals(40));
+      expect(options.config!['topP'], equals(0.9));
+    });
+
+    test('resolves tool names from config', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          toolNames: ['tool1', 'tool2'],
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.tools, equals(['tool1', 'tool2']));
+    });
+
+    test('resolves toolChoice from config', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          toolChoice: 'required',
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.toolChoice, equals('required'));
+    });
+
+    test('opts toolChoice overrides config', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          toolChoice: 'auto',
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render(
+        {},
+        PromptGenerateOptions(toolChoice: 'required'),
+      );
+
+      expect(options.toolChoice, equals('required'));
+    });
+
+    test('resolves maxTurns from config', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', maxTurns: 10, prompt: 'Hello'),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.maxTurns, equals(10));
+    });
+
+    test('adds history from opts when no messages config', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', prompt: 'New question'),
+      );
+
+      final history = [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'Old question')],
+        ),
+        Message(
+          role: Role.model,
+          content: [TextPart(text: 'Old answer')],
+        ),
+      ];
+
+      final options = await ep.render(
+        {},
+        PromptGenerateOptions(messages: history),
+      );
+
+      // History + new prompt
+      expect(options.messages!.length, equals(3));
+    });
+
+    test('renders with literal promptParts', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          promptParts: [TextPart(text: 'Literal user prompt')],
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.messages, isNotEmpty);
+      final lastMsg = options.messages!.last;
+      expect(lastMsg.role, equals(Role.user));
+      final text = lastMsg.content[0].toJson()['text'];
+      expect(text, equals('Literal user prompt'));
+    });
+
+    test('renders with systemParts and promptParts (no templates)', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          systemParts: [TextPart(text: 'System instruction')],
+          promptParts: [TextPart(text: 'User question')],
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.messages!.length, equals(2));
+      expect(options.messages![0].role, equals(Role.system));
+      expect(
+        options.messages![0].content[0].toJson()['text'],
+        equals('System instruction'),
+      );
+      expect(options.messages![1].role, equals(Role.user));
+      expect(
+        options.messages![1].content[0].toJson()['text'],
+        equals('User question'),
+      );
+    });
+
+    test('renders messagesTemplate with variable substitution', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          messagesTemplate: 'Hello {{name}}, welcome!',
+        ),
+      );
+
+      final options = await ep.render({'name': 'World'});
+
+      expect(options.messages, isNotEmpty);
+      final text = options.messages!.last.content[0].toJson()['text'];
+      expect(text, contains('Hello World, welcome!'));
+    });
+
+    test('messagesTemplate takes priority over messages', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          messagesTemplate: 'Template message',
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Literal message')],
+            ),
+          ],
+        ),
+      );
+
+      final options = await ep.render({});
+
+      // messagesTemplate should be used, not literal messages
+      final text = options.messages!.last.content[0].toJson()['text'];
+      expect(text, contains('Template message'));
+    });
+
+    test('messages config takes priority over opts messages', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Config message')],
+            ),
+          ],
+        ),
+      );
+
+      final options = await ep.render(
+        {},
+        PromptGenerateOptions(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Opts message')],
+            ),
+          ],
+        ),
+      );
+
+      // Config messages should be used, not opts messages
+      expect(options.messages!.length, equals(1));
+      final text = options.messages![0].content[0].toJson()['text'];
+      expect(text, equals('Config message'));
+    });
+
+    test('prompt string takes priority over promptParts', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          prompt: 'Template prompt {{name}}',
+          promptParts: [TextPart(text: 'Literal prompt')],
+        ),
+      );
+
+      final options = await ep.render({'name': 'World'});
+
+      final text = options.messages!.last.content[0].toJson()['text'];
+      expect(text, contains('Template prompt World'));
+    });
+
+    test('system string takes priority over systemParts', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          system: 'Template system {{kind}}',
+          systemParts: [TextPart(text: 'Literal system')],
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({'kind': 'helpful'});
+
+      final sysText = options.messages!.first.content[0].toJson()['text'];
+      expect(sysText, contains('Template system helpful'));
+    });
+
+    test('renders with null input', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', prompt: 'Hello static prompt'),
+      );
+
+      final options = await ep.render(null);
+
+      expect(options.messages, isNotEmpty);
+      final text = options.messages!.last.content[0].toJson()['text'];
+      expect(text, contains('Hello static prompt'));
+    });
+  });
+
+  group('lookupPrompt', () {
+    late Registry registry;
+    late DotpromptRegistry dpRegistry;
+
+    setUp(() {
+      registry = Registry();
+      dpRegistry = DotpromptRegistry();
+    });
+
+    test('finds a registered prompt by name', () async {
+      definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'greet', prompt: 'Hello {{name}}'),
+      );
+
+      final ep = await lookupPrompt(registry, 'greet');
+      expect(ep, isA<ExecutablePrompt>());
+      expect(ep.ref.name, equals('greet'));
+    });
+
+    test('finds a registered prompt by name and variant', () async {
+      definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'greet',
+          variant: 'formal',
+          prompt: 'Good day {{name}}',
+        ),
+      );
+
+      final ep = await lookupPrompt(registry, 'greet', variant: 'formal');
+      expect(ep, isA<ExecutablePrompt>());
+      expect(ep.ref.name, equals('greet.formal'));
+    });
+
+    test('throws when prompt not found', () async {
+      expect(
+        () => lookupPrompt(registry, 'nonexistent'),
+        throwsA(isA<GenkitException>()),
+      );
+    });
+  });
+
+  group('PromptAction', () {
+    test('can be invoked with executablePrompt', () async {
+      final registry = Registry();
+      final dpRegistry = DotpromptRegistry();
+
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', prompt: 'Hello {{name}}'),
+      );
+
+      final action = await registry.lookupAction('prompt', 'test');
+      expect(action, isNotNull);
+
+      // Invoke via the action
+      final result = await action!({'name': 'World'});
+      expect(result, isA<GenerateActionOptions>());
+      final opts = result as GenerateActionOptions;
+      expect(opts.messages, isNotEmpty);
+    });
+
+    test('can be invoked with legacy fn', () async {
+      final action = PromptAction<String>(
+        name: 'legacy',
+        fn: (input, ctx) async {
+          return GenerateActionOptions(
+            model: 'test-model',
+            messages: [
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'Hello $input')],
+              ),
+            ],
+          );
+        },
+      );
+
+      final result = await action('World');
+      expect(result, isA<GenerateActionOptions>());
+      final opts = result as GenerateActionOptions;
+      expect(opts.model, equals('test-model'));
+    });
+  });
+
+  group('Genkit.definePrompt integration', () {
+    late Genkit genkit;
+
+    setUp(() {
+      genkit = Genkit(isDevEnv: false, promptDir: null);
+    });
+
+    tearDown(() async {
+      await genkit.shutdown();
+    });
+
+    test('definePrompt returns ExecutablePrompt', () {
+      final ep = genkit.definePrompt(
+        name: 'hi',
+        prompt: 'Say hi to {{name}}',
+      );
+
+      expect(ep, isA<ExecutablePrompt>());
+      expect(ep.ref.name, equals('hi'));
+    });
+
+    test('definePrompt with model', () async {
+      final ep = genkit.definePrompt(
+        name: 'hi',
+        model: modelRef('test/model'),
+        prompt: 'Say hi to {{name}}',
+      );
+
+      final options = await ep.render({'name': 'Sparky'});
+      expect(options.model, equals('test/model'));
+    });
+
+    test('prompt() looks up defined prompts', () async {
+      genkit.definePrompt(
+        name: 'greeting',
+        prompt: 'Hello {{name}}',
+      );
+
+      final ep = await genkit.prompt('greeting');
+      expect(ep, isA<ExecutablePrompt>());
+    });
+
+    test('prompt() with variant', () async {
+      genkit.definePrompt(
+        name: 'greeting',
+        variant: 'formal',
+        prompt: 'Good day, {{name}}',
+      );
+
+      final ep = await genkit.prompt('greeting', variant: 'formal');
+      expect(ep, isA<ExecutablePrompt>());
+      expect(ep.ref.name, equals('greeting.formal'));
+    });
+
+    test('prompt() throws for missing prompt', () {
+      expect(
+        () => genkit.prompt('nonexistent'),
+        throwsA(isA<GenkitException>()),
+      );
+    });
+
+    test('definePrompt with system and prompt templates', () async {
+      final ep = genkit.definePrompt(
+        name: 'assistant',
+        system: 'You are a {{kind}} assistant',
+        prompt: 'Help me with {{task}}',
+      );
+
+      final options = await ep.render({
+        'kind': 'coding',
+        'task': 'Dart',
+      });
+
+      expect(options.messages!.length, equals(2));
+      expect(options.messages![0].role, equals(Role.system));
+      expect(options.messages![1].role, equals(Role.user));
+    });
+
+    test('definePrompt with config options', () async {
+      final ep = genkit.definePrompt(
+        name: 'creative',
+        model: modelRef('test/model'),
+        config: {'temperature': 0.9},
+        maxTurns: 3,
+        toolChoice: 'auto',
+        prompt: 'Write a story',
+      );
+
+      final options = await ep.render({});
+      expect(options.model, equals('test/model'));
+      expect(options.config!['temperature'], equals(0.9));
+      expect(options.maxTurns, equals(3));
+      expect(options.toolChoice, equals('auto'));
+    });
+
+    test('defineLegacyPrompt works for backwards compatibility', () async {
+      final pa = genkit.defineLegacyPrompt<String>(
+        name: 'old-style',
+        fn: (input, ctx) async {
+          return GenerateActionOptions(
+            model: 'test-model',
+            messages: [
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'Hello $input')],
+              ),
+            ],
+          );
+        },
+      );
+
+      expect(pa, isA<PromptAction<String>>());
+      final result = await pa('World');
+      expect(result, isA<GenerateActionOptions>());
+    });
+
+    test('definePartial registers a partial', () async {
+      genkit.definePartial('greeting', 'Hello {{name}}!');
+
+      // Use the partial in a prompt
+      final ep = genkit.definePrompt(
+        name: 'with-partial',
+        prompt: '{{> greeting}}',
+      );
+
+      final options = await ep.render({'name': 'World'});
+      final text = options.messages!.last.content[0].toJson()['text'];
+      expect(text, contains('Hello World!'));
+    });
+
+    test('multiple prompts can be defined', () async {
+      genkit.definePrompt(name: 'p1', prompt: 'Prompt 1');
+      genkit.definePrompt(name: 'p2', prompt: 'Prompt 2');
+      genkit.definePrompt(name: 'p3', prompt: 'Prompt 3');
+
+      final ep1 = await genkit.prompt('p1');
+      final ep2 = await genkit.prompt('p2');
+      final ep3 = await genkit.prompt('p3');
+
+      expect(ep1.ref.name, equals('p1'));
+      expect(ep2.ref.name, equals('p2'));
+      expect(ep3.ref.name, equals('p3'));
+    });
+  });
+
+  group('loadPromptFolder', () {
+    late Registry registry;
+    late DotpromptRegistry dpRegistry;
+    late Directory tempDir;
+
+    setUp(() {
+      registry = Registry();
+      dpRegistry = DotpromptRegistry();
+      tempDir = Directory.systemTemp.createTempSync('genkit_prompt_test_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('loads a simple .prompt file', () async {
+      File(p.join(tempDir.path, 'hello.prompt'))
+          .writeAsStringSync('Hello {{name}}!');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final action = await registry.lookupAction('prompt', 'hello');
+      expect(action, isNotNull);
+      expect(action, isA<PromptAction>());
+    });
+
+    test('loads prompt with frontmatter', () async {
+      File(p.join(tempDir.path, 'greeting.prompt')).writeAsStringSync('''
+---
+model: test-model
+config:
+  temperature: 0.7
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final action = await registry.lookupAction('prompt', 'greeting');
+      expect(action, isNotNull);
+      final pa = action as PromptAction;
+      expect(pa.metadata['prompt']['model'], equals('test-model'));
+    });
+
+    test('loads variant prompts', () async {
+      File(p.join(tempDir.path, 'greeting.prompt'))
+          .writeAsStringSync('Hi {{name}}!');
+      File(p.join(tempDir.path, 'greeting.formal.prompt'))
+          .writeAsStringSync('Good day, {{name}}.');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final defaultAction =
+          await registry.lookupAction('prompt', 'greeting');
+      final formalAction =
+          await registry.lookupAction('prompt', 'greeting.formal');
+
+      expect(defaultAction, isNotNull);
+      expect(formalAction, isNotNull);
+    });
+
+    test('registers underscore-prefixed files as partials', () async {
+      // Create a partial
+      File(p.join(tempDir.path, '_header.prompt'))
+          .writeAsStringSync('Welcome, {{name}}!');
+      // Create a prompt that uses the partial
+      File(p.join(tempDir.path, 'page.prompt'))
+          .writeAsStringSync('{{> header}} How can I help?');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      // The partial should not be registered as a prompt action
+      final partialAction = await registry.lookupAction('prompt', 'header');
+      expect(partialAction, isNull);
+
+      // But the main prompt should be registered
+      final pageAction = await registry.lookupAction('prompt', 'page');
+      expect(pageAction, isNotNull);
+    });
+
+    test('loads prompts from subdirectories', () async {
+      final subDir = Directory(p.join(tempDir.path, 'sub'));
+      subDir.createSync();
+      File(p.join(subDir.path, 'nested.prompt'))
+          .writeAsStringSync('Nested prompt');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final action = await registry.lookupAction('prompt', 'sub/nested');
+      expect(action, isNotNull);
+    });
+
+    test('does nothing when directory does not exist', () {
+      // Should not throw
+      loadPromptFolder(
+        registry,
+        dpRegistry,
+        dir: '/nonexistent/path/that/does/not/exist',
+      );
+    });
+
+    test('loads with namespace', () async {
+      File(p.join(tempDir.path, 'hello.prompt'))
+          .writeAsStringSync('Hello {{name}}!');
+
+      loadPromptFolder(
+        registry,
+        dpRegistry,
+        dir: tempDir.path,
+        ns: 'myapp',
+      );
+
+      final action = await registry.lookupAction('prompt', 'myapp/hello');
+      expect(action, isNotNull);
+    });
+
+    test('loads multiple prompts', () async {
+      File(p.join(tempDir.path, 'a.prompt')).writeAsStringSync('Prompt A');
+      File(p.join(tempDir.path, 'b.prompt')).writeAsStringSync('Prompt B');
+      File(p.join(tempDir.path, 'c.prompt')).writeAsStringSync('Prompt C');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      expect(await registry.lookupAction('prompt', 'a'), isNotNull);
+      expect(await registry.lookupAction('prompt', 'b'), isNotNull);
+      expect(await registry.lookupAction('prompt', 'c'), isNotNull);
+    });
+
+    test('ignores non-prompt files', () async {
+      File(p.join(tempDir.path, 'hello.prompt'))
+          .writeAsStringSync('Hello {{name}}!');
+      File(p.join(tempDir.path, 'readme.md'))
+          .writeAsStringSync('# Not a prompt');
+      File(p.join(tempDir.path, 'config.json'))
+          .writeAsStringSync('{"key": "value"}');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      // Only the .prompt file should be loaded
+      final action = await registry.lookupAction('prompt', 'hello');
+      expect(action, isNotNull);
+
+      final mdAction = await registry.lookupAction('prompt', 'readme');
+      expect(mdAction, isNull);
+    });
+  });
+
+  group('DotpromptRegistry', () {
+    late DotpromptRegistry dpRegistry;
+
+    setUp(() {
+      dpRegistry = DotpromptRegistry();
+    });
+
+    test('parses a template', () {
+      final parsed = dpRegistry.parse('Hello {{name}}!');
+      expect(parsed.template, isNotEmpty);
+    });
+
+    test('parses template with frontmatter', () {
+      final parsed = dpRegistry.parse('''
+---
+model: test-model
+config:
+  temperature: 0.5
+---
+Hello {{name}}!
+''');
+      expect(parsed.metadata.model, equals('test-model'));
+      expect(parsed.template, contains('Hello'));
+    });
+
+    test('compiles and renders a template', () async {
+      final compiled = await dpRegistry.compile('Hello {{name}}!');
+      final result = await compiled.render(
+        dp.DataArgument(input: {'name': 'World'}),
+      );
+      expect(result.messages, isNotEmpty);
+      final text = (result.messages.first.content.first as dp.TextPart).text;
+      expect(text, contains('Hello World!'));
+    });
+
+    test('defines and uses partials', () async {
+      dpRegistry.definePartial('greet', 'Hi {{name}}!');
+      final compiled = await dpRegistry.compile('{{> greet}}');
+      final result = await compiled.render(
+        dp.DataArgument(input: {'name': 'Dart'}),
+      );
+      final text = (result.messages.first.content.first as dp.TextPart).text;
+      expect(text, contains('Hi Dart!'));
+    });
+
+    test('renders a template directly', () async {
+      final result = await dpRegistry.render(
+        'Hello {{name}}!',
+        dp.DataArgument(input: {'name': 'World'}),
+      );
+      expect(result.messages, isNotEmpty);
+    });
+  });
+}
+

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -159,6 +159,7 @@ void main() {
         model: modelRef('test-model'),
         prompt: 'Hello {{name}}',
         toolNames: ['tool1'],
+        toolChoice: 'auto',
       );
 
       definePromptAction(registry, dpRegistry, config);
@@ -169,6 +170,7 @@ void main() {
       expect(pa.metadata['type'], equals('prompt'));
       expect(pa.metadata['prompt']['model'], equals('test-model'));
       expect(pa.metadata['prompt']['tools'], equals(['tool1']));
+      expect(pa.metadata['prompt']['toolChoice'], equals('auto'));
     });
   });
 
@@ -190,11 +192,13 @@ void main() {
 
       final options = await ep.render({'name': 'World'});
 
-      expect(options.messages, isNotEmpty);
-      final lastMsg = options.messages!.last;
-      expect(lastMsg.role, equals(Role.user));
-      final text = lastMsg.content[0].toJson()['text'];
-      expect(text, contains('Hello World'));
+      // JS: messages: [{ content: [{ text: 'hello foo' }], role: 'user' }]
+      expect(options.messages!.length, equals(1));
+      expect(options.messages![0].role, equals(Role.user));
+      expect(
+        options.messages![0].content[0].toJson()['text'],
+        equals('Hello World'),
+      );
     });
 
     test('renders system template', () async {
@@ -210,10 +214,18 @@ void main() {
 
       final options = await ep.render({'kind': 'helpful'});
 
-      // System message should be first
-      expect(options.messages!.first.role, equals(Role.system));
-      final sysText = options.messages!.first.content[0].toJson()['text'];
-      expect(sysText, contains('helpful'));
+      // JS: messages: [system, user] — 2 messages
+      expect(options.messages!.length, equals(2));
+      expect(options.messages![0].role, equals(Role.system));
+      expect(
+        options.messages![0].content[0].toJson()['text'],
+        equals('You are a helpful assistant'),
+      );
+      expect(options.messages![1].role, equals(Role.user));
+      expect(
+        options.messages![1].content[0].toJson()['text'],
+        equals('Help me'),
+      );
     });
 
     test('renders with literal Part system', () async {
@@ -408,8 +420,23 @@ void main() {
         PromptGenerateOptions(messages: history),
       );
 
-      // History + new prompt
+      // JS: messages: [history user, history model, prompt user]
       expect(options.messages!.length, equals(3));
+      expect(options.messages![0].role, equals(Role.user));
+      expect(
+        options.messages![0].content[0].toJson()['text'],
+        equals('Old question'),
+      );
+      expect(options.messages![1].role, equals(Role.model));
+      expect(
+        options.messages![1].content[0].toJson()['text'],
+        equals('Old answer'),
+      );
+      expect(options.messages![2].role, equals(Role.user));
+      expect(
+        options.messages![2].content[0].toJson()['text'],
+        equals('New question'),
+      );
     });
 
     test('renders with literal promptParts', () async {
@@ -659,11 +686,11 @@ void main() {
         final history = [
           Message(
             role: Role.user,
-            content: [TextPart(text: 'previous question')],
+            content: [TextPart(text: 'hi')],
           ),
           Message(
             role: Role.model,
-            content: [TextPart(text: 'previous answer')],
+            content: [TextPart(text: 'bye')],
           ),
         ];
 
@@ -672,14 +699,21 @@ void main() {
           PromptGenerateOptions(messages: history),
         );
 
-        // History should be inserted + template message
-        expect(options.messages!.length, greaterThanOrEqualTo(3));
-        // The template message should contain rendered content
-        final allText = options.messages!
-            .map((m) => m.content[0].toJson()['text'])
-            .join(', ');
-        expect(allText, contains('hello World'));
-        expect(allText, contains('previous question'));
+        // JS: messages: [template, history user, history model] — 3 messages
+        // History is inserted after the template content
+        expect(options.messages!.length, equals(3));
+        // Verify all messages are present with correct content
+        final texts = options.messages!
+            .map((m) => m.content[0].toJson()['text'] as String)
+            .toList();
+        expect(texts.any((t) => t.contains('hello World')), isTrue);
+        expect(texts.any((t) => t.contains('hi')), isTrue);
+        expect(texts.any((t) => t.contains('bye')), isTrue);
+        // History messages should have purpose metadata
+        final historyMsgs = options.messages!
+            .where((m) => m.toJson()['metadata']?['purpose'] == 'history')
+            .toList();
+        expect(historyMsgs.length, equals(2));
       },
     );
 
@@ -691,7 +725,7 @@ void main() {
           dpRegistry,
           PromptConfig(
             name: 'test',
-            messagesTemplate: 'hello {{name}}{{history}}',
+            messagesTemplate: 'hello {{name}}\n{{history}}',
           ),
         );
 
@@ -711,12 +745,27 @@ void main() {
           PromptGenerateOptions(messages: history),
         );
 
-        // Template message first, then history
-        expect(options.messages!.length, greaterThanOrEqualTo(3));
+        // JS: messages: [template user, history user (purpose:history),
+        //                history model (purpose:history)]
+        expect(options.messages!.length, equals(3));
         // First message should be from the template
+        expect(options.messages![0].role, equals(Role.user));
         expect(
           options.messages![0].content[0].toJson()['text'],
           contains('hello World'),
+        );
+        // History messages should have purpose metadata
+        final historyMsgs = options.messages!
+            .where((m) => m.toJson()['metadata']?['purpose'] == 'history')
+            .toList();
+        expect(historyMsgs.length, equals(2));
+        expect(
+          historyMsgs[0].content[0].toJson()['text'],
+          equals('prev Q'),
+        );
+        expect(
+          historyMsgs[1].content[0].toJson()['text'],
+          equals('prev A'),
         );
       },
     );

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -565,6 +565,189 @@ void main() {
       expect(sysText, contains('Template system helpful'));
     });
 
+    test(
+      'renders system + messages + prompt in correct order',
+      () async {
+        final ep = definePromptAction(
+          registry,
+          dpRegistry,
+          PromptConfig(
+            name: 'test',
+            system: 'system {{name}}',
+            messages: [
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'hi')],
+              ),
+              Message(
+                role: Role.model,
+                content: [TextPart(text: 'bye')],
+              ),
+            ],
+            prompt: 'user prompt {{name}}',
+          ),
+        );
+
+        final options = await ep.render({'name': 'foo'});
+
+        // Order should be: system, messages history, user prompt
+        expect(options.messages!.length, equals(4));
+        expect(options.messages![0].role, equals(Role.system));
+        expect(
+          options.messages![0].content[0].toJson()['text'],
+          contains('system foo'),
+        );
+        expect(options.messages![1].role, equals(Role.user));
+        expect(
+          options.messages![1].content[0].toJson()['text'],
+          equals('hi'),
+        );
+        expect(options.messages![2].role, equals(Role.model));
+        expect(
+          options.messages![2].content[0].toJson()['text'],
+          equals('bye'),
+        );
+        expect(options.messages![3].role, equals(Role.user));
+        expect(
+          options.messages![3].content[0].toJson()['text'],
+          contains('user prompt foo'),
+        );
+      },
+    );
+
+    test(
+      'renders multi-role messagesTemplate with {{role}} helper',
+      () async {
+        final ep = definePromptAction(
+          registry,
+          dpRegistry,
+          PromptConfig(
+            name: 'test',
+            messagesTemplate:
+                '{{role "system"}}\nsystem {{name}}\n{{role "user"}}\nuser {{name}}',
+          ),
+        );
+
+        final options = await ep.render({'name': 'foo'});
+
+        expect(options.messages!.length, equals(2));
+        expect(options.messages![0].role, equals(Role.system));
+        expect(
+          options.messages![0].content[0].toJson()['text'],
+          contains('system foo'),
+        );
+        expect(options.messages![1].role, equals(Role.user));
+        expect(
+          options.messages![1].content[0].toJson()['text'],
+          contains('user foo'),
+        );
+      },
+    );
+
+    test(
+      'messagesTemplate with opts.messages prepends history',
+      () async {
+        final ep = definePromptAction(
+          registry,
+          dpRegistry,
+          PromptConfig(
+            name: 'test',
+            messagesTemplate: 'hello {{name}}',
+          ),
+        );
+
+        final history = [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'previous question')],
+          ),
+          Message(
+            role: Role.model,
+            content: [TextPart(text: 'previous answer')],
+          ),
+        ];
+
+        final options = await ep.render(
+          {'name': 'World'},
+          PromptGenerateOptions(messages: history),
+        );
+
+        // History should be inserted + template message
+        expect(options.messages!.length, greaterThanOrEqualTo(3));
+        // The template message should contain rendered content
+        final allText = options.messages!
+            .map((m) => m.content[0].toJson()['text'])
+            .join(', ');
+        expect(allText, contains('hello World'));
+        expect(allText, contains('previous question'));
+      },
+    );
+
+    test(
+      'messagesTemplate with {{history}} controls history placement',
+      () async {
+        final ep = definePromptAction(
+          registry,
+          dpRegistry,
+          PromptConfig(
+            name: 'test',
+            messagesTemplate: 'hello {{name}}{{history}}',
+          ),
+        );
+
+        final history = [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'prev Q')],
+          ),
+          Message(
+            role: Role.model,
+            content: [TextPart(text: 'prev A')],
+          ),
+        ];
+
+        final options = await ep.render(
+          {'name': 'World'},
+          PromptGenerateOptions(messages: history),
+        );
+
+        // Template message first, then history
+        expect(options.messages!.length, greaterThanOrEqualTo(3));
+        // First message should be from the template
+        expect(
+          options.messages![0].content[0].toJson()['text'],
+          contains('hello World'),
+        );
+      },
+    );
+
+    test('preserves output config through render', () async {
+      final outputConfig = GenerateActionOutputConfig.fromJson({
+        'format': 'json',
+        'jsonSchema': {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+          },
+        },
+      });
+
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          prompt: 'Generate a name',
+          output: outputConfig,
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.output, isNotNull);
+      expect(options.output!.toJson()['format'], equals('json'));
+    });
+
     test('renders with null input', () async {
       final ep = definePromptAction(
         registry,

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -168,9 +168,10 @@ void main() {
       expect(action, isNotNull);
       final pa = action as PromptAction;
       expect(pa.metadata['type'], equals('prompt'));
-      expect(pa.metadata['prompt']['model'], equals('test-model'));
-      expect(pa.metadata['prompt']['tools'], equals(['tool1']));
-      expect(pa.metadata['prompt']['toolChoice'], equals('auto'));
+      final promptMeta = pa.metadata['prompt'] as Map<String, dynamic>;
+      expect(promptMeta['model'], equals('test-model'));
+      expect(promptMeta['tools'], equals(['tool1']));
+      expect(promptMeta['toolChoice'], equals('auto'));
     });
   });
 
@@ -193,10 +194,10 @@ void main() {
       final options = await ep.render({'name': 'World'});
 
       // JS: messages: [{ content: [{ text: 'hello foo' }], role: 'user' }]
-      expect(options.messages!.length, equals(1));
-      expect(options.messages![0].role, equals(Role.user));
+      expect(options.messages.length, equals(1));
+      expect(options.messages[0].role, equals(Role.user));
       expect(
-        options.messages![0].content[0].toJson()['text'],
+        options.messages[0].content[0].toJson()['text'],
         equals('Hello World'),
       );
     });
@@ -215,15 +216,15 @@ void main() {
       final options = await ep.render({'kind': 'helpful'});
 
       // JS: messages: [system, user] — 2 messages
-      expect(options.messages!.length, equals(2));
-      expect(options.messages![0].role, equals(Role.system));
+      expect(options.messages.length, equals(2));
+      expect(options.messages[0].role, equals(Role.system));
       expect(
-        options.messages![0].content[0].toJson()['text'],
+        options.messages[0].content[0].toJson()['text'],
         equals('You are a helpful assistant'),
       );
-      expect(options.messages![1].role, equals(Role.user));
+      expect(options.messages[1].role, equals(Role.user));
       expect(
-        options.messages![1].content[0].toJson()['text'],
+        options.messages[1].content[0].toJson()['text'],
         equals('Help me'),
       );
     });
@@ -241,8 +242,8 @@ void main() {
 
       final options = await ep.render({});
 
-      expect(options.messages!.first.role, equals(Role.system));
-      final sysText = options.messages!.first.content[0].toJson()['text'];
+      expect(options.messages.first.role, equals(Role.system));
+      final sysText = options.messages.first.content[0].toJson()['text'];
       expect(sysText, equals('Be helpful'));
     });
 
@@ -271,10 +272,10 @@ void main() {
       final options = await ep.render({});
 
       // Should have history + new prompt
-      expect(options.messages!.length, equals(3));
-      expect(options.messages![0].role, equals(Role.user));
-      expect(options.messages![1].role, equals(Role.model));
-      expect(options.messages![2].role, equals(Role.user));
+      expect(options.messages.length, equals(3));
+      expect(options.messages[0].role, equals(Role.user));
+      expect(options.messages[1].role, equals(Role.model));
+      expect(options.messages[2].role, equals(Role.user));
     });
 
     test('resolves model from config', () async {
@@ -421,20 +422,20 @@ void main() {
       );
 
       // JS: messages: [history user, history model, prompt user]
-      expect(options.messages!.length, equals(3));
-      expect(options.messages![0].role, equals(Role.user));
+      expect(options.messages.length, equals(3));
+      expect(options.messages[0].role, equals(Role.user));
       expect(
-        options.messages![0].content[0].toJson()['text'],
+        options.messages[0].content[0].toJson()['text'],
         equals('Old question'),
       );
-      expect(options.messages![1].role, equals(Role.model));
+      expect(options.messages[1].role, equals(Role.model));
       expect(
-        options.messages![1].content[0].toJson()['text'],
+        options.messages[1].content[0].toJson()['text'],
         equals('Old answer'),
       );
-      expect(options.messages![2].role, equals(Role.user));
+      expect(options.messages[2].role, equals(Role.user));
       expect(
-        options.messages![2].content[0].toJson()['text'],
+        options.messages[2].content[0].toJson()['text'],
         equals('New question'),
       );
     });
@@ -452,7 +453,7 @@ void main() {
       final options = await ep.render({});
 
       expect(options.messages, isNotEmpty);
-      final lastMsg = options.messages!.last;
+      final lastMsg = options.messages.last;
       expect(lastMsg.role, equals(Role.user));
       final text = lastMsg.content[0].toJson()['text'];
       expect(text, equals('Literal user prompt'));
@@ -471,15 +472,15 @@ void main() {
 
       final options = await ep.render({});
 
-      expect(options.messages!.length, equals(2));
-      expect(options.messages![0].role, equals(Role.system));
+      expect(options.messages.length, equals(2));
+      expect(options.messages[0].role, equals(Role.system));
       expect(
-        options.messages![0].content[0].toJson()['text'],
+        options.messages[0].content[0].toJson()['text'],
         equals('System instruction'),
       );
-      expect(options.messages![1].role, equals(Role.user));
+      expect(options.messages[1].role, equals(Role.user));
       expect(
-        options.messages![1].content[0].toJson()['text'],
+        options.messages[1].content[0].toJson()['text'],
         equals('User question'),
       );
     });
@@ -497,7 +498,7 @@ void main() {
       final options = await ep.render({'name': 'World'});
 
       expect(options.messages, isNotEmpty);
-      final text = options.messages!.last.content[0].toJson()['text'];
+      final text = options.messages.last.content[0].toJson()['text'];
       expect(text, contains('Hello World, welcome!'));
     });
 
@@ -520,7 +521,7 @@ void main() {
       final options = await ep.render({});
 
       // messagesTemplate should be used, not literal messages
-      final text = options.messages!.last.content[0].toJson()['text'];
+      final text = options.messages.last.content[0].toJson()['text'];
       expect(text, contains('Template message'));
     });
 
@@ -552,8 +553,8 @@ void main() {
       );
 
       // Config messages should be used, not opts messages
-      expect(options.messages!.length, equals(1));
-      final text = options.messages![0].content[0].toJson()['text'];
+      expect(options.messages.length, equals(1));
+      final text = options.messages[0].content[0].toJson()['text'];
       expect(text, equals('Config message'));
     });
 
@@ -570,7 +571,7 @@ void main() {
 
       final options = await ep.render({'name': 'World'});
 
-      final text = options.messages!.last.content[0].toJson()['text'];
+      final text = options.messages.last.content[0].toJson()['text'];
       expect(text, contains('Template prompt World'));
     });
 
@@ -588,7 +589,7 @@ void main() {
 
       final options = await ep.render({'kind': 'helpful'});
 
-      final sysText = options.messages!.first.content[0].toJson()['text'];
+      final sysText = options.messages.first.content[0].toJson()['text'];
       expect(sysText, contains('Template system helpful'));
     });
 
@@ -618,25 +619,25 @@ void main() {
         final options = await ep.render({'name': 'foo'});
 
         // Order should be: system, messages history, user prompt
-        expect(options.messages!.length, equals(4));
-        expect(options.messages![0].role, equals(Role.system));
+        expect(options.messages.length, equals(4));
+        expect(options.messages[0].role, equals(Role.system));
         expect(
-          options.messages![0].content[0].toJson()['text'],
+          options.messages[0].content[0].toJson()['text'],
           contains('system foo'),
         );
-        expect(options.messages![1].role, equals(Role.user));
+        expect(options.messages[1].role, equals(Role.user));
         expect(
-          options.messages![1].content[0].toJson()['text'],
+          options.messages[1].content[0].toJson()['text'],
           equals('hi'),
         );
-        expect(options.messages![2].role, equals(Role.model));
+        expect(options.messages[2].role, equals(Role.model));
         expect(
-          options.messages![2].content[0].toJson()['text'],
+          options.messages[2].content[0].toJson()['text'],
           equals('bye'),
         );
-        expect(options.messages![3].role, equals(Role.user));
+        expect(options.messages[3].role, equals(Role.user));
         expect(
-          options.messages![3].content[0].toJson()['text'],
+          options.messages[3].content[0].toJson()['text'],
           contains('user prompt foo'),
         );
       },
@@ -657,15 +658,15 @@ void main() {
 
         final options = await ep.render({'name': 'foo'});
 
-        expect(options.messages!.length, equals(2));
-        expect(options.messages![0].role, equals(Role.system));
+        expect(options.messages.length, equals(2));
+        expect(options.messages[0].role, equals(Role.system));
         expect(
-          options.messages![0].content[0].toJson()['text'],
+          options.messages[0].content[0].toJson()['text'],
           contains('system foo'),
         );
-        expect(options.messages![1].role, equals(Role.user));
+        expect(options.messages[1].role, equals(Role.user));
         expect(
-          options.messages![1].content[0].toJson()['text'],
+          options.messages[1].content[0].toJson()['text'],
           contains('user foo'),
         );
       },
@@ -701,17 +702,18 @@ void main() {
 
         // JS: messages: [template, history user, history model] — 3 messages
         // History is inserted after the template content
-        expect(options.messages!.length, equals(3));
+        expect(options.messages.length, equals(3));
         // Verify all messages are present with correct content
-        final texts = options.messages!
+        final texts = options.messages
             .map((m) => m.content[0].toJson()['text'] as String)
             .toList();
         expect(texts.any((t) => t.contains('hello World')), isTrue);
         expect(texts.any((t) => t.contains('hi')), isTrue);
         expect(texts.any((t) => t.contains('bye')), isTrue);
         // History messages should have purpose metadata
-        final historyMsgs = options.messages!
-            .where((m) => m.toJson()['metadata']?['purpose'] == 'history')
+        final historyMsgs = options.messages
+            .where((m) =>
+                (m.toJson()['metadata'] as Map?)?['purpose'] == 'history')
             .toList();
         expect(historyMsgs.length, equals(2));
       },
@@ -747,16 +749,17 @@ void main() {
 
         // JS: messages: [template user, history user (purpose:history),
         //                history model (purpose:history)]
-        expect(options.messages!.length, equals(3));
+        expect(options.messages.length, equals(3));
         // First message should be from the template
-        expect(options.messages![0].role, equals(Role.user));
+        expect(options.messages[0].role, equals(Role.user));
         expect(
-          options.messages![0].content[0].toJson()['text'],
+          options.messages[0].content[0].toJson()['text'],
           contains('hello World'),
         );
         // History messages should have purpose metadata
-        final historyMsgs = options.messages!
-            .where((m) => m.toJson()['metadata']?['purpose'] == 'history')
+        final historyMsgs = options.messages
+            .where((m) =>
+                (m.toJson()['metadata'] as Map?)?['purpose'] == 'history')
             .toList();
         expect(historyMsgs.length, equals(2));
         expect(
@@ -807,7 +810,7 @@ void main() {
       final options = await ep.render(null);
 
       expect(options.messages, isNotEmpty);
-      final text = options.messages!.last.content[0].toJson()['text'];
+      final text = options.messages.last.content[0].toJson()['text'];
       expect(text, contains('Hello static prompt'));
     });
   });
@@ -862,7 +865,7 @@ void main() {
       final registry = Registry();
       final dpRegistry = DotpromptRegistry();
 
-      final ep = definePromptAction(
+      definePromptAction(
         registry,
         dpRegistry,
         PromptConfig(name: 'test', prompt: 'Hello {{name}}'),
@@ -896,7 +899,7 @@ void main() {
 
       final result = await action('World');
       expect(result, isA<GenerateActionOptions>());
-      final opts = result as GenerateActionOptions;
+      final opts = result;
       expect(opts.model, equals('test-model'));
     });
   });
@@ -974,9 +977,9 @@ void main() {
         'task': 'Dart',
       });
 
-      expect(options.messages!.length, equals(2));
-      expect(options.messages![0].role, equals(Role.system));
-      expect(options.messages![1].role, equals(Role.user));
+      expect(options.messages.length, equals(2));
+      expect(options.messages[0].role, equals(Role.system));
+      expect(options.messages[1].role, equals(Role.user));
     });
 
     test('definePrompt with config options', () async {
@@ -996,8 +999,8 @@ void main() {
       expect(options.toolChoice, equals('auto'));
     });
 
-    test('defineLegacyPrompt works for backwards compatibility', () async {
-      final pa = genkit.defineLegacyPrompt<String>(
+    test('defineCustomPrompt works for programmatic prompt building', () async {
+      final pa = genkit.defineCustomPrompt<String>(
         name: 'old-style',
         fn: (input, ctx) async {
           return GenerateActionOptions(
@@ -1027,7 +1030,7 @@ void main() {
       );
 
       final options = await ep.render({'name': 'World'});
-      final text = options.messages!.last.content[0].toJson()['text'];
+      final text = options.messages.last.content[0].toJson()['text'];
       expect(text, contains('Hello World!'));
     });
 
@@ -1087,7 +1090,10 @@ Hello {{name}}!
       final action = await registry.lookupAction('prompt', 'greeting');
       expect(action, isNotNull);
       final pa = action as PromptAction;
-      expect(pa.metadata['prompt']['model'], equals('test-model'));
+      expect(
+        (pa.metadata['prompt'] as Map<String, dynamic>)['model'],
+        equals('test-model'),
+      );
     });
 
     test('loads variant prompts', () async {

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -985,6 +985,82 @@ void main() {
       expect(ep2.ref.name, equals('p2'));
       expect(ep3.ref.name, equals('p3'));
     });
+
+    test('defineSchema registers a named schema', () {
+      // Should not throw
+      genkit.defineSchema('Address', {
+        'type': 'object',
+        'properties': {
+          'street': {'type': 'string'},
+          'city': {'type': 'string'},
+        },
+        'required': ['street', 'city'],
+      });
+
+      // Schema should be stored in the registry
+      final schema = genkit.registry.lookupValue<Map<String, dynamic>>(
+        'schema',
+        'Address',
+      );
+      expect(schema, isNotNull);
+      expect(schema!['type'], equals('object'));
+      expect(schema['properties'], contains('street'));
+    });
+
+    test('defineSchema makes schema available for picoschema in prompts',
+        () async {
+      genkit.defineSchema('Person', {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+          'age': {'type': 'integer'},
+        },
+        'required': ['name', 'age'],
+      });
+
+      // Define a prompt with picoschema output that references named schema
+      final ep = genkit.definePrompt(
+        name: 'person-prompt',
+        prompt: 'Generate a person',
+        output: GenerateActionOutputConfig.fromJson({
+          'format': 'json',
+        }),
+      );
+
+      // Verify the prompt was created successfully
+      expect(ep, isA<ExecutablePrompt>());
+      final options = await ep.render({});
+      expect(options.messages, isNotEmpty);
+    });
+
+    test('defineSchema allows multiple schemas', () {
+      genkit.defineSchema('Schema1', {
+        'type': 'object',
+        'properties': {
+          'a': {'type': 'string'},
+        },
+      });
+      genkit.defineSchema('Schema2', {
+        'type': 'object',
+        'properties': {
+          'b': {'type': 'integer'},
+        },
+      });
+
+      final s1 = genkit.registry.lookupValue<Map<String, dynamic>>(
+        'schema',
+        'Schema1',
+      );
+      final s2 = genkit.registry.lookupValue<Map<String, dynamic>>(
+        'schema',
+        'Schema2',
+      );
+
+      expect(s1, isNotNull);
+      expect(s2, isNotNull);
+      expect(s1!['properties'], contains('a'));
+      expect(s2!['properties'], contains('b'));
+    });
   });
 
   group('Genkit promptDir integration', () {
@@ -1211,6 +1287,85 @@ Hello {{name}}!
 
     setUp(() {
       dpRegistry = DotpromptRegistry();
+    });
+
+    test('defineSchema registers a named schema', () {
+      dpRegistry.defineSchema('MyAddress', {
+        'type': 'object',
+        'properties': {
+          'street': {'type': 'string'},
+          'city': {'type': 'string'},
+        },
+        'required': ['street', 'city'],
+      });
+
+      // The schema should not throw - it's registered internally
+      // We verify it works by using it in a picoschema prompt below
+    });
+
+    test('defineSchema makes schema available in picoschema resolution',
+        () async {
+      dpRegistry.defineSchema('MyAddress', {
+        'type': 'object',
+        'properties': {
+          'street': {'type': 'string'},
+          'city': {'type': 'string'},
+        },
+        'required': ['street', 'city'],
+      });
+
+      // Create a prompt with picoschema output referencing the named schema.
+      // A primitive field (name: string) is needed so isPicoschema() detects
+      // this as Picoschema and triggers conversion.
+      final metadata = await dpRegistry.renderMetadata('''
+---
+output:
+  schema:
+    name: string
+    address: MyAddress
+---
+Tell me an address
+''');
+
+      // The output schema should have resolved MyAddress to its JSON Schema
+      expect(metadata.output, isNotNull);
+      expect(metadata.output!.schema, isNotNull);
+      final props =
+          metadata.output!.schema!['properties'] as Map<String, dynamic>;
+      // The primitive field should be present
+      expect(props, contains('name'));
+      // The named schema reference should be resolved
+      expect(props, containsPair('address', isA<Map>()));
+      final addressSchema = props['address'] as Map<String, dynamic>;
+      expect(addressSchema['type'], equals('object'));
+      expect(addressSchema['properties'], isNotNull);
+      final addressProps =
+          addressSchema['properties'] as Map<String, dynamic>;
+      expect(addressProps, contains('street'));
+      expect(addressProps, contains('city'));
+    });
+
+    test('schema resolver callback is used for schema lookup', () async {
+      final resolvedSchemas = <String, Map<String, dynamic>>{
+        'RemoteSchema': {
+          'type': 'object',
+          'properties': {
+            'id': {'type': 'integer'},
+            'name': {'type': 'string'},
+          },
+          'required': ['id', 'name'],
+        },
+      };
+
+      final registry = DotpromptRegistry(
+        schemaResolver: (name) async => resolvedSchemas[name],
+      );
+
+      // While schemaResolver is wired through DotpromptOptions,
+      // the current dotprompt implementation uses _schemas (defineSchema)
+      // for picoschema resolution. The resolver is available for future use.
+      // Verify the registry can be created with a schemaResolver without error.
+      expect(registry.dotprompt, isNotNull);
     });
 
     test('parses a template', () {

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -33,10 +33,7 @@ void main() {
     });
 
     test('fullName includes variant', () {
-      final config = PromptConfig(
-        name: 'test',
-        variant: 'v2',
-      );
+      final config = PromptConfig(name: 'test', variant: 'v2');
       expect(config.fullName, equals('test.v2'));
     });
 
@@ -106,26 +103,16 @@ void main() {
     });
 
     test('returns an ExecutablePrompt', () {
-      final config = PromptConfig(
-        name: 'greet',
-        prompt: 'Hello {{name}}',
-      );
+      final config = PromptConfig(name: 'greet', prompt: 'Hello {{name}}');
 
-      final ep = definePromptAction(
-        registry,
-        dpRegistry,
-        config,
-      );
+      final ep = definePromptAction(registry, dpRegistry, config);
 
       expect(ep, isA<ExecutablePrompt>());
       expect(ep.ref.name, equals('greet'));
     });
 
     test('registers a PromptAction in the registry', () async {
-      final config = PromptConfig(
-        name: 'greet',
-        prompt: 'Hello {{name}}',
-      );
+      final config = PromptConfig(name: 'greet', prompt: 'Hello {{name}}');
 
       definePromptAction(registry, dpRegistry, config);
 
@@ -141,11 +128,7 @@ void main() {
         prompt: 'Good day, {{name}}',
       );
 
-      final ep = definePromptAction(
-        registry,
-        dpRegistry,
-        config,
-      );
+      final ep = definePromptAction(registry, dpRegistry, config);
 
       expect(ep.ref.name, equals('greet.formal'));
 
@@ -262,11 +245,7 @@ void main() {
       final ep = definePromptAction(
         registry,
         dpRegistry,
-        PromptConfig(
-          name: 'test',
-          messages: history,
-          prompt: 'New question',
-        ),
+        PromptConfig(name: 'test', messages: history, prompt: 'New question'),
       );
 
       final options = await ep.render({});
@@ -355,11 +334,7 @@ void main() {
       final ep = definePromptAction(
         registry,
         dpRegistry,
-        PromptConfig(
-          name: 'test',
-          toolChoice: 'required',
-          prompt: 'Hello',
-        ),
+        PromptConfig(name: 'test', toolChoice: 'required', prompt: 'Hello'),
       );
 
       final options = await ep.render({});
@@ -371,11 +346,7 @@ void main() {
       final ep = definePromptAction(
         registry,
         dpRegistry,
-        PromptConfig(
-          name: 'test',
-          toolChoice: 'auto',
-          prompt: 'Hello',
-        ),
+        PromptConfig(name: 'test', toolChoice: 'auto', prompt: 'Hello'),
       );
 
       final options = await ep.render(
@@ -593,131 +564,113 @@ void main() {
       expect(sysText, contains('Template system helpful'));
     });
 
-    test(
-      'renders system + messages + prompt in correct order',
-      () async {
-        final ep = definePromptAction(
-          registry,
-          dpRegistry,
-          PromptConfig(
-            name: 'test',
-            system: 'system {{name}}',
-            messages: [
-              Message(
-                role: Role.user,
-                content: [TextPart(text: 'hi')],
-              ),
-              Message(
-                role: Role.model,
-                content: [TextPart(text: 'bye')],
-              ),
-            ],
-            prompt: 'user prompt {{name}}',
-          ),
-        );
+    test('renders system + messages + prompt in correct order', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          system: 'system {{name}}',
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'hi')],
+            ),
+            Message(
+              role: Role.model,
+              content: [TextPart(text: 'bye')],
+            ),
+          ],
+          prompt: 'user prompt {{name}}',
+        ),
+      );
 
-        final options = await ep.render({'name': 'foo'});
+      final options = await ep.render({'name': 'foo'});
 
-        // Order should be: system, messages history, user prompt
-        expect(options.messages.length, equals(4));
-        expect(options.messages[0].role, equals(Role.system));
-        expect(
-          options.messages[0].content[0].toJson()['text'],
-          contains('system foo'),
-        );
-        expect(options.messages[1].role, equals(Role.user));
-        expect(
-          options.messages[1].content[0].toJson()['text'],
-          equals('hi'),
-        );
-        expect(options.messages[2].role, equals(Role.model));
-        expect(
-          options.messages[2].content[0].toJson()['text'],
-          equals('bye'),
-        );
-        expect(options.messages[3].role, equals(Role.user));
-        expect(
-          options.messages[3].content[0].toJson()['text'],
-          contains('user prompt foo'),
-        );
-      },
-    );
+      // Order should be: system, messages history, user prompt
+      expect(options.messages.length, equals(4));
+      expect(options.messages[0].role, equals(Role.system));
+      expect(
+        options.messages[0].content[0].toJson()['text'],
+        contains('system foo'),
+      );
+      expect(options.messages[1].role, equals(Role.user));
+      expect(options.messages[1].content[0].toJson()['text'], equals('hi'));
+      expect(options.messages[2].role, equals(Role.model));
+      expect(options.messages[2].content[0].toJson()['text'], equals('bye'));
+      expect(options.messages[3].role, equals(Role.user));
+      expect(
+        options.messages[3].content[0].toJson()['text'],
+        contains('user prompt foo'),
+      );
+    });
 
-    test(
-      'renders multi-role messagesTemplate with {{role}} helper',
-      () async {
-        final ep = definePromptAction(
-          registry,
-          dpRegistry,
-          PromptConfig(
-            name: 'test',
-            messagesTemplate:
-                '{{role "system"}}\nsystem {{name}}\n{{role "user"}}\nuser {{name}}',
-          ),
-        );
+    test('renders multi-role messagesTemplate with {{role}} helper', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          messagesTemplate:
+              '{{role "system"}}\nsystem {{name}}\n{{role "user"}}\nuser {{name}}',
+        ),
+      );
 
-        final options = await ep.render({'name': 'foo'});
+      final options = await ep.render({'name': 'foo'});
 
-        expect(options.messages.length, equals(2));
-        expect(options.messages[0].role, equals(Role.system));
-        expect(
-          options.messages[0].content[0].toJson()['text'],
-          contains('system foo'),
-        );
-        expect(options.messages[1].role, equals(Role.user));
-        expect(
-          options.messages[1].content[0].toJson()['text'],
-          contains('user foo'),
-        );
-      },
-    );
+      expect(options.messages.length, equals(2));
+      expect(options.messages[0].role, equals(Role.system));
+      expect(
+        options.messages[0].content[0].toJson()['text'],
+        contains('system foo'),
+      );
+      expect(options.messages[1].role, equals(Role.user));
+      expect(
+        options.messages[1].content[0].toJson()['text'],
+        contains('user foo'),
+      );
+    });
 
-    test(
-      'messagesTemplate with opts.messages prepends history',
-      () async {
-        final ep = definePromptAction(
-          registry,
-          dpRegistry,
-          PromptConfig(
-            name: 'test',
-            messagesTemplate: 'hello {{name}}',
-          ),
-        );
+    test('messagesTemplate with opts.messages prepends history', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', messagesTemplate: 'hello {{name}}'),
+      );
 
-        final history = [
-          Message(
-            role: Role.user,
-            content: [TextPart(text: 'hi')],
-          ),
-          Message(
-            role: Role.model,
-            content: [TextPart(text: 'bye')],
-          ),
-        ];
+      final history = [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hi')],
+        ),
+        Message(
+          role: Role.model,
+          content: [TextPart(text: 'bye')],
+        ),
+      ];
 
-        final options = await ep.render(
-          {'name': 'World'},
-          PromptGenerateOptions(messages: history),
-        );
+      final options = await ep.render({
+        'name': 'World',
+      }, PromptGenerateOptions(messages: history));
 
-        // JS: messages: [template, history user, history model] — 3 messages
-        // History is inserted after the template content
-        expect(options.messages.length, equals(3));
-        // Verify all messages are present with correct content
-        final texts = options.messages
-            .map((m) => m.content[0].toJson()['text'] as String)
-            .toList();
-        expect(texts.any((t) => t.contains('hello World')), isTrue);
-        expect(texts.any((t) => t.contains('hi')), isTrue);
-        expect(texts.any((t) => t.contains('bye')), isTrue);
-        // History messages should have purpose metadata
-        final historyMsgs = options.messages
-            .where((m) =>
-                (m.toJson()['metadata'] as Map?)?['purpose'] == 'history')
-            .toList();
-        expect(historyMsgs.length, equals(2));
-      },
-    );
+      // JS: messages: [template, history user, history model] — 3 messages
+      // History is inserted after the template content
+      expect(options.messages.length, equals(3));
+      // Verify all messages are present with correct content
+      final texts = options.messages
+          .map((m) => m.content[0].toJson()['text'] as String)
+          .toList();
+      expect(texts.any((t) => t.contains('hello World')), isTrue);
+      expect(texts.any((t) => t.contains('hi')), isTrue);
+      expect(texts.any((t) => t.contains('bye')), isTrue);
+      // History messages should have purpose metadata
+      final historyMsgs = options.messages
+          .where(
+            (m) => (m.toJson()['metadata'] as Map?)?['purpose'] == 'history',
+          )
+          .toList();
+      expect(historyMsgs.length, equals(2));
+    });
 
     test(
       'messagesTemplate with {{history}} controls history placement',
@@ -742,10 +695,9 @@ void main() {
           ),
         ];
 
-        final options = await ep.render(
-          {'name': 'World'},
-          PromptGenerateOptions(messages: history),
-        );
+        final options = await ep.render({
+          'name': 'World',
+        }, PromptGenerateOptions(messages: history));
 
         // JS: messages: [template user, history user (purpose:history),
         //                history model (purpose:history)]
@@ -758,18 +710,13 @@ void main() {
         );
         // History messages should have purpose metadata
         final historyMsgs = options.messages
-            .where((m) =>
-                (m.toJson()['metadata'] as Map?)?['purpose'] == 'history')
+            .where(
+              (m) => (m.toJson()['metadata'] as Map?)?['purpose'] == 'history',
+            )
             .toList();
         expect(historyMsgs.length, equals(2));
-        expect(
-          historyMsgs[0].content[0].toJson()['text'],
-          equals('prev Q'),
-        );
-        expect(
-          historyMsgs[1].content[0].toJson()['text'],
-          equals('prev A'),
-        );
+        expect(historyMsgs[0].content[0].toJson()['text'], equals('prev Q'));
+        expect(historyMsgs[1].content[0].toJson()['text'], equals('prev A'));
       },
     );
 
@@ -916,10 +863,7 @@ void main() {
     });
 
     test('definePrompt returns ExecutablePrompt', () {
-      final ep = genkit.definePrompt(
-        name: 'hi',
-        prompt: 'Say hi to {{name}}',
-      );
+      final ep = genkit.definePrompt(name: 'hi', prompt: 'Say hi to {{name}}');
 
       expect(ep, isA<ExecutablePrompt>());
       expect(ep.ref.name, equals('hi'));
@@ -937,10 +881,7 @@ void main() {
     });
 
     test('prompt() looks up defined prompts', () async {
-      genkit.definePrompt(
-        name: 'greeting',
-        prompt: 'Hello {{name}}',
-      );
+      genkit.definePrompt(name: 'greeting', prompt: 'Hello {{name}}');
 
       final ep = await genkit.prompt('greeting');
       expect(ep, isA<ExecutablePrompt>());
@@ -972,10 +913,7 @@ void main() {
         prompt: 'Help me with {{task}}',
       );
 
-      final options = await ep.render({
-        'kind': 'coding',
-        'task': 'Dart',
-      });
+      final options = await ep.render({'kind': 'coding', 'task': 'Dart'});
 
       expect(options.messages.length, equals(2));
       expect(options.messages[0].role, equals(Role.system));
@@ -1049,6 +987,69 @@ void main() {
     });
   });
 
+  group('Genkit promptDir integration', () {
+    late Directory tempDir;
+    late Genkit genkit;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('genkit_promptdir_test_');
+    });
+
+    tearDown(() async {
+      await genkit.shutdown();
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('loads .prompt files from promptDir on construction', () async {
+      File(
+        p.join(tempDir.path, 'hello.prompt'),
+      ).writeAsStringSync('Hello {{name}}!');
+
+      genkit = Genkit(isDevEnv: false, promptDir: tempDir.path);
+
+      final ep = await genkit.prompt('hello');
+      expect(ep, isA<ExecutablePrompt>());
+
+      final options = await ep.render({'name': 'World'});
+      expect(options.messages.length, equals(1));
+      expect(options.messages[0].role, equals(Role.user));
+      expect(
+        options.messages[0].content[0].toJson()['text'],
+        equals('Hello World!'),
+      );
+    });
+
+    test('loads prompt with frontmatter from promptDir', () async {
+      File(p.join(tempDir.path, 'greeting.prompt')).writeAsStringSync('''
+---
+model: test-model
+config:
+  temperature: 0.7
+---
+Hello {{name}}!
+''');
+
+      genkit = Genkit(isDevEnv: false, promptDir: tempDir.path);
+
+      final ep = await genkit.prompt('greeting');
+      expect(ep, isA<ExecutablePrompt>());
+
+      final options = await ep.render({'name': 'Dart'});
+      expect(options.model, equals('test-model'));
+      expect(options.config!['temperature'], equals(0.7));
+      expect(
+        options.messages[0].content[0].toJson()['text'],
+        equals('Hello Dart!'),
+      );
+    });
+
+    test('does not load prompts when promptDir is null', () async {
+      genkit = Genkit(isDevEnv: false, promptDir: null);
+
+      expect(() => genkit.prompt('anything'), throwsA(isA<GenkitException>()));
+    });
+  });
+
   group('loadPromptFolder', () {
     late Registry registry;
     late DotpromptRegistry dpRegistry;
@@ -1065,8 +1066,9 @@ void main() {
     });
 
     test('loads a simple .prompt file', () async {
-      File(p.join(tempDir.path, 'hello.prompt'))
-          .writeAsStringSync('Hello {{name}}!');
+      File(
+        p.join(tempDir.path, 'hello.prompt'),
+      ).writeAsStringSync('Hello {{name}}!');
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
@@ -1097,17 +1099,20 @@ Hello {{name}}!
     });
 
     test('loads variant prompts', () async {
-      File(p.join(tempDir.path, 'greeting.prompt'))
-          .writeAsStringSync('Hi {{name}}!');
-      File(p.join(tempDir.path, 'greeting.formal.prompt'))
-          .writeAsStringSync('Good day, {{name}}.');
+      File(
+        p.join(tempDir.path, 'greeting.prompt'),
+      ).writeAsStringSync('Hi {{name}}!');
+      File(
+        p.join(tempDir.path, 'greeting.formal.prompt'),
+      ).writeAsStringSync('Good day, {{name}}.');
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
-      final defaultAction =
-          await registry.lookupAction('prompt', 'greeting');
-      final formalAction =
-          await registry.lookupAction('prompt', 'greeting.formal');
+      final defaultAction = await registry.lookupAction('prompt', 'greeting');
+      final formalAction = await registry.lookupAction(
+        'prompt',
+        'greeting.formal',
+      );
 
       expect(defaultAction, isNotNull);
       expect(formalAction, isNotNull);
@@ -1115,11 +1120,13 @@ Hello {{name}}!
 
     test('registers underscore-prefixed files as partials', () async {
       // Create a partial
-      File(p.join(tempDir.path, '_header.prompt'))
-          .writeAsStringSync('Welcome, {{name}}!');
+      File(
+        p.join(tempDir.path, '_header.prompt'),
+      ).writeAsStringSync('Welcome, {{name}}!');
       // Create a prompt that uses the partial
-      File(p.join(tempDir.path, 'page.prompt'))
-          .writeAsStringSync('{{> header}} How can I help?');
+      File(
+        p.join(tempDir.path, 'page.prompt'),
+      ).writeAsStringSync('{{> header}} How can I help?');
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
@@ -1135,8 +1142,9 @@ Hello {{name}}!
     test('loads prompts from subdirectories', () async {
       final subDir = Directory(p.join(tempDir.path, 'sub'));
       subDir.createSync();
-      File(p.join(subDir.path, 'nested.prompt'))
-          .writeAsStringSync('Nested prompt');
+      File(
+        p.join(subDir.path, 'nested.prompt'),
+      ).writeAsStringSync('Nested prompt');
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
@@ -1154,15 +1162,11 @@ Hello {{name}}!
     });
 
     test('loads with namespace', () async {
-      File(p.join(tempDir.path, 'hello.prompt'))
-          .writeAsStringSync('Hello {{name}}!');
+      File(
+        p.join(tempDir.path, 'hello.prompt'),
+      ).writeAsStringSync('Hello {{name}}!');
 
-      loadPromptFolder(
-        registry,
-        dpRegistry,
-        dir: tempDir.path,
-        ns: 'myapp',
-      );
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path, ns: 'myapp');
 
       final action = await registry.lookupAction('prompt', 'myapp/hello');
       expect(action, isNotNull);
@@ -1181,12 +1185,15 @@ Hello {{name}}!
     });
 
     test('ignores non-prompt files', () async {
-      File(p.join(tempDir.path, 'hello.prompt'))
-          .writeAsStringSync('Hello {{name}}!');
-      File(p.join(tempDir.path, 'readme.md'))
-          .writeAsStringSync('# Not a prompt');
-      File(p.join(tempDir.path, 'config.json'))
-          .writeAsStringSync('{"key": "value"}');
+      File(
+        p.join(tempDir.path, 'hello.prompt'),
+      ).writeAsStringSync('Hello {{name}}!');
+      File(
+        p.join(tempDir.path, 'readme.md'),
+      ).writeAsStringSync('# Not a prompt');
+      File(
+        p.join(tempDir.path, 'config.json'),
+      ).writeAsStringSync('{"key": "value"}');
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
@@ -1253,4 +1260,3 @@ Hello {{name}}!
     });
   });
 }
-

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -116,7 +116,7 @@ void main() {
 
       definePromptAction(registry, dpRegistry, config);
 
-      final action = await registry.lookupAction('prompt', 'greet');
+      final action = await registry.lookupAction('executable-prompt', 'greet');
       expect(action, isNotNull);
       expect(action, isA<PromptAction>());
     });
@@ -132,7 +132,10 @@ void main() {
 
       expect(ep.ref.name, equals('greet.formal'));
 
-      final action = await registry.lookupAction('prompt', 'greet.formal');
+      final action = await registry.lookupAction(
+        'executable-prompt',
+        'greet.formal',
+      );
       expect(action, isNotNull);
     });
 
@@ -147,7 +150,7 @@ void main() {
 
       definePromptAction(registry, dpRegistry, config);
 
-      final action = await registry.lookupAction('prompt', 'greet');
+      final action = await registry.lookupAction('executable-prompt', 'greet');
       expect(action, isNotNull);
       final pa = action as PromptAction;
       expect(pa.metadata['type'], equals('prompt'));
@@ -818,7 +821,7 @@ void main() {
         PromptConfig(name: 'test', prompt: 'Hello {{name}}'),
       );
 
-      final action = await registry.lookupAction('prompt', 'test');
+      final action = await registry.lookupAction('executable-prompt', 'test');
       expect(action, isNotNull);
 
       // Invoke via the action
@@ -1148,7 +1151,7 @@ Hello {{name}}!
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
-      final action = await registry.lookupAction('prompt', 'hello');
+      final action = await registry.lookupAction('executable-prompt', 'hello');
       expect(action, isNotNull);
       expect(action, isA<PromptAction>());
     });
@@ -1165,7 +1168,10 @@ Hello {{name}}!
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
-      final action = await registry.lookupAction('prompt', 'greeting');
+      final action = await registry.lookupAction(
+        'executable-prompt',
+        'greeting',
+      );
       expect(action, isNotNull);
       final pa = action as PromptAction;
       expect(
@@ -1184,9 +1190,12 @@ Hello {{name}}!
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
-      final defaultAction = await registry.lookupAction('prompt', 'greeting');
+      final defaultAction = await registry.lookupAction(
+        'executable-prompt',
+        'greeting',
+      );
       final formalAction = await registry.lookupAction(
-        'prompt',
+        'executable-prompt',
         'greeting.formal',
       );
 
@@ -1207,11 +1216,17 @@ Hello {{name}}!
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
       // The partial should not be registered as a prompt action
-      final partialAction = await registry.lookupAction('prompt', 'header');
+      final partialAction = await registry.lookupAction(
+        'executable-prompt',
+        'header',
+      );
       expect(partialAction, isNull);
 
       // But the main prompt should be registered
-      final pageAction = await registry.lookupAction('prompt', 'page');
+      final pageAction = await registry.lookupAction(
+        'executable-prompt',
+        'page',
+      );
       expect(pageAction, isNotNull);
     });
 
@@ -1224,7 +1239,10 @@ Hello {{name}}!
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
-      final action = await registry.lookupAction('prompt', 'sub/nested');
+      final action = await registry.lookupAction(
+        'executable-prompt',
+        'sub/nested',
+      );
       expect(action, isNotNull);
     });
 
@@ -1244,7 +1262,10 @@ Hello {{name}}!
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path, ns: 'myapp');
 
-      final action = await registry.lookupAction('prompt', 'myapp/hello');
+      final action = await registry.lookupAction(
+        'executable-prompt',
+        'myapp/hello',
+      );
       expect(action, isNotNull);
     });
 
@@ -1255,9 +1276,9 @@ Hello {{name}}!
 
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
-      expect(await registry.lookupAction('prompt', 'a'), isNotNull);
-      expect(await registry.lookupAction('prompt', 'b'), isNotNull);
-      expect(await registry.lookupAction('prompt', 'c'), isNotNull);
+      expect(await registry.lookupAction('executable-prompt', 'a'), isNotNull);
+      expect(await registry.lookupAction('executable-prompt', 'b'), isNotNull);
+      expect(await registry.lookupAction('executable-prompt', 'c'), isNotNull);
     });
 
     test('ignores non-prompt files', () async {
@@ -1274,10 +1295,13 @@ Hello {{name}}!
       loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
 
       // Only the .prompt file should be loaded
-      final action = await registry.lookupAction('prompt', 'hello');
+      final action = await registry.lookupAction('executable-prompt', 'hello');
       expect(action, isNotNull);
 
-      final mdAction = await registry.lookupAction('prompt', 'readme');
+      final mdAction = await registry.lookupAction(
+        'executable-prompt',
+        'readme',
+      );
       expect(mdAction, isNull);
     });
   });

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -1007,31 +1007,31 @@ void main() {
       expect(schema['properties'], contains('street'));
     });
 
-    test('defineSchema makes schema available for picoschema in prompts',
-        () async {
-      genkit.defineSchema('Person', {
-        'type': 'object',
-        'properties': {
-          'name': {'type': 'string'},
-          'age': {'type': 'integer'},
-        },
-        'required': ['name', 'age'],
-      });
+    test(
+      'defineSchema makes schema available for picoschema in prompts',
+      () async {
+        genkit.defineSchema('Person', {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+            'age': {'type': 'integer'},
+          },
+          'required': ['name', 'age'],
+        });
 
-      // Define a prompt with picoschema output that references named schema
-      final ep = genkit.definePrompt(
-        name: 'person-prompt',
-        prompt: 'Generate a person',
-        output: GenerateActionOutputConfig.fromJson({
-          'format': 'json',
-        }),
-      );
+        // Define a prompt with picoschema output that references named schema
+        final ep = genkit.definePrompt(
+          name: 'person-prompt',
+          prompt: 'Generate a person',
+          output: GenerateActionOutputConfig.fromJson({'format': 'json'}),
+        );
 
-      // Verify the prompt was created successfully
-      expect(ep, isA<ExecutablePrompt>());
-      final options = await ep.render({});
-      expect(options.messages, isNotEmpty);
-    });
+        // Verify the prompt was created successfully
+        expect(ep, isA<ExecutablePrompt>());
+        final options = await ep.render({});
+        expect(options.messages, isNotEmpty);
+      },
+    );
 
     test('defineSchema allows multiple schemas', () {
       genkit.defineSchema('Schema1', {
@@ -1303,21 +1303,22 @@ Hello {{name}}!
       // We verify it works by using it in a picoschema prompt below
     });
 
-    test('defineSchema makes schema available in picoschema resolution',
-        () async {
-      dpRegistry.defineSchema('MyAddress', {
-        'type': 'object',
-        'properties': {
-          'street': {'type': 'string'},
-          'city': {'type': 'string'},
-        },
-        'required': ['street', 'city'],
-      });
+    test(
+      'defineSchema makes schema available in picoschema resolution',
+      () async {
+        dpRegistry.defineSchema('MyAddress', {
+          'type': 'object',
+          'properties': {
+            'street': {'type': 'string'},
+            'city': {'type': 'string'},
+          },
+          'required': ['street', 'city'],
+        });
 
-      // Create a prompt with picoschema output referencing the named schema.
-      // A primitive field (name: string) is needed so isPicoschema() detects
-      // this as Picoschema and triggers conversion.
-      final metadata = await dpRegistry.renderMetadata('''
+        // Create a prompt with picoschema output referencing the named schema.
+        // A primitive field (name: string) is needed so isPicoschema() detects
+        // this as Picoschema and triggers conversion.
+        final metadata = await dpRegistry.renderMetadata('''
 ---
 output:
   schema:
@@ -1327,23 +1328,24 @@ output:
 Tell me an address
 ''');
 
-      // The output schema should have resolved MyAddress to its JSON Schema
-      expect(metadata.output, isNotNull);
-      expect(metadata.output!.schema, isNotNull);
-      final props =
-          metadata.output!.schema!['properties'] as Map<String, dynamic>;
-      // The primitive field should be present
-      expect(props, contains('name'));
-      // The named schema reference should be resolved
-      expect(props, containsPair('address', isA<Map>()));
-      final addressSchema = props['address'] as Map<String, dynamic>;
-      expect(addressSchema['type'], equals('object'));
-      expect(addressSchema['properties'], isNotNull);
-      final addressProps =
-          addressSchema['properties'] as Map<String, dynamic>;
-      expect(addressProps, contains('street'));
-      expect(addressProps, contains('city'));
-    });
+        // The output schema should have resolved MyAddress to its JSON Schema
+        expect(metadata.output, isNotNull);
+        expect(metadata.output!.schema, isNotNull);
+        final props =
+            metadata.output!.schema!['properties'] as Map<String, dynamic>;
+        // The primitive field should be present
+        expect(props, contains('name'));
+        // The named schema reference should be resolved
+        expect(props, containsPair('address', isA<Map>()));
+        final addressSchema = props['address'] as Map<String, dynamic>;
+        expect(addressSchema['type'], equals('object'));
+        expect(addressSchema['properties'], isNotNull);
+        final addressProps =
+            addressSchema['properties'] as Map<String, dynamic>;
+        expect(addressProps, contains('street'));
+        expect(addressProps, contains('city'));
+      },
+    );
 
     test('schema resolver callback is used for schema lookup', () async {
       final resolvedSchemas = <String, Map<String, dynamic>>{

--- a/packages/genkit/test/ai/prompt_types_test.dart
+++ b/packages/genkit/test/ai/prompt_types_test.dart
@@ -118,10 +118,7 @@ void main() {
         final genkitPart = dpPartToGenkitPart(dpPart);
 
         expect(genkitPart, isA<DataPart>());
-        expect(
-          (genkitPart as DataPart).data,
-          equals({'custom': 'data'}),
-        );
+        expect((genkitPart as DataPart).data, equals({'custom': 'data'}));
       });
     });
 
@@ -247,9 +244,7 @@ void main() {
       test('message roundtrip preserves data', () {
         final original = Message(
           role: Role.user,
-          content: [
-            TextPart(text: 'Hello world'),
-          ],
+          content: [TextPart(text: 'Hello world')],
         );
 
         final dpMsg = genkitMessageToDpMessage(original);

--- a/packages/genkit/test/ai/prompt_types_test.dart
+++ b/packages/genkit/test/ai/prompt_types_test.dart
@@ -1,0 +1,275 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:dotprompt/dotprompt.dart' as dp;
+import 'package:genkit/genkit.dart';
+import 'package:genkit/src/ai/prompt_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('prompt_types', () {
+    group('dpRoleToGenkitRole', () {
+      test('converts user role', () {
+        expect(dpRoleToGenkitRole(dp.Role.user), equals(Role.user));
+      });
+
+      test('converts model role', () {
+        expect(dpRoleToGenkitRole(dp.Role.model), equals(Role.model));
+      });
+
+      test('converts system role', () {
+        expect(dpRoleToGenkitRole(dp.Role.system), equals(Role.system));
+      });
+
+      test('converts tool role', () {
+        expect(dpRoleToGenkitRole(dp.Role.tool), equals(Role.tool));
+      });
+    });
+
+    group('genkitRoleToDpRole', () {
+      test('converts user role', () {
+        expect(genkitRoleToDpRole(Role.user), equals(dp.Role.user));
+      });
+
+      test('converts model role', () {
+        expect(genkitRoleToDpRole(Role.model), equals(dp.Role.model));
+      });
+
+      test('converts system role', () {
+        expect(genkitRoleToDpRole(Role.system), equals(dp.Role.system));
+      });
+
+      test('converts tool role', () {
+        expect(genkitRoleToDpRole(Role.tool), equals(dp.Role.tool));
+      });
+    });
+
+    group('dpPartToGenkitPart', () {
+      test('converts TextPart', () {
+        final dpPart = dp.TextPart(text: 'Hello world');
+        final genkitPart = dpPartToGenkitPart(dpPart);
+
+        expect(genkitPart, isA<TextPart>());
+        expect(genkitPart.toJson()['text'], equals('Hello world'));
+      });
+
+      test('converts MediaPart with url', () {
+        final dpPart = dp.MediaPart(
+          media: dp.MediaContent(
+            contentType: 'image/png',
+            url: 'https://example.com/image.png',
+          ),
+        );
+        final genkitPart = dpPartToGenkitPart(dpPart);
+
+        expect(genkitPart, isA<MediaPart>());
+        final mediaPart = genkitPart as MediaPart;
+        expect(mediaPart.media.contentType, equals('image/png'));
+        expect(mediaPart.media.url, equals('https://example.com/image.png'));
+      });
+
+      test('converts ToolRequestPart', () {
+        final dpPart = dp.ToolRequestPart(
+          toolRequest: dp.ToolRequest(
+            name: 'myTool',
+            ref: 'ref123',
+            input: {'key': 'value'},
+          ),
+        );
+        final genkitPart = dpPartToGenkitPart(dpPart);
+
+        expect(genkitPart, isA<ToolRequestPart>());
+        final trPart = genkitPart as ToolRequestPart;
+        expect(trPart.toolRequest.name, equals('myTool'));
+        expect(trPart.toolRequest.ref, equals('ref123'));
+        expect(trPart.toolRequest.input, equals({'key': 'value'}));
+      });
+
+      test('converts ToolResponsePart', () {
+        final dpPart = dp.ToolResponsePart(
+          toolResponse: dp.ToolResponse(
+            name: 'myTool',
+            ref: 'ref123',
+            output: {'result': 42},
+          ),
+        );
+        final genkitPart = dpPartToGenkitPart(dpPart);
+
+        expect(genkitPart, isA<ToolResponsePart>());
+        final trPart = genkitPart as ToolResponsePart;
+        expect(trPart.toolResponse.name, equals('myTool'));
+        expect(trPart.toolResponse.ref, equals('ref123'));
+        expect(trPart.toolResponse.output, equals({'result': 42}));
+      });
+
+      test('converts DataPart', () {
+        final dpPart = dp.DataPart(data: {'custom': 'data'});
+        final genkitPart = dpPartToGenkitPart(dpPart);
+
+        expect(genkitPart, isA<DataPart>());
+        expect(
+          (genkitPart as DataPart).data,
+          equals({'custom': 'data'}),
+        );
+      });
+    });
+
+    group('dpMessageToGenkitMessage', () {
+      test('converts a simple user message', () {
+        final dpMsg = dp.Message(
+          role: dp.Role.user,
+          content: [dp.TextPart(text: 'Hello')],
+        );
+        final genkitMsg = dpMessageToGenkitMessage(dpMsg);
+
+        expect(genkitMsg.role, equals(Role.user));
+        expect(genkitMsg.content.length, equals(1));
+        expect(genkitMsg.content[0].toJson()['text'], equals('Hello'));
+      });
+
+      test('converts a model message with multiple parts', () {
+        final dpMsg = dp.Message(
+          role: dp.Role.model,
+          content: [
+            dp.TextPart(text: 'Part 1'),
+            dp.TextPart(text: 'Part 2'),
+          ],
+        );
+        final genkitMsg = dpMessageToGenkitMessage(dpMsg);
+
+        expect(genkitMsg.role, equals(Role.model));
+        expect(genkitMsg.content.length, equals(2));
+        expect(genkitMsg.content[0].toJson()['text'], equals('Part 1'));
+        expect(genkitMsg.content[1].toJson()['text'], equals('Part 2'));
+      });
+
+      test('preserves metadata', () {
+        final dpMsg = dp.Message(
+          role: dp.Role.user,
+          content: [dp.TextPart(text: 'Hello')],
+          metadata: {'key': 'value'},
+        );
+        final genkitMsg = dpMessageToGenkitMessage(dpMsg);
+
+        expect(genkitMsg.metadata, equals({'key': 'value'}));
+      });
+    });
+
+    group('genkitMessageToDpMessage', () {
+      test('converts a simple user message', () {
+        final genkitMsg = Message(
+          role: Role.user,
+          content: [TextPart(text: 'Hello')],
+        );
+        final dpMsg = genkitMessageToDpMessage(genkitMsg);
+
+        expect(dpMsg.role, equals(dp.Role.user));
+        expect(dpMsg.content.length, equals(1));
+        expect((dpMsg.content[0] as dp.TextPart).text, equals('Hello'));
+      });
+
+      test('converts a system message', () {
+        final genkitMsg = Message(
+          role: Role.system,
+          content: [TextPart(text: 'System instruction')],
+        );
+        final dpMsg = genkitMessageToDpMessage(genkitMsg);
+
+        expect(dpMsg.role, equals(dp.Role.system));
+      });
+    });
+
+    group('genkitPartToDpPart', () {
+      test('converts TextPart', () {
+        final genkitPart = TextPart(text: 'Hello');
+        final dpPart = genkitPartToDpPart(genkitPart);
+
+        expect(dpPart, isA<dp.TextPart>());
+        expect((dpPart as dp.TextPart).text, equals('Hello'));
+      });
+
+      test('converts MediaPart', () {
+        final genkitPart = MediaPart(
+          media: Media(
+            contentType: 'image/jpeg',
+            url: 'https://example.com/img.jpg',
+          ),
+        );
+        final dpPart = genkitPartToDpPart(genkitPart);
+
+        expect(dpPart, isA<dp.MediaPart>());
+        final mp = dpPart as dp.MediaPart;
+        expect(mp.media.contentType, equals('image/jpeg'));
+        expect(mp.media.url, equals('https://example.com/img.jpg'));
+      });
+
+      test('converts ToolRequestPart', () {
+        final genkitPart = ToolRequestPart(
+          toolRequest: ToolRequest(
+            name: 'search',
+            ref: 'ref1',
+            input: {'query': 'dart'},
+          ),
+        );
+        final dpPart = genkitPartToDpPart(genkitPart);
+
+        expect(dpPart, isA<dp.ToolRequestPart>());
+        final trp = dpPart as dp.ToolRequestPart;
+        expect(trp.toolRequest.name, equals('search'));
+      });
+
+      test('converts ToolResponsePart', () {
+        final genkitPart = ToolResponsePart(
+          toolResponse: ToolResponse(
+            name: 'search',
+            ref: 'ref1',
+            output: 'results here',
+          ),
+        );
+        final dpPart = genkitPartToDpPart(genkitPart);
+
+        expect(dpPart, isA<dp.ToolResponsePart>());
+      });
+    });
+
+    group('roundtrip conversions', () {
+      test('message roundtrip preserves data', () {
+        final original = Message(
+          role: Role.user,
+          content: [
+            TextPart(text: 'Hello world'),
+          ],
+        );
+
+        final dpMsg = genkitMessageToDpMessage(original);
+        final roundtripped = dpMessageToGenkitMessage(dpMsg);
+
+        expect(roundtripped.role, equals(original.role));
+        expect(roundtripped.content.length, equals(original.content.length));
+        expect(
+          roundtripped.content[0].toJson()['text'],
+          equals(original.content[0].toJson()['text']),
+        );
+      });
+
+      test('role roundtrip for all roles', () {
+        for (final role in [Role.user, Role.model, Role.system, Role.tool]) {
+          final dpRole = genkitRoleToDpRole(role);
+          final roundtripped = dpRoleToGenkitRole(dpRole);
+          expect(roundtripped, equals(role));
+        }
+      });
+    });
+  });
+}

--- a/packages/genkit_mcp/example/example.dart
+++ b/packages/genkit_mcp/example/example.dart
@@ -45,7 +45,7 @@ Future<void> main() async {
     },
   );
 
-  serverAi.definePrompt<PromptInput>(
+  serverAi.defineCustomPrompt<PromptInput>(
     name: 'echoPrompt',
     description: 'Returns a simple prompt with one user message.',
     inputSchema: PromptInput.$schema,

--- a/packages/genkit_mcp/lib/src/client/mcp_client.dart
+++ b/packages/genkit_mcp/lib/src/client/mcp_client.dart
@@ -1023,7 +1023,7 @@ class GenkitMcpClient {
     switch (descriptor.actionType) {
       case 'tool':
         return _resolveToolAction(descriptor);
-      case 'prompt':
+      case 'executable-prompt':
         return _resolvePromptAction(descriptor);
       case 'resource':
         return _resolveResourceAction(descriptor);
@@ -1075,7 +1075,7 @@ class GenkitMcpClient {
       actions.add(
         ActionMetadata(
           name: fullName,
-          actionType: 'prompt',
+          actionType: 'executable-prompt',
           description: prompt['description']?.toString(),
           inputSchema: promptSchemaFromArgs(args),
           outputSchema: GenerateActionOptions.$schema,
@@ -1088,7 +1088,7 @@ class GenkitMcpClient {
       );
       index[fullName] = _McpClientActionDescriptor(
         actionName: promptName,
-        actionType: 'prompt',
+        actionType: 'executable-prompt',
         payload: prompt,
       );
     }

--- a/packages/genkit_mcp/lib/src/server/mcp_server.dart
+++ b/packages/genkit_mcp/lib/src/server/mcp_server.dart
@@ -73,7 +73,7 @@ class GenkitMcpServer {
       if (resolved == null) continue;
       if (resolved.actionType == 'tool') {
         _toolActions.add(resolved as Tool);
-      } else if (resolved.actionType == 'prompt') {
+      } else if (resolved.actionType == 'executable-prompt') {
         _promptActions.add(resolved as PromptAction);
       } else if (resolved.actionType == 'resource') {
         _resourceActions.add(resolved as ResourceAction);

--- a/packages/genkit_mcp/test/mcp_integration_test.dart
+++ b/packages/genkit_mcp/test/mcp_integration_test.dart
@@ -94,7 +94,7 @@ void main() {
       inputSchema: .map(.string(), .dynamicSchema()),
       fn: (input, _) async => 'yep ${input['foo']}',
     );
-    ai.definePrompt<Map<String, dynamic>>(
+    ai.defineCustomPrompt<Map<String, dynamic>>(
       name: 'testPrompt',
       description: 'test prompt',
       inputSchema: const _PromptInputSchema(),

--- a/packages/genkit_mcp/test/mcp_server_test.dart
+++ b/packages/genkit_mcp/test/mcp_server_test.dart
@@ -130,7 +130,7 @@ void main() {
       inputSchema: .map(.string(), .dynamicSchema()),
       fn: (input, _) async => 'yep ${jsonEncode(input)}',
     );
-    ai.definePrompt<Map<String, dynamic>>(
+    ai.defineCustomPrompt<Map<String, dynamic>>(
       name: 'testPrompt',
       description: 'test prompt',
       inputSchema: const _PromptInputSchema(),
@@ -251,7 +251,7 @@ void main() {
       inputSchema: .map(.string(), .dynamicSchema()),
       fn: (_, _) async => 'done',
     );
-    ai.definePrompt<Map<String, dynamic>>(
+    ai.defineCustomPrompt<Map<String, dynamic>>(
       name: 'enumPrompt',
       inputSchema: const _EnumPromptSchema(),
       fn: (_, _) async => GenerateActionOptions(messages: []),
@@ -659,7 +659,7 @@ void main() {
 
   test('MCP server includes _meta in prompt/resource listings', () async {
     final ai = Genkit();
-    ai.definePrompt<Map<String, dynamic>>(
+    ai.defineCustomPrompt<Map<String, dynamic>>(
       name: 'metaPrompt',
       description: 'meta prompt',
       inputSchema: const _PromptInputSchema(),
@@ -764,7 +764,7 @@ void main() {
         );
       },
     );
-    ai.definePrompt<Map<String, dynamic>>(
+    ai.defineCustomPrompt<Map<String, dynamic>>(
       name: 'badPrompt',
       description: 'bad prompt',
       inputSchema: const _PromptInputSchema(),

--- a/packages/genkit_mcp/test/stdio_test_server.dart
+++ b/packages/genkit_mcp/test/stdio_test_server.dart
@@ -49,7 +49,7 @@ Future<void> main() async {
     inputSchema: .map(.string(), .dynamicSchema()),
     fn: (input, _) async => 'yep ${input['foo'] as Object?}',
   );
-  ai.definePrompt<Map<String, dynamic>>(
+  ai.defineCustomPrompt<Map<String, dynamic>>(
     name: 'testPrompt',
     description: 'test prompt',
     inputSchema: const _PromptInputSchema(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ workspace:
   - testapps/middleware
   - testapps/remote_models
   - testapps/gemini
+  - testapps/prompts
   - testapps/evals
   - testapps/schemantic_sample
 

--- a/testapps/mcp_server/bin/server.dart
+++ b/testapps/mcp_server/bin/server.dart
@@ -60,7 +60,7 @@ void main() async {
 
   // --- Prompts ---
 
-  ai.definePrompt<PromptInput>(
+  ai.defineCustomPrompt<PromptInput>(
     name: 'echoPrompt',
     description: 'Returns a simple prompt with one user message.',
     inputSchema: PromptInput.$schema,

--- a/testapps/prompts/bin/main.dart
+++ b/testapps/prompts/bin/main.dart
@@ -1,0 +1,157 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:prompts_testapp/schemas.dart';
+
+/// Testapp that exercises various prompt features:
+/// - .prompt files loaded from the `prompts/` directory (with picoschema inputs)
+/// - Inline definePrompt with Handlebars templates and generated input schemas
+/// - Prompt variants (.formal variant)
+/// - Partials (_signature.prompt)
+/// - defineCustomPrompt for programmatic prompt building
+/// - Flows that use prompts
+void main() {
+  final ai = Genkit(plugins: [googleAI()], promptDir: './prompts');
+
+  // --- Inline definePrompt with generated input schema ---
+
+  final jokePrompt = ai.definePrompt<Map<String, dynamic>, JokeInput>(
+    name: 'joke',
+    model: modelRef('googleai/gemini-flash-latest'),
+    config: {'temperature': 0.9},
+    inputSchema: JokeInput.schema,
+    system: 'You are a witty comedian. Keep jokes family-friendly.',
+    prompt: 'Tell me a {{style}} joke about {{topic}}.',
+  );
+
+  // --- Inline definePrompt with partials and generated input schema ---
+
+  ai.definePrompt<Map<String, dynamic>, EmailInput>(
+    name: 'email',
+    model: modelRef('googleai/gemini-flash-latest'),
+    config: {'temperature': 0.5},
+    inputSchema: EmailInput.schema,
+    system: 'You are a professional email composer.',
+    prompt: '''Write a short email to {{recipient}} about {{subject}}.
+
+{{> signature}}''',
+  );
+
+  // --- defineCustomPrompt with generated input schema ---
+
+  ai.defineCustomPrompt<StoryInput>(
+    name: 'custom-story',
+    description: 'Programmatically builds a story prompt with character list',
+    inputSchema: StoryInput.schema,
+    fn: (input, ctx) async {
+      final genre = input.genre;
+      final charList = input.characters.map((c) => '- $c').join('\n');
+
+      return GenerateActionOptions(
+        model: 'googleai/gemini-flash-latest',
+        config: {'temperature': 0.8},
+        messages: [
+          Message(
+            role: Role.system,
+            content: [
+              TextPart(
+                text: 'You are a creative storyteller specializing in $genre.',
+              ),
+            ],
+          ),
+          Message(
+            role: Role.user,
+            content: [
+              TextPart(
+                text:
+                    'Write a short $genre story featuring these characters:\n$charList',
+              ),
+            ],
+          ),
+        ],
+      );
+    },
+  );
+
+  // --- Flows that use prompts ---
+
+  // Flow: tell a joke using the inline prompt
+  ai.defineFlow(
+    name: 'tellJoke',
+    fn: (Map<String, dynamic>? input, ctx) async {
+      final topic = input?['topic'] as String? ?? 'programming';
+      final style = input?['style'] as String? ?? 'punny';
+      final response = await jokePrompt(JokeInput(topic: topic, style: style));
+      return response.text;
+    },
+  );
+
+  // Flow: greet someone using the .prompt file
+  ai.defineFlow(
+    name: 'greetUser',
+    fn: (Map<String, dynamic>? input, ctx) async {
+      final greetingPrompt = await ai.prompt('greeting');
+      final response = await greetingPrompt({
+        'name': input?['name'] ?? 'World',
+        'style': input?['style'] ?? 'cheerful',
+      });
+      return response.text;
+    },
+  );
+
+  // Flow: formal greeting using the .prompt variant
+  ai.defineFlow(
+    name: 'formalGreeting',
+    fn: (Map<String, dynamic>? input, ctx) async {
+      final formalPrompt = await ai.prompt('greeting', variant: 'formal');
+      final response = await formalPrompt({
+        'name': input?['name'] ?? 'Dr. Smith',
+        'title': input?['title'] ?? 'Professor',
+      });
+      return response.text;
+    },
+  );
+
+  // Flow: summarize text using the .prompt file
+  ai.defineFlow(
+    name: 'summarizeText',
+    fn: (Map<String, dynamic>? input, ctx) async {
+      final summarizePrompt = await ai.prompt('summarize');
+      final response = await summarizePrompt({
+        'text': input?['text'] ?? 'No text provided.',
+        'maxSentences': input?['maxSentences'] ?? '3',
+      });
+      return response.text;
+    },
+  );
+
+  // Flow: render a prompt without calling the model
+  ai.defineFlow(
+    name: 'renderPrompt',
+    fn: (Map<String, dynamic>? input, ctx) async {
+      final greetingPrompt = await ai.prompt('greeting');
+      final rendered = await greetingPrompt.render({
+        'name': input?['name'] ?? 'World',
+        'style': input?['style'] ?? 'casual',
+      });
+      // Return the rendered messages as a serializable map
+      return {
+        'model': rendered.model,
+        'messages': rendered.messages.map((m) => m.toJson()).toList(),
+      };
+    },
+  );
+}

--- a/testapps/prompts/build.yaml
+++ b/testapps/prompts/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          create_json_schema: true

--- a/testapps/prompts/lib/schemas.dart
+++ b/testapps/prompts/lib/schemas.dart
@@ -1,0 +1,87 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:schemantic/schemantic.dart';
+
+part 'schemas.g.dart';
+
+/// Input schema for the joke prompt.
+@JsonSerializable(createJsonSchema: true)
+class JokeInput {
+  /// The joke topic (e.g. programming, cats, cooking).
+  final String topic;
+
+  /// The joke style (e.g. punny, dry, dad, knock-knock).
+  final String style;
+
+  JokeInput({required this.topic, required this.style});
+
+  factory JokeInput.fromJson(Map<String, dynamic> json) =>
+      _$JokeInputFromJson(json);
+  Map<String, dynamic> toJson() => _$JokeInputToJson(this);
+
+  static const jsonSchema = _$JokeInputJsonSchema;
+
+  static final schema = SchemanticType.from<JokeInput>(
+    jsonSchema: JokeInput.jsonSchema,
+    parse: (json) => JokeInput.fromJson(json as Map<String, dynamic>),
+  );
+}
+
+/// Input schema for the email prompt.
+@JsonSerializable(createJsonSchema: true)
+class EmailInput {
+  /// The email recipient name.
+  final String recipient;
+
+  /// The email subject.
+  final String subject;
+
+  EmailInput({required this.recipient, required this.subject});
+
+  factory EmailInput.fromJson(Map<String, dynamic> json) =>
+      _$EmailInputFromJson(json);
+  Map<String, dynamic> toJson() => _$EmailInputToJson(this);
+
+  static const jsonSchema = _$EmailInputJsonSchema;
+
+  static final schema = SchemanticType.from<EmailInput>(
+    jsonSchema: EmailInput.jsonSchema,
+    parse: (json) => EmailInput.fromJson(json as Map<String, dynamic>),
+  );
+}
+
+/// Input schema for the custom story prompt.
+@JsonSerializable(createJsonSchema: true)
+class StoryInput {
+  /// The story genre (e.g. fantasy, sci-fi, mystery).
+  final String genre;
+
+  /// List of character names to include.
+  final List<String> characters;
+
+  StoryInput({required this.genre, required this.characters});
+
+  factory StoryInput.fromJson(Map<String, dynamic> json) =>
+      _$StoryInputFromJson(json);
+  Map<String, dynamic> toJson() => _$StoryInputToJson(this);
+
+  static const jsonSchema = _$StoryInputJsonSchema;
+
+  static final schema = SchemanticType.from<StoryInput>(
+    jsonSchema: StoryInput.jsonSchema,
+    parse: (json) => StoryInput.fromJson(json as Map<String, dynamic>),
+  );
+}

--- a/testapps/prompts/lib/schemas.g.dart
+++ b/testapps/prompts/lib/schemas.g.dart
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'schemas.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+JokeInput _$JokeInputFromJson(Map<String, dynamic> json) =>
+    JokeInput(topic: json['topic'] as String, style: json['style'] as String);
+
+Map<String, dynamic> _$JokeInputToJson(JokeInput instance) => <String, dynamic>{
+  'topic': instance.topic,
+  'style': instance.style,
+};
+
+const _$JokeInputJsonSchema = {
+  r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+  'type': 'object',
+  'properties': {
+    'topic': {
+      'type': 'string',
+      'description': 'The joke topic (e.g. programming, cats, cooking).',
+    },
+    'style': {
+      'type': 'string',
+      'description': 'The joke style (e.g. punny, dry, dad, knock-knock).',
+    },
+  },
+  'required': ['topic', 'style'],
+};
+
+EmailInput _$EmailInputFromJson(Map<String, dynamic> json) => EmailInput(
+  recipient: json['recipient'] as String,
+  subject: json['subject'] as String,
+);
+
+Map<String, dynamic> _$EmailInputToJson(EmailInput instance) =>
+    <String, dynamic>{
+      'recipient': instance.recipient,
+      'subject': instance.subject,
+    };
+
+const _$EmailInputJsonSchema = {
+  r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+  'type': 'object',
+  'properties': {
+    'recipient': {'type': 'string', 'description': 'The email recipient name.'},
+    'subject': {'type': 'string', 'description': 'The email subject.'},
+  },
+  'required': ['recipient', 'subject'],
+};
+
+StoryInput _$StoryInputFromJson(Map<String, dynamic> json) => StoryInput(
+  genre: json['genre'] as String,
+  characters: (json['characters'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+);
+
+Map<String, dynamic> _$StoryInputToJson(StoryInput instance) =>
+    <String, dynamic>{
+      'genre': instance.genre,
+      'characters': instance.characters,
+    };
+
+const _$StoryInputJsonSchema = {
+  r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+  'type': 'object',
+  'properties': {
+    'genre': {
+      'type': 'string',
+      'description': 'The story genre (e.g. fantasy, sci-fi, mystery).',
+    },
+    'characters': {
+      'type': 'array',
+      'items': {'type': 'string'},
+      'description': 'List of character names to include.',
+    },
+  },
+  'required': ['genre', 'characters'],
+};

--- a/testapps/prompts/prompts/_signature.prompt
+++ b/testapps/prompts/prompts/_signature.prompt
@@ -1,0 +1,2 @@
+Best regards,
+The Genkit Team 🚀

--- a/testapps/prompts/prompts/greeting.formal.prompt
+++ b/testapps/prompts/prompts/greeting.formal.prompt
@@ -1,0 +1,13 @@
+---
+model: googleai/gemini-flash-latest
+config:
+  temperature: 0.3
+input:
+  schema:
+    name: string, the person to greet
+    title: string, the person's title (e.g. Professor, Doctor, Director)
+---
+{{role "system"}}
+You are a formal and professional assistant. Always use proper titles and honorifics.
+{{role "user"}}
+Compose a formal greeting for {{name}} who holds the title of {{title}}.

--- a/testapps/prompts/prompts/greeting.prompt
+++ b/testapps/prompts/prompts/greeting.prompt
@@ -1,0 +1,13 @@
+---
+model: googleai/gemini-flash-latest
+config:
+  temperature: 0.7
+input:
+  schema:
+    name: string, the person to greet
+    style: string, the greeting style (e.g. cheerful, casual, pirate)
+---
+{{role "system"}}
+You are a friendly greeter. Greet the user warmly.
+{{role "user"}}
+Say hello to {{name}} in a {{style}} way.

--- a/testapps/prompts/prompts/summarize.prompt
+++ b/testapps/prompts/prompts/summarize.prompt
@@ -1,0 +1,15 @@
+---
+model: googleai/gemini-flash-latest
+config:
+  temperature: 0.2
+input:
+  schema:
+    text: string, the text to summarize
+    maxSentences: string, maximum number of sentences in the summary
+---
+{{role "system"}}
+You are a concise summarizer. Produce clear, brief summaries.
+{{role "user"}}
+Summarize the following text in {{maxSentences}} sentences or fewer:
+
+{{text}}

--- a/testapps/prompts/pubspec.yaml
+++ b/testapps/prompts/pubspec.yaml
@@ -1,0 +1,17 @@
+name: prompts_testapp
+publish_to: none
+description: Genkit Dart prompts testapp - exercises definePrompt, .prompt files, and flows
+resolution: workspace
+
+environment:
+  sdk: ^3.10.0
+
+dependencies:
+  genkit: ^0.13.0
+  genkit_google_genai: ^0.2.5
+  json_annotation: ^4.11.0
+  schemantic: ^0.1.2
+
+dev_dependencies:
+  build_runner: ^2.4.9
+  json_serializable: ^6.13.0


### PR DESCRIPTION
Adds dotprompt integration with executable prompts and `.prompt` file loading from disk.

### What's new

- **`ExecutablePrompt`** — A callable prompt that renders Handlebars templates, calls models via `generate`, and supports streaming. Created via `Genkit.definePrompt()`.
- **`.prompt` file loading** — Genkit automatically loads `.prompt` files from a configurable `promptDir` (default: `./prompts`) at construction. Supports frontmatter (model, config, tools, output), variants (`name.variant.prompt`), partials (`_partial.prompt`), subdirectories, and namespaces.
- **`DotpromptRegistry`** — Manages the dotprompt engine lifecycle, including partials, helpers, and named schemas.
- **Template helpers** — `Genkit.defineHelper()` registers custom Handlebars helpers. `Genkit.definePartial()` registers reusable template fragments.
- **Named schemas** — `Genkit.defineSchema()` registers JSON Schemas that can be referenced by name in Picoschema definitions within prompt templates.
- **Type conversions** — Bidirectional conversion between dotprompt and Genkit message/part/role types.
- **Platform support** — Conditional imports for IO (full filesystem loading), web (silent no-op), and stub (silent no-op).

### Breaking changes

- **`Genkit.definePrompt`** — The signature has changed. It now creates an `ExecutablePrompt` with template-based parameters (`prompt`, `system`, `model`, etc.) instead of requiring a `PromptFn`. The previous behavior (programmatic prompt building with a custom function) is available via **`Genkit.defineCustomPrompt`**.

### Migration

```dart
// Before
ai.definePrompt<MyInput>(
  name: 'myPrompt',
  fn: (input, ctx) async { ... },
);

// After
ai.defineCustomPrompt<MyInput>(
  name: 'myPrompt',
  fn: (input, ctx) async { ... },
);