### PR TITLE
feat(reflection/v1): add listValues

### DIFF
--- a/packages/genkit/lib/src/core/reflection/reflection_v1.dart
+++ b/packages/genkit/lib/src/core/reflection/reflection_v1.dart
@@ -19,6 +19,8 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import '../../ai/generate_middleware.dart';
+import '../../ai/model.dart';
 import '../../exception.dart';
 import '../../schema.dart';
 import '../../utils.dart';
@@ -125,6 +127,9 @@ class ReflectionServerV1 {
         } else if (request.method == 'POST' &&
             request.uri.path == '/api/runAction') {
           await _handleRunAction(request);
+        } else if (request.method == 'GET' &&
+            request.uri.path == '/api/values') {
+          await _handleListValues(request);
         } else {
           request.response
             ..statusCode = HttpStatus.notFound
@@ -162,6 +167,52 @@ class ReflectionServerV1 {
     request.response
       ..headers.contentType = ContentType.json
       ..write(jsonEncode(convertedActions))
+      ..close();
+  }
+
+  Future<void> _handleListValues(HttpRequest request) async {
+    final type = request.uri.queryParameters['type'];
+
+    if (type == null) {
+      request.response
+        ..statusCode = HttpStatus.badRequest
+        ..write('Missing type parameter for listValues')
+        ..close();
+      return;
+    }
+
+    if (type != 'middleware' && type != 'defaultModel') {
+      request.response
+        ..statusCode = HttpStatus.badRequest
+        ..write('Unsupported type parameter for listValues: $type')
+        ..close();
+      return;
+    }
+
+    final values = registry.listValues<dynamic>(type);
+    final sanitizedValues = <String, dynamic>{};
+
+    for (final MapEntry(:key, :value) in values.entries) {
+      if (type == 'middleware' && value is GenerateMiddlewareDef) {
+        sanitizedValues[key] = {
+          'name': value.name,
+          if (value.configJsonSchema != null)
+            'configSchema': value.configJsonSchema,
+        };
+      } else if (type == 'defaultModel' && value is ModelRef) {
+        sanitizedValues[key] = {
+          'name': value.name,
+          if (value.config != null)
+            'config': value.config is Map
+                ? value.config
+                : (value.config as dynamic)?.toJson(),
+        };
+      }
+    }
+
+    request.response
+      ..headers.contentType = ContentType.json
+      ..write(jsonEncode(sanitizedValues))
       ..close();
   }
 

--- a/packages/genkit/lib/src/core/reflection/reflection_v2.dart
+++ b/packages/genkit/lib/src/core/reflection/reflection_v2.dart
@@ -247,7 +247,7 @@ class ReflectionServerV2 {
     final values = registry.listValues<dynamic>(type);
     final sanitizedValues = <String, dynamic>{};
 
-    values.forEach((key, value) {
+    for (final MapEntry(:key, :value) in values.entries) {
       if (type == 'middleware' && value is GenerateMiddlewareDef) {
         sanitizedValues[key] = {
           'name': value.name,
@@ -260,7 +260,7 @@ class ReflectionServerV2 {
           if (value.config != null) 'config': value.config,
         };
       }
-    });
+    }
 
     final response = ReflectionListValuesResponse(values: sanitizedValues);
     _sendResponse(id, response.toJson());

--- a/packages/genkit/test/core/reflection_v1_test.dart
+++ b/packages/genkit/test/core/reflection_v1_test.dart
@@ -17,6 +17,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:genkit/src/ai/generate_middleware.dart';
+import 'package:genkit/src/ai/model.dart';
 import 'package:genkit/src/core/action.dart';
 import 'package:genkit/src/core/reflection/reflection_v1.dart';
 import 'package:genkit/src/core/registry.dart';
@@ -101,6 +103,57 @@ void main() {
       expect(body, contains('/test/testAction'));
       final action = body['/test/testAction'];
       expect(action['name'], 'testAction');
+    });
+
+    test('GET /api/values for middleware', () async {
+      final def = defineMiddleware<dynamic>(
+        name: 'retry',
+        create: ([config]) => throw UnimplementedError(),
+      );
+      registry.registerValue('middleware', def.name, def);
+
+      final response = await http.get(
+        Uri.parse('$url/api/values?type=middleware'),
+      );
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(response.body);
+      expect(body['/middleware/retry'], isNotNull);
+      expect(body['/middleware/retry']['name'], equals('retry'));
+    });
+
+    test('GET /api/values for defaultModel', () async {
+      final model = modelRef('test-model', config: {'temperature': 2});
+      registry.registerValue('defaultModel', 'defaultModel', model);
+
+      final response = await http.get(
+        Uri.parse('$url/api/values?type=defaultModel'),
+      );
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(response.body);
+      expect(body['/defaultModel/defaultModel'], isNotNull);
+      expect(body['/defaultModel/defaultModel']['name'], equals('test-model'));
+      expect(
+        body['/defaultModel/defaultModel']['config']['temperature'],
+        equals(2),
+      );
+    });
+
+    test('GET /api/values with unsupported type', () async {
+      final response = await http.get(
+        Uri.parse('$url/api/values?type=unsupported'),
+      );
+
+      expect(response.statusCode, 400);
+      expect(response.body, contains('Unsupported type parameter'));
+    });
+
+    test('GET /api/values with missing type', () async {
+      final response = await http.get(Uri.parse('$url/api/values'));
+
+      expect(response.statusCode, 400);
+      expect(response.body, contains('Missing type parameter'));
     });
 
     test('POST /api/runAction (non-streaming)', () async {


### PR DESCRIPTION
Allows `middleware` and `defaultModel` to be used by the Dev UI. We already have it for reflection v2, but v1 was missed.