### PR TITLE
fix(schemantic): `$ref` is missing a backslash for `allOf`

### DIFF
--- a/packages/schemantic/lib/src/schema_generator.dart
+++ b/packages/schemantic/lib/src/schema_generator.dart
@@ -1171,7 +1171,7 @@ final class SchemaGenerator extends GeneratorForAnnotation<Schema> {
             final allOfList = [
               refer('\$Schema.fromMap').call([
                 literalMap({
-                  r'$ref': CodeExpression(Code("r'#/\$defs/$nestedBaseName'")),
+                  r'\$ref': CodeExpression(Code("r'#/\$defs/$nestedBaseName'")),
                 }),
               ]),
             ];


### PR DESCRIPTION
Fixed a schema-related issue. For the `allOf` property, the `$ref` is missing a backslash.

```dart
import 'package:schemantic/schemantic.dart';

part 'example.g.dart';

@Schema()
abstract class $Location {
  String? get address;
}

@Schema()
abstract class $House {
  @Field(description: 'The location of the house') // need this
  $Location get location; //< here will generate a `$ref` in the `allOf` property
}
```

```dart
// generated section:
              'allOf': [
                $Schema.fromMap({'$ref': r'#/$defs/Location'}), //< missing a backslash before the second dollar sign.
              ],
```