### PR TITLE
fix(genkit_chrome): handle `params` not being defined

### DIFF
--- a/packages/genkit_chrome/lib/src/chrome_interop.dart
+++ b/packages/genkit_chrome/lib/src/chrome_interop.dart
@@ -33,7 +33,15 @@ extension type LanguageModelFactory._(JSObject _) implements JSObject {
   ///
   /// Deprecated: only available in extension contexts or with the Prompt API
   /// Sampling Parameters origin trial enabled; resolves to null otherwise.
-  external JSPromise<LanguageModelParams?> params();
+  JSPromise<LanguageModelParams?>? params() {
+    if (has('params')) {
+      return _params();
+    }
+    return null;
+  }
+
+  @JS('params')
+  external JSPromise<LanguageModelParams?>? _params();
 }
 
 @JS()

--- a/packages/genkit_chrome/lib/src/chrome_model.dart
+++ b/packages/genkit_chrome/lib/src/chrome_model.dart
@@ -34,9 +34,10 @@ class ChromeModel extends Model<LanguageModelOptions> {
          fn: (req, ctx) => _processRequest(req, ctx, options),
        );
 
-  /// Returns model params. Only available in Chrome extension contexts or with
-  /// the Prompt API Sampling Parameters origin trial enabled;
-  /// returns null on the open web.
+  /// Returns model params.
+  ///
+  /// Only available in Chrome extension contexts or with the Prompt API
+  /// Sampling Parameters origin trial enabled; returns `null` on the open web.
   static Future<LanguageModelParams?> getParams() async {
     return await _languageModel.params()?.toDart;
   }

--- a/packages/genkit_chrome/lib/src/chrome_model.dart
+++ b/packages/genkit_chrome/lib/src/chrome_model.dart
@@ -37,8 +37,8 @@ class ChromeModel extends Model<LanguageModelOptions> {
   /// Returns model params. Only available in Chrome extension contexts or with
   /// the Prompt API Sampling Parameters origin trial enabled;
   /// returns null on the open web.
-  static Future<LanguageModelParams?> getParams() {
-    return _languageModel.params().toDart;
+  static Future<LanguageModelParams?> getParams() async {
+    return await _languageModel.params()?.toDart;
   }
 
   static Future<ModelResponse> _processRequest(


### PR DESCRIPTION
Removes a chrome warning at runtime
