### PR TITLE
fix(ai): preserve middleware in generation

### DIFF
--- a/packages/genkit/lib/src/ai/formatters/formatters.dart
+++ b/packages/genkit/lib/src/ai/formatters/formatters.dart
@@ -124,6 +124,7 @@ GenerateActionOptions applyFormat(
     returnToolRequests: request.returnToolRequests,
     maxTurns: request.maxTurns,
     stepName: request.stepName,
+    use: request.use,
   );
 }
 

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -51,7 +51,6 @@ GenerateAction defineGenerateAction(Registry registry) {
           status: StatusCodes.INVALID_ARGUMENT,
         );
       }
-      // TODO: resolve middleware from `options.use`.
       final response = await runGenerateAction(
         registry,
         options,
@@ -102,7 +101,14 @@ abstract class GenerateConfig {}
             status: StatusCodes.NOT_FOUND,
           );
         }
-        resolvedMiddleware.add(def.create(mw.middlewareRef!.config));
+
+        final config = mw.middlewareRef!.config;
+        final parsedConfig =
+            (config is Map<String, dynamic> && def.configSchema != null)
+            ? def.configSchema!.parse(config)
+            : config;
+
+        resolvedMiddleware.add(def.create(parsedConfig));
       } else {
         throw GenkitException(
           'Invalid middleware type: ${mw.runtimeType}. Expected GenerateMiddleware or GenerateMiddlewareRef.',
@@ -405,6 +411,7 @@ Future<GenerateResponseHelper> _runGenerateLoop(
     returnToolRequests: options.returnToolRequests,
     maxTurns: options.maxTurns,
     stepName: options.stepName,
+    use: options.use,
   );
 
   // Recursively call composedGenerate for the next turn
@@ -463,7 +470,19 @@ Future<GenerateResponseHelper> _runGenerateAction(
     'config': resolvedConfigMap,
   });
 
-  final resolved = _resolveMiddleware(registry, middleware);
+  final resolved = _resolveMiddleware(
+    registry,
+    middleware ??
+        options.use
+            ?.whereType<MiddlewareRef>()
+            .map(
+              (m) => (
+                middlewareRef: middlewareRef(name: m.name, config: m.config),
+                middlewareInstance: null,
+              ),
+            )
+            .toList(),
+  );
   final generateRegistry = resolved.registry;
   final resolvedMiddleware = resolved.middleware;
 
@@ -535,6 +554,7 @@ Future<GenerateResponseHelper> _runGenerateAction(
         returnToolRequests: opts.returnToolRequests,
         maxTurns: opts.maxTurns,
         output: opts.output,
+        use: opts.use,
         resume: GenerateResumeOptions(
           respond: respond,
           restart: [],
@@ -662,6 +682,19 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
       maxTurns: maxTurns,
       output: output,
       resume: resolvedResume,
+      use: middleware
+          ?.map((m) {
+            final ref = m.middlewareRef;
+            if (ref != null) {
+              return MiddlewareRef(
+                name: ref.name,
+                config: _configToMap(ref.config),
+              );
+            }
+            return null;
+          })
+          .whereType<MiddlewareRef>()
+          .toList(),
     ),
     (
       streamingRequested: onChunk != null,
@@ -947,7 +980,12 @@ _executeTools(
 
 Map<String, dynamic>? _configToMap(dynamic config) {
   if (config == null) return null;
-  return config is Map
-      ? config as Map<String, dynamic>
-      : (config as dynamic)?.toJson() as Map<String, dynamic>?;
+  if (config is Map) return config.cast<String, dynamic>();
+  if (config is String || config is num || config is bool) return null;
+
+  try {
+    return (config as dynamic).toJson() as Map<String, dynamic>?;
+  } catch (_) {
+    return null;
+  }
 }

--- a/packages/genkit/test/ai/formats_test.dart
+++ b/packages/genkit/test/ai/formats_test.dart
@@ -377,6 +377,23 @@ void main() {
       expect(instructionParts!.first.text, 'Manual instructions');
     });
 
+    test('applyFormat should preserve middleware', () {
+      final request = GenerateActionOptions(
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'hi')],
+          ),
+        ],
+        use: [MiddlewareRef(name: 'res1')],
+      );
+
+      final result = applyFormat(request, null);
+
+      expect(result.use, isNotEmpty);
+      expect(result.use!.first.name, 'res1');
+    });
+
     test('parses partial json chunks', () async {
       genkit.defineModel(
         name: 'streamingJsonModel',

--- a/packages/genkit/test/ai/middleware_test.dart
+++ b/packages/genkit/test/ai/middleware_test.dart
@@ -562,7 +562,268 @@ void main() {
         expect(checkTurn, 2);
       },
     );
+
+    group('options preservation', () {
+      setUp(() {
+        genkit = Genkit(isDevEnv: false);
+      });
+
+      test('multi-turn generation should preserve middleware', () async {
+        genkit.defineModel(
+          name: 'multiTurnModel',
+          fn: (req, ctx) async {
+            return ModelResponse(
+              finishReason: req.messages.length < 3
+                  ? FinishReason.other
+                  : FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: req.messages.length < 3
+                    ? [
+                        ToolRequestPart(
+                          toolRequest: ToolRequest(
+                            name: 'myTool',
+                            input: {'foo': 'bar'},
+                            ref: '123',
+                          ),
+                        ),
+                      ]
+                    : [TextPart(text: 'done')],
+              ),
+            );
+          },
+        );
+
+        genkit.defineTool(
+          name: 'myTool',
+          description: 'a tool',
+          fn: (input, ctx) async => 'tool output',
+        );
+
+        final capturedOptions = <GenerateActionOptions>[];
+        final middleware = defineMiddleware(
+          name: 'captureOptions',
+          create: ([config]) => _CaptureMiddleware(capturedOptions),
+        );
+        genkit.registry.registerValue(
+          'middleware',
+          middleware.name,
+          middleware,
+        );
+
+        await genkit.generate(
+          model: modelRef('multiTurnModel'),
+          prompt: 'hi',
+          use: [middlewareRef(name: 'captureOptions')],
+          toolNames: ['myTool'],
+        );
+
+        expect(capturedOptions.length, greaterThan(1));
+        for (var i = 0; i < capturedOptions.length; i++) {
+          expect(
+            capturedOptions[i].use,
+            isNotEmpty,
+            reason: 'Turn $i missing middleware',
+          );
+          expect(capturedOptions[i].use!.first.name, 'captureOptions');
+        }
+      });
+
+      test('resume flow should preserve middleware', () async {
+        final capturedOptions = <GenerateActionOptions>[];
+        final middleware = defineMiddleware(
+          name: 'captureOptionsResume',
+          create: ([config]) => _CaptureMiddleware(capturedOptions),
+        );
+        genkit.registry.registerValue(
+          'middleware',
+          middleware.name,
+          middleware,
+        );
+
+        genkit.defineModel(
+          name: 'resumeModel',
+          fn: (req, ctx) async {
+            if (req.messages.any(
+              (m) => m.content.any((p) => p.isToolResponse),
+            )) {
+              return ModelResponse(
+                finishReason: FinishReason.stop,
+                message: Message(
+                  role: Role.model,
+                  content: [TextPart(text: 'resumed')],
+                ),
+              );
+            }
+
+            return ModelResponse(
+              finishReason: FinishReason.other,
+              message: Message(
+                role: Role.model,
+                content: [
+                  ToolRequestPart(
+                    toolRequest: ToolRequest(
+                      name: 'interruptTool',
+                      input: {'foo': 'bar'},
+                      ref: '123',
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+
+        genkit.defineTool(
+          name: 'interruptTool',
+          description: 'interrupts',
+          fn: (input, ctx) async {
+            throw ToolInterruptException('interrupt');
+          },
+        );
+
+        final response1 = await genkit.generate(
+          model: modelRef('resumeModel'),
+          prompt: 'hi',
+          use: [middlewareRef(name: 'captureOptionsResume')],
+          toolNames: ['interruptTool'],
+        );
+
+        expect(response1.interrupts, isNotEmpty);
+
+        capturedOptions.clear();
+
+        await genkit.generate(
+          model: modelRef('resumeModel'),
+          prompt: 'hi',
+          interruptRespond: [
+            InterruptResponse(response1.interrupts.first, 'resumed output'),
+          ],
+          use: [middlewareRef(name: 'captureOptionsResume')],
+          toolNames: ['interruptTool'],
+        );
+
+        expect(
+          capturedOptions.any((o) => o.resume?.respond?.isNotEmpty ?? false),
+          isTrue,
+        );
+        final resumedOption = capturedOptions.firstWhere(
+          (o) => o.resume?.respond?.isNotEmpty ?? false,
+        );
+
+        expect(
+          resumedOption.use,
+          isNotEmpty,
+          reason: 'Middleware lost on resume',
+        );
+        expect(resumedOption.use!.first.name, 'captureOptionsResume');
+      });
+
+      test('generate should preserve middleware (use) in options', () async {
+        final capturedOptions = <GenerateActionOptions>[];
+        final middleware = defineMiddleware(
+          name: 'captureOptionsMiddleware',
+          create: ([config]) => _CaptureMiddleware(capturedOptions),
+        );
+        genkit.registry.registerValue(
+          'middleware',
+          middleware.name,
+          middleware,
+        );
+
+        genkit.defineModel(
+          name: 'simpleModel',
+          fn: (req, ctx) async => ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [TextPart(text: 'ok')],
+            ),
+          ),
+        );
+
+        await genkit.generate(
+          model: modelRef('simpleModel'),
+          prompt: 'hi',
+          use: [middlewareRef(name: 'captureOptionsMiddleware')],
+        );
+
+        expect(capturedOptions.last.use, isNotEmpty);
+        expect(
+          capturedOptions.last.use!.first.name,
+          'captureOptionsMiddleware',
+        );
+      });
+
+      test(
+        'generate action should resolve middleware from options.use',
+        () async {
+          final capturedOptions = <GenerateActionOptions>[];
+          final middleware = defineMiddleware(
+            name: 'captureOptionsAction',
+            create: ([config]) => _CaptureMiddleware(capturedOptions),
+          );
+          genkit.registry.registerValue(
+            'middleware',
+            middleware.name,
+            middleware,
+          );
+
+          genkit.defineModel(
+            name: 'simpleModelAction',
+            fn: (req, ctx) async => ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'ok')],
+              ),
+            ),
+          );
+
+          final generateAction = (await genkit.registry.lookupAction(
+            'util',
+            'generate',
+          ))!;
+
+          await generateAction(
+            GenerateActionOptions(
+              model: 'simpleModelAction',
+              messages: [
+                Message(
+                  role: Role.user,
+                  content: [TextPart(text: 'hi')],
+                ),
+              ],
+              use: [MiddlewareRef(name: 'captureOptionsAction')],
+            ),
+          );
+
+          expect(capturedOptions, isNotEmpty);
+          expect(capturedOptions.first.use, isNotEmpty);
+          expect(capturedOptions.first.use!.first.name, 'captureOptionsAction');
+        },
+      );
+    });
   });
+}
+
+class _CaptureMiddleware extends GenerateMiddleware {
+  final List<GenerateActionOptions> capturedOptions;
+  _CaptureMiddleware(this.capturedOptions);
+
+  @override
+  Future<GenerateResponseHelper> generate(
+    GenerateTurnState envelope,
+    ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    Future<GenerateResponseHelper> Function(
+      GenerateTurnState envelope,
+      ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    )
+    next,
+  ) async {
+    capturedOptions.add(envelope.request);
+    return next(envelope, ctx);
+  }
 }
 
 class FunctionMiddleware extends GenerateMiddleware {


### PR DESCRIPTION
Middleware is current missing in generate options on traces, which led to a few different fixes in this PR: 

*   **`applyFormat`**: Fixed to ensure that when a request is formatted (e.g., adding instructions), the `use` property (middleware references) is copied over to the new options object.
 *   **Multi-turn Tool Loop**: Fixed the recursive generation calls during tool execution to ensure the `use` property is preserved in the options passed to subsequent model turns.
 *   **Resume/Interrupt Flow**: Fixed the logic that restarts tools after an interrupt to preserve the original middleware references when the flow resumes.
 *   **Action Resolution**: Corrected the top-level `generate` action to properly resolve and initialize middleware when they are provided as references within the `GenerateActionOptions` object.