### PR TITLE
docs: update model references to gemini-flash-latest

### DIFF
--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -28,7 +28,7 @@ void main() async {
   final ai = Genkit(plugins: [googleAI()]);
 
   final response = await ai.generate(
-    model: googleAI.gemini('gemini-2.5-flash'),
+    model: googleAI.gemini('gemini-flash-latest'),
     prompt: 'Why is Dart a great language for AI applications?',
   );
 
@@ -53,7 +53,7 @@ Call any model with a simple, unified API:
 
 ```dart
 final response = await ai.generate(
-  model: googleAI.gemini('gemini-2.5-flash'),
+  model: googleAI.gemini('gemini-flash-latest'),
   prompt: 'Explain quantum computing in simple terms.',
 );
 print(response.text);
@@ -65,7 +65,7 @@ Stream text as it's generated for responsive user experiences:
 
 ```dart
 final stream = ai.generateStream(
-  model: googleAI.gemini('gemini-2.5-flash'),
+  model: googleAI.gemini('gemini-flash-latest'),
   prompt: 'Write a short story about a robot learning to paint.',
 );
 
@@ -113,7 +113,7 @@ final weatherTool = ai.defineTool(
 );
 
 final response = await ai.generate(
-  model: googleAI.gemini('gemini-2.5-flash'),
+  model: googleAI.gemini('gemini-flash-latest'),
   prompt: 'What\'s the weather like in San Francisco?',
   toolNames: ['getWeather'],
 );
@@ -131,7 +131,7 @@ final jokeFlow = ai.defineFlow(
   outputSchema: .string(),
   fn: (topic, _) async {
     final response = await ai.generate(
-      model: googleAI.gemini('gemini-2.5-flash'),
+      model: googleAI.gemini('gemini-flash-latest'),
       prompt: 'Tell me a joke about $topic',
     );
     return response.text;
@@ -154,7 +154,7 @@ final streamStory = ai.defineFlow(
   streamSchema: .string(),
   fn: (topic, context) async {
     final stream = ai.generateStream(
-      model: googleAI.gemini('gemini-2.5-flash'),
+      model: googleAI.gemini('gemini-flash-latest'),
       prompt: 'Write a story about $topic',
     );
 
@@ -284,7 +284,7 @@ final ai = Genkit(
 );
 
 final response = await ai.generate(
-  model: googleAI.gemini('gemini-2.5-flash'),
+  model: googleAI.gemini('gemini-flash-latest'),
   prompt: 'Reliable request',
   use: [
     retry(
@@ -605,7 +605,7 @@ void main() async {
 
   // 2. Direct generation call without a Genkit instance
   final response = await lite.generate(
-    model: gemini.model('gemini-2.5-flash'),
+    model: gemini.model('gemini-flash-latest'),
     prompt: 'Hello from Lite API!',
     // Middleware objects are used directly in the Lite API
     use: [

--- a/packages/genkit_firebase_ai/README.md
+++ b/packages/genkit_firebase_ai/README.md
@@ -14,7 +14,7 @@ void main() async {
 
   // Generate text
   final response = await ai.generate(
-    model: firebaseAI.gemini('gemini-2.5-flash'),
+    model: firebaseAI.gemini('gemini-flash-latest'),
     prompt: 'Tell me a joke about a developer.',
   );
 
@@ -53,7 +53,7 @@ ai.defineTool(
 
 // Generate with tools
 final response = await ai.generate(
-  model: firebaseAI.gemini('gemini-2.5-flash'),
+  model: firebaseAI.gemini('gemini-flash-latest'),
   prompt: 'What is the weather in Boston?',
   toolNames: ['getWeather'],
 );

--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
@@ -114,7 +114,7 @@ class FirebaseGenAiPluginHandle {
 
   /// Ref to a model in the Firebase AI plugin.
   ///
-  /// The [name] is the model name, e.g. 'gemini-2.5-flash'.
+  /// The [name] is the model name, e.g. 'gemini-flash-latest'.
   ModelRef<GeminiOptions> gemini(String name) {
     return modelRef('firebaseai/$name', customOptions: GeminiOptions.$schema);
   }
@@ -142,9 +142,9 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
   @override
   Future<List<Action>> init() async {
     return [
-      _createModel('gemini-2.5-flash'),
+      _createModel('gemini-flash-latest'),
       _createModel('gemini-2.5-pro'),
-      _createBidiModel('gemini-2.5-flash-native-audio-preview-12-2025'),
+      _createBidiModel('gemini-flash-latest-native-audio-preview-12-2025'),
     ];
   }
 

--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
@@ -144,7 +144,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
     return [
       _createModel('gemini-flash-latest'),
       _createModel('gemini-2.5-pro'),
-      _createBidiModel('gemini-flash-latest-native-audio-preview-12-2025'),
+      _createBidiModel('gemini-2.5-flash-native-audio-preview-12-2025'),
     ];
   }
 

--- a/packages/genkit_google_genai/README.md
+++ b/packages/genkit_google_genai/README.md
@@ -14,7 +14,7 @@ void main() async {
 
   // Generate text
   final response = await ai.generate(
-    model: googleAI.gemini('gemini-2.5-flash'),
+    model: googleAI.gemini('gemini-flash-latest'),
     prompt: 'Tell me a joke about a developer.',
   );
 
@@ -49,7 +49,7 @@ void main() async {
   );
 
   final response = await ai.generate(
-    model: googleAI.gemini('gemini-2.5-flash'),
+    model: googleAI.gemini('gemini-flash-latest'),
     prompt: 'What is the weather in Boston?',
     toolNames: ['getWeather'],
   );

--- a/packages/genkit_google_genai/example/example.dart
+++ b/packages/genkit_google_genai/example/example.dart
@@ -325,7 +325,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
+        model: googleAI.gemini('gemini-3.1-flash-tts-preview'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],
@@ -355,7 +355,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
+        model: googleAI.gemini('gemini-3.1-flash-tts-preview'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],

--- a/packages/genkit_google_genai/example/example.dart
+++ b/packages/genkit_google_genai/example/example.dart
@@ -30,7 +30,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (input, context) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;
@@ -48,7 +48,7 @@ void main(List<String> args) async {
       final photoBase64 = base64Encode(photoBytes);
 
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash-image'),
+        model: googleAI.gemini('gemini-flash-latest-image'),
         prompt: input,
         messages: [
           Message(
@@ -76,7 +76,7 @@ void main(List<String> args) async {
     fn: (input, context) async {
       final gemini = googleAI();
       final response = await lite.generate(
-        model: gemini.model('gemini-2.5-flash'),
+        model: gemini.model('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;
@@ -139,7 +139,7 @@ void main(List<String> args) async {
     outputSchema: RpgCharacter.$schema,
     fn: (name, ctx) async {
       final stream = ai.generateStream(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         config: GeminiOptions(temperature: 2.0),
         outputSchema: RpgCharacter.$schema,
         prompt: 'Generate an RPC character called $name',
@@ -166,7 +166,7 @@ void main(List<String> args) async {
     streamSchema: CharacterProfile.$schema,
     fn: (prompt, ctx) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         outputSchema: CharacterProfile.$schema,
         prompt: prompt,
         onChunk: ctx.streamingRequested
@@ -186,7 +186,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         messages: [
           Message(
@@ -213,7 +213,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         messages: [
           Message(
@@ -269,7 +269,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         config: GeminiOptions(
           safetySettings: [
@@ -293,7 +293,7 @@ void main(List<String> args) async {
     outputSchema: .map(.string(), .dynamicSchema()),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         config: GeminiOptions(googleSearch: GoogleSearch()),
       );
@@ -308,7 +308,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-pro'),
+        model: googleAI.gemini('gemini-pro-latest'),
         prompt: prompt,
         config: GeminiOptions(codeExecution: true),
       );
@@ -325,7 +325,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash-preview-tts'),
+        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],
@@ -355,7 +355,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash-preview-tts'),
+        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],

--- a/packages/genkit_google_genai/example/example.dart
+++ b/packages/genkit_google_genai/example/example.dart
@@ -48,7 +48,7 @@ void main(List<String> args) async {
       final photoBase64 = base64Encode(photoBytes);
 
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-flash-latest-image'),
+        model: googleAI.gemini('gemini-3.1-flash-image'),
         prompt: input,
         messages: [
           Message(

--- a/packages/genkit_google_genai/example/example.dart
+++ b/packages/genkit_google_genai/example/example.dart
@@ -19,6 +19,7 @@ import 'package:genkit/lite.dart' as lite;
 import 'package:genkit_google_genai/genkit_google_genai.dart';
 
 import 'src/model.dart';
+import 'src/wav.dart';
 
 void main(List<String> args) async {
   final ai = Genkit(plugins: [googleAI()]);
@@ -336,10 +337,13 @@ void main(List<String> args) async {
           ),
         ),
       );
-      if (response.media != null) {
-        return response.media!;
+      if (response.media == null) {
+        throw Exception('No audio generated');
       }
-      throw Exception('No audio generated');
+      // Gemini TTS returns raw PCM audio (16-bit, mono, 24kHz) which is not a
+      // playable file on its own. Wrap it in a WAV container so it can be
+      // played back. (This mirrors the `toWav` helper used in the JS samples.)
+      return pcmMediaToWav(response.media!);
     },
   );
 
@@ -379,10 +383,13 @@ void main(List<String> args) async {
           ),
         ),
       );
-      if (response.media != null) {
-        return response.media!;
+      if (response.media == null) {
+        throw Exception('No audio generated');
       }
-      throw Exception('No audio generated');
+      // Gemini TTS returns raw PCM audio (16-bit, mono, 24kHz) which is not a
+      // playable file on its own. Wrap it in a WAV container so it can be
+      // played back. (This mirrors the `toWav` helper used in the JS samples.)
+      return pcmMediaToWav(response.media!);
     },
   );
 

--- a/packages/genkit_google_genai/example/src/wav.dart
+++ b/packages/genkit_google_genai/example/src/wav.dart
@@ -1,0 +1,107 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:genkit/genkit.dart';
+
+/// Wraps the raw PCM audio returned by the Gemini TTS models in a WAV
+/// container so that it becomes a playable audio file.
+///
+/// The Gemini TTS API returns audio as raw, headerless PCM (signed 16-bit,
+/// little-endian) with an inline-data MIME type such as
+/// `audio/L16;codec=pcm;rate=24000`. Without a container header this data
+/// cannot be played by most audio players, so we prepend a standard 44-byte
+/// WAV/RIFF header. This mirrors the `toWav` helper used in the Genkit JS
+/// samples.
+Media pcmMediaToWav(Media media) {
+  final url = media.url;
+  // Extract the base64 payload from the data URL.
+  final commaIndex = url.indexOf(',');
+  final base64Data = commaIndex >= 0 ? url.substring(commaIndex + 1) : url;
+  final pcmBytes = base64Decode(base64Data);
+
+  // Derive the sample rate from the MIME type (e.g. `...;rate=24000`),
+  // defaulting to 24000 Hz which is what the Gemini TTS models use.
+  var sampleRate = 24000;
+  final contentType = media.contentType ?? '';
+  final rateMatch = RegExp(r'rate=(\d+)').firstMatch(contentType);
+  if (rateMatch != null) {
+    sampleRate = int.parse(rateMatch.group(1)!);
+  }
+
+  final wavBytes = _pcmToWav(
+    pcmBytes,
+    channels: 1,
+    sampleRate: sampleRate,
+    bitsPerSample: 16,
+  );
+
+  return Media(
+    url: 'data:audio/wav;base64,${base64Encode(wavBytes)}',
+    contentType: 'audio/wav',
+  );
+}
+
+/// Builds a WAV (RIFF) byte buffer from raw little-endian PCM samples.
+Uint8List _pcmToWav(
+  Uint8List pcmData, {
+  required int channels,
+  required int sampleRate,
+  required int bitsPerSample,
+}) {
+  final byteRate = sampleRate * channels * (bitsPerSample ~/ 8);
+  final blockAlign = channels * (bitsPerSample ~/ 8);
+  final dataSize = pcmData.length;
+  final fileSize = 36 + dataSize;
+
+  final builder = BytesBuilder();
+
+  void writeString(String value) {
+    builder.add(ascii.encode(value));
+  }
+
+  void writeUint32(int value) {
+    final b = ByteData(4)..setUint32(0, value, Endian.little);
+    builder.add(b.buffer.asUint8List());
+  }
+
+  void writeUint16(int value) {
+    final b = ByteData(2)..setUint16(0, value, Endian.little);
+    builder.add(b.buffer.asUint8List());
+  }
+
+  // RIFF header.
+  writeString('RIFF');
+  writeUint32(fileSize);
+  writeString('WAVE');
+
+  // fmt subchunk.
+  writeString('fmt ');
+  writeUint32(16); // Subchunk1Size for PCM.
+  writeUint16(1); // AudioFormat = PCM.
+  writeUint16(channels);
+  writeUint32(sampleRate);
+  writeUint32(byteRate);
+  writeUint16(blockAlign);
+  writeUint16(bitsPerSample);
+
+  // data subchunk.
+  writeString('data');
+  writeUint32(dataSize);
+  builder.add(pcmData);
+
+  return builder.toBytes();
+}

--- a/packages/genkit_google_genai/test/test_live.dart
+++ b/packages/genkit_google_genai/test/test_live.dart
@@ -45,7 +45,7 @@ void main() {
         plugin: googleAI(apiKey: apiKey),
         gemini: googleAI.gemini,
         textEmbedding: googleAI.textEmbedding,
-        modelName: 'gemini-2.5-flash',
+        modelName: 'gemini-flash-latest',
         embedderName: 'gemini-embedding-001',
       ),
   ];

--- a/packages/genkit_mcp/README.md
+++ b/packages/genkit_mcp/README.md
@@ -103,14 +103,14 @@ void main() async {
 
   // Tools can be discovered and executed dynamically using a wildcard...
   final response = await ai.generate(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     prompt: 'Summarize the contents of README.md',
     toolNames: ['my-host:tool/fs/*'],
   );
 
   // ...or by specifying the exact tool name
   final exactResponse = await ai.generate(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     prompt: 'Read README.md',
     toolNames: ['my-host:tool/fs/read_file'],
   );
@@ -159,7 +159,7 @@ void main() async {
   final tools = await client.getActiveTools(ai);
   
   final response = await ai.generate(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     prompt: 'Read the contents of README.md',
     // Pass the tools directly to generate
     tools: tools,

--- a/packages/genkit_mcp/example/example.dart
+++ b/packages/genkit_mcp/example/example.dart
@@ -211,7 +211,7 @@ Future<void> main() async {
     // and injected into generate by Genkit.
     try {
       final response = await hostAi.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: 'Say hello to Dart using the local tool.',
         toolNames: ['example-host:tool/local/*'],
       );

--- a/packages/genkit_shelf/README.md
+++ b/packages/genkit_shelf/README.md
@@ -41,7 +41,7 @@ import 'package:genkit_shelf/genkit_shelf.dart';
 void main() async {
   // Just an example, can use Anthropic, OpenAI, etc. models
   final geminiApi = googleAI();
-  final geminiFlash = geminiApi.model('gemini-2.5-flash');
+  final geminiFlash = geminiApi.model('gemini-flash-latest');
 
   await startFlowServer(
     flows: [geminiFlash],
@@ -73,7 +73,7 @@ void main() async {
   );
 
   final geminiApi = googleAI();
-  final geminiFlash = geminiApi.model('gemini-2.5-flash');
+  final geminiFlash = geminiApi.model('gemini-flash-latest');
 
   // Create a Shelf Router
   final router = Router();
@@ -109,7 +109,7 @@ final secureFlow = ai.defineFlow(
 
 // 2. Define a model you want to secure
 final geminiApi = googleAI();
-final secureModel = geminiApi.model('gemini-2.5-flash');
+final secureModel = geminiApi.model('gemini-flash-latest');
 
 final router = Router();
 
@@ -175,7 +175,7 @@ final ai = Genkit();
 
 final remoteModel = ai.defineRemoteModel(
   name: 'myRemoteModel',
-  url: 'http://localhost:8080/googleai/gemini-2.5-flash',
+  url: 'http://localhost:8080/googleai/gemini-flash-latest',
 );
 
 final response = await ai.generate(

--- a/packages/genkit_vertexai/README.md
+++ b/packages/genkit_vertexai/README.md
@@ -29,7 +29,7 @@ void main() async {
 
   // Generate text
   final response = await ai.generate(
-    model: vertexAI.gemini('gemini-2.5-flash'),
+    model: vertexAI.gemini('gemini-flash-latest'),
     prompt: 'Tell me a joke about a developer.',
   );
 

--- a/packages/genkit_vertexai/example/example.dart
+++ b/packages/genkit_vertexai/example/example.dart
@@ -34,7 +34,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (input, context) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;

--- a/packages/genkit_vertexai/test/test_live.dart
+++ b/packages/genkit_vertexai/test/test_live.dart
@@ -44,7 +44,7 @@ void main() {
         plugin: vertexAI(projectId: projectId, location: location),
         gemini: vertexAI.gemini,
         textEmbedding: vertexAI.textEmbedding,
-        modelName: 'gemini-2.5-flash',
+        modelName: 'gemini-flash-latest',
         embedderName: 'gemini-embedding-001',
       ),
   ];

--- a/packages/schemantic/README.md
+++ b/packages/schemantic/README.md
@@ -66,7 +66,7 @@ void main() {
   print(matrix.parse([[1, 2], [3, 4]])); // [[1, 2], [3, 4]]
   
   // JSON Schema generation works as expected
-  print(scores.jsonSchema().toJson());
+  print(scores.jsonSchema());
   // {type: object, additionalProperties: {type: integer}}
 }
 ```
@@ -126,10 +126,10 @@ void main() async {
   print(parsed.name); // Bob
 
   // Access JSON Schema at runtime
-  final schema = User.$schema.jsonSchema;
-  print(schema.toJson()); 
+  final schema = User.$schema;
+  print(schema.jsonSchema());
   // Output: {type: object, properties: {name: {type: string}, ...}, required: [name, isAdmin]}
-  
+
   // Validate data
   final validation = await schema.validate({'name': 'Charlie'}); // Missing 'isAdmin'
   if (validation.isNotEmpty) {
@@ -174,7 +174,7 @@ class Person {
 
 ```dart
 final personSchema = Person.schema;
-print(personSchema.jsonSchema().toJson());
+print(personSchema.jsonSchema());
 // Output: {type: object, properties: {firstName: {type: string}, ...}, required: [firstName, lastName]}
 ```
 
@@ -195,9 +195,9 @@ abstract class $Node {
 ```dart
 void main() {
   // Must use useRefs: true for recursive schemas
-  final schema = Node.$schema.jsonSchema;
-  
-  print(schema.toJson());
+  final schema = Node.$schema.jsonSchema(useRefs: true);
+
+  print(schema);
   // Generates schema with "$ref": "#/$defs/Node"
 }
 ```
@@ -259,7 +259,7 @@ abstract class $User {
 
 ### Enhanced Collections
 
-You can use `listSchema` and `mapSchema` to create collections with metadata and validation:
+You can use `SchemanticType.list` and `SchemanticType.map` to create collections with metadata and validation:
 
 ```dart
 // A list of strings with description and size constraints.
@@ -274,7 +274,7 @@ final tags = SchemanticType.list(
 // A map with integer values.
 final scores = SchemanticType.map(
   .string(),
-  .int(),
+  .integer(),
   description: 'Player scores',
   minProperties: 1,
 );

--- a/testapps/agentic_patterns/README.md
+++ b/testapps/agentic_patterns/README.md
@@ -38,7 +38,7 @@ Below is a list of the available samples and how to run them:
   ```
 
 - **Image Generator**
-  Generates a detailed image prompt from a concept and then generates an image using `gemini-2.5-flash-image` (Nano Banana).
+  Generates a detailed image prompt from a concept and then generates an image using `gemini-flash-latest-image` (Nano Banana).
   ```bash
   dart run bin/main.dart imageGenerator "Cyberpunk city"
   ```

--- a/testapps/agentic_patterns/README.md
+++ b/testapps/agentic_patterns/README.md
@@ -38,7 +38,7 @@ Below is a list of the available samples and how to run them:
   ```
 
 - **Image Generator**
-  Generates a detailed image prompt from a concept and then generates an image using `gemini-flash-latest-image` (Nano Banana).
+  Generates a detailed image prompt from a concept and then generates an image using `gemini-3.1-flash-image` (Nano Banana).
   ```bash
   dart run bin/main.dart imageGenerator "Cyberpunk city"
   ```

--- a/testapps/agentic_patterns/bin/main.dart
+++ b/testapps/agentic_patterns/bin/main.dart
@@ -29,7 +29,7 @@ import 'package:genkit_google_genai/genkit_google_genai.dart';
 void main(List<String> arguments) async {
   // Initialize Genkit and Model
   final ai = Genkit(plugins: [googleAI()]);
-  final geminiFlash = googleAI.gemini('gemini-2.5-flash');
+  final geminiFlash = googleAI.gemini('gemini-flash-latest');
 
   // Initialize Flows
   final iterativeRefinementFlow = defineIterativeRefinementFlow(

--- a/testapps/agentic_patterns/lib/sequential_processing.dart
+++ b/testapps/agentic_patterns/lib/sequential_processing.dart
@@ -70,7 +70,7 @@ Flow<ImageGeneratorInput, String, void, void> defineImageGeneratorFlow(
   Genkit ai,
   ModelRef geminiFlash,
 ) {
-  final geminiImage = modelRef('googleai/gemini-2.5-flash-image');
+  final geminiImage = modelRef('googleai/gemini-flash-latest-image');
 
   return ai.defineFlow(
     name: 'imageGeneratorFlow',

--- a/testapps/agentic_patterns/lib/sequential_processing.dart
+++ b/testapps/agentic_patterns/lib/sequential_processing.dart
@@ -70,7 +70,7 @@ Flow<ImageGeneratorInput, String, void, void> defineImageGeneratorFlow(
   Genkit ai,
   ModelRef geminiFlash,
 ) {
-  final geminiImage = modelRef('googleai/gemini-flash-latest-image');
+  final geminiImage = modelRef('googleai/gemini-3.1-flash-image');
 
   return ai.defineFlow(
     name: 'imageGeneratorFlow',

--- a/testapps/ai_features/lib/tool_interrupt_sample.dart
+++ b/testapps/ai_features/lib/tool_interrupt_sample.dart
@@ -50,7 +50,7 @@ Future<void> main(List<String> args) async {
 
   print('Generating trivia question...');
   final response = await ai.generate(
-    model: googleAI.gemini('gemini-2.5-flash'),
+    model: googleAI.gemini('gemini-flash-latest'),
     prompt: '''
       Generate a trivia question and call present_questions tool to present it to the user.
       Answers are provided numbered starting from 1. When answer is provided, be dramatic about
@@ -87,7 +87,7 @@ Future<void> main(List<String> args) async {
     // Resume flow
     print('\nResuming flow with answer...');
     final response2 = await ai.generate(
-      model: googleAI.gemini('gemini-2.5-flash'),
+      model: googleAI.gemini('gemini-flash-latest'),
       messages: response.messages,
       toolNames: ['present_questions'],
       interruptRespond: [InterruptResponse(interruptPart, userSelection)],

--- a/testapps/ai_features/lib/tool_restart_sample.dart
+++ b/testapps/ai_features/lib/tool_restart_sample.dart
@@ -51,7 +51,7 @@ Future<void> main(List<String> args) async {
 
   print('Generating fund transfer request...');
   final response = await ai.generate(
-    model: googleAI.gemini('gemini-2.5-flash'),
+    model: googleAI.gemini('gemini-flash-latest'),
     prompt: '''
       Transfer \$500 to the account '12345-6789'.
     ''',
@@ -93,7 +93,7 @@ Future<void> main(List<String> args) async {
     isApproved = true;
 
     final response2 = await ai.generate(
-      model: googleAI.gemini('gemini-2.5-flash'),
+      model: googleAI.gemini('gemini-flash-latest'),
       messages: response.messages,
       toolNames: ['transfer_funds'],
       interruptRestart: [interruptPart], // Null output = Restart

--- a/testapps/basic/bin/simple_flow.dart
+++ b/testapps/basic/bin/simple_flow.dart
@@ -38,7 +38,7 @@ void main() async {
     name: 'inner',
     fn: (String subject, context) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: 'tell me joke about $subject',
       );
       return response.text;

--- a/testapps/evals/bin/evals.dart
+++ b/testapps/evals/bin/evals.dart
@@ -25,7 +25,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (input, context) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;

--- a/testapps/firebase_ai/lib/main.dart
+++ b/testapps/firebase_ai/lib/main.dart
@@ -260,7 +260,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
       });
 
       final newSession = await _ai.generateBidi(
-        model: 'firebaseai/gemini-2.5-flash-native-audio-preview-12-2025',
+        model: 'firebaseai/gemini-flash-latest-native-audio-preview-12-2025',
         config: LiveGenerationConfig(
           responseModalities: ['AUDIO'],
           speechConfig: SpeechConfig(
@@ -653,7 +653,7 @@ class _StructuredStreamingScreenState extends State<StructuredStreamingScreen> {
       outputSchema: RpgCharacter.$schema,
       fn: (name, ctx) async {
         final stream = _ai.generateStream(
-          model: firebaseAI.gemini('gemini-2.5-flash'),
+          model: firebaseAI.gemini('gemini-flash-latest'),
           config: GeminiOptions(temperature: 1.0),
           outputSchema: RpgCharacter.$schema,
           prompt: 'Generate an RPG character called $name',

--- a/testapps/firebase_ai/lib/main.dart
+++ b/testapps/firebase_ai/lib/main.dart
@@ -260,7 +260,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
       });
 
       final newSession = await _ai.generateBidi(
-        model: 'firebaseai/gemini-flash-latest-native-audio-preview-12-2025',
+        model: 'firebaseai/gemini-2.5-flash-native-audio-preview-12-2025',
         config: LiveGenerationConfig(
           responseModalities: ['AUDIO'],
           speechConfig: SpeechConfig(

--- a/testapps/flutter_genai/bin/server.dart
+++ b/testapps/flutter_genai/bin/server.dart
@@ -52,7 +52,7 @@ void main() async {
     streamSchema: .string(),
     fn: (RecipeRequest request, context) async {
       final model = switch (request.provider) {
-        'google' => googleAI.gemini('gemini-2.5-flash'),
+        'google' => googleAI.gemini('gemini-flash-latest'),
         'openai' => openAI.model('gpt-4o'),
         _ => anthropic.model('claude-sonnet-4-5'),
       };
@@ -74,7 +74,7 @@ void main() async {
     },
   );
 
-  final geminiModel = googleAI(apiKey: googleApiKey).model('gemini-2.5-flash');
+  final geminiModel = googleAI(apiKey: googleApiKey).model('gemini-flash-latest');
   final openAiModel = openAI(apiKey: openAiApiKey).model('gpt-4o');
   final anthropicModel = anthropic(
     apiKey: anthropicApiKey,
@@ -82,7 +82,7 @@ void main() async {
 
   final router = Router();
 
-  router.post('/googleai/gemini-2.5-flash', shelfHandler(geminiModel));
+  router.post('/googleai/gemini-flash-latest', shelfHandler(geminiModel));
   router.post('/openai/gpt-4o', shelfHandler(openAiModel));
   router.post('/anthropic/claude-sonnet-4-5', shelfHandler(anthropicModel));
   router.post('/serverFlow', shelfHandler(serverFlow));

--- a/testapps/flutter_genai/bin/server.dart
+++ b/testapps/flutter_genai/bin/server.dart
@@ -74,7 +74,9 @@ void main() async {
     },
   );
 
-  final geminiModel = googleAI(apiKey: googleApiKey).model('gemini-flash-latest');
+  final geminiModel = googleAI(
+    apiKey: googleApiKey,
+  ).model('gemini-flash-latest');
   final openAiModel = openAI(apiKey: openAiApiKey).model('gpt-4o');
   final anthropicModel = anthropic(
     apiKey: anthropicApiKey,

--- a/testapps/flutter_genai/lib/main.dart
+++ b/testapps/flutter_genai/lib/main.dart
@@ -34,8 +34,8 @@ void main() {
   );
 
   ai.defineRemoteModel(
-    name: 'googleai/gemini-2.5-flash',
-    url: 'http://localhost:8080/googleai/gemini-2.5-flash',
+    name: 'googleai/gemini-flash-latest',
+    url: 'http://localhost:8080/googleai/gemini-flash-latest',
   );
   ai.defineRemoteModel(
     name: 'openai/gpt-4o',
@@ -121,7 +121,7 @@ class _ClientSideTabState extends State<ClientSideTab> {
       );
 
       final model = switch (_selectedProvider) {
-        AiProvider.google => googleAI(apiKey: apiKey).model('gemini-2.5-flash'),
+        AiProvider.google => googleAI(apiKey: apiKey).model('gemini-flash-latest'),
         AiProvider.openai => openAI(apiKey: apiKey).model('gpt-4o'),
         AiProvider.anthropic => anthropic(
           apiKey: apiKey,
@@ -253,7 +253,7 @@ class _RemoteModelTabState extends State<RemoteModelTab> {
 
     try {
       final modelName = switch (_selectedProvider) {
-        AiProvider.google => 'googleai/gemini-2.5-flash',
+        AiProvider.google => 'googleai/gemini-flash-latest',
         AiProvider.openai => 'openai/gpt-4o',
         AiProvider.anthropic => 'anthropic/claude-sonnet-4-5',
       };

--- a/testapps/flutter_genai/lib/main.dart
+++ b/testapps/flutter_genai/lib/main.dart
@@ -121,7 +121,9 @@ class _ClientSideTabState extends State<ClientSideTab> {
       );
 
       final model = switch (_selectedProvider) {
-        AiProvider.google => googleAI(apiKey: apiKey).model('gemini-flash-latest'),
+        AiProvider.google => googleAI(
+          apiKey: apiKey,
+        ).model('gemini-flash-latest'),
         AiProvider.openai => openAI(apiKey: apiKey).model('gpt-4o'),
         AiProvider.anthropic => anthropic(
           apiKey: apiKey,

--- a/testapps/gemini/bin/googleai.dart
+++ b/testapps/gemini/bin/googleai.dart
@@ -304,7 +304,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
+        model: googleAI.gemini('gemini-3.1-flash-tts-preview'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],
@@ -334,7 +334,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
+        model: googleAI.gemini('gemini-3.1-flash-tts-preview'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],

--- a/testapps/gemini/bin/googleai.dart
+++ b/testapps/gemini/bin/googleai.dart
@@ -48,7 +48,7 @@ void main(List<String> args) async {
       final photoBase64 = base64Encode(photoBytes);
 
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-flash-latest-image'),
+        model: googleAI.gemini('gemini-3.1-flash-image'),
         prompt: input,
         messages: [
           Message(

--- a/testapps/gemini/bin/googleai.dart
+++ b/testapps/gemini/bin/googleai.dart
@@ -30,7 +30,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (input, context) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;
@@ -48,7 +48,7 @@ void main(List<String> args) async {
       final photoBase64 = base64Encode(photoBytes);
 
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash-image'),
+        model: googleAI.gemini('gemini-flash-latest-image'),
         prompt: input,
         messages: [
           Message(
@@ -76,7 +76,7 @@ void main(List<String> args) async {
     fn: (input, context) async {
       final gemini = googleAI();
       final response = await lite.generate(
-        model: gemini.model('gemini-2.5-flash'),
+        model: gemini.model('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;
@@ -118,7 +118,7 @@ void main(List<String> args) async {
     outputSchema: RpgCharacter.$schema,
     fn: (name, ctx) async {
       final stream = ai.generateStream(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         config: GeminiOptions(temperature: 2.0),
         outputSchema: RpgCharacter.$schema,
         prompt: 'Generate an RPC character called $name',
@@ -145,7 +145,7 @@ void main(List<String> args) async {
     streamSchema: CharacterProfile.$schema,
     fn: (prompt, ctx) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         outputSchema: CharacterProfile.$schema,
         prompt: prompt,
         onChunk: ctx.streamingRequested
@@ -165,7 +165,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         messages: [
           Message(
@@ -192,7 +192,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         messages: [
           Message(
@@ -248,7 +248,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         config: GeminiOptions(
           safetySettings: [
@@ -272,7 +272,7 @@ void main(List<String> args) async {
     outputSchema: .map(.string(), .dynamicSchema()),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         config: GeminiOptions(googleSearch: GoogleSearch()),
       );
@@ -287,7 +287,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-pro'),
+        model: googleAI.gemini('gemini-pro-latest'),
         prompt: prompt,
         config: GeminiOptions(codeExecution: true),
       );
@@ -304,7 +304,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash-preview-tts'),
+        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],
@@ -334,7 +334,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash-preview-tts'),
+        model: googleAI.gemini('gemini-flash-latest-preview-tts'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],

--- a/testapps/gemini/bin/vertexai.dart
+++ b/testapps/gemini/bin/vertexai.dart
@@ -37,7 +37,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (input, context) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;
@@ -55,7 +55,7 @@ void main(List<String> args) async {
       final photoBase64 = base64Encode(photoBytes);
 
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash-image'),
+        model: vertexAI.gemini('gemini-flash-latest-image'),
         prompt: input,
         messages: [
           Message(
@@ -86,7 +86,7 @@ void main(List<String> args) async {
         location: Platform.environment['GCLOUD_LOCATION'] ?? 'global',
       );
       final response = await lite.generate(
-        model: gemini.model('gemini-2.5-flash'),
+        model: gemini.model('gemini-flash-latest'),
         prompt: input,
       );
       return response.text;
@@ -128,7 +128,7 @@ void main(List<String> args) async {
     outputSchema: RpgCharacter.$schema,
     fn: (name, ctx) async {
       final stream = ai.generateStream(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         config: GeminiOptions(temperature: 2.0),
         outputSchema: RpgCharacter.$schema,
         prompt: 'Generate an RPC character called $name',
@@ -155,7 +155,7 @@ void main(List<String> args) async {
     streamSchema: CharacterProfile.$schema,
     fn: (prompt, ctx) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         outputSchema: CharacterProfile.$schema,
         prompt: prompt,
         onChunk: ctx.streamingRequested
@@ -175,7 +175,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         messages: [
           Message(
@@ -202,7 +202,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         messages: [
           Message(
@@ -258,7 +258,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         config: GeminiOptions(
           safetySettings: [
@@ -282,7 +282,7 @@ void main(List<String> args) async {
     outputSchema: .map(.string(), .dynamicSchema()),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash'),
+        model: vertexAI.gemini('gemini-flash-latest'),
         prompt: prompt,
         config: GeminiOptions(googleSearch: GoogleSearch()),
       );
@@ -297,7 +297,7 @@ void main(List<String> args) async {
     outputSchema: .string(),
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-pro'),
+        model: vertexAI.gemini('gemini-pro-latest'),
         prompt: prompt,
         config: GeminiOptions(codeExecution: true),
       );
@@ -314,7 +314,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash-preview-tts'),
+        model: vertexAI.gemini('gemini-flash-latest-preview-tts'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],
@@ -344,7 +344,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-2.5-flash-preview-tts'),
+        model: vertexAI.gemini('gemini-flash-latest-preview-tts'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],

--- a/testapps/gemini/bin/vertexai.dart
+++ b/testapps/gemini/bin/vertexai.dart
@@ -55,7 +55,7 @@ void main(List<String> args) async {
       final photoBase64 = base64Encode(photoBytes);
 
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-flash-latest-image'),
+        model: vertexAI.gemini('gemini-3.1-flash-image'),
         prompt: input,
         messages: [
           Message(

--- a/testapps/gemini/bin/vertexai.dart
+++ b/testapps/gemini/bin/vertexai.dart
@@ -314,7 +314,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-flash-latest-preview-tts'),
+        model: vertexAI.gemini('gemini-3.1-flash-tts-preview'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],
@@ -344,7 +344,7 @@ void main(List<String> args) async {
     outputSchema: Media.$schema,
     fn: (prompt, _) async {
       final response = await ai.generate(
-        model: vertexAI.gemini('gemini-flash-latest-preview-tts'),
+        model: vertexAI.gemini('gemini-3.1-flash-tts-preview'),
         prompt: prompt,
         config: GeminiTtsOptions(
           responseModalities: ['AUDIO'],

--- a/testapps/middleware/bin/main.dart
+++ b/testapps/middleware/bin/main.dart
@@ -53,7 +53,7 @@ void main() async {
       final skillsRoot = '$currentDir/skills';
 
       final response = await ai.generate(
-        model: googleAI.gemini('gemini-2.5-flash'),
+        model: googleAI.gemini('gemini-flash-latest'),
         prompt: input,
         use: [
           filesystem(rootDirectory: fsRoot),


### PR DESCRIPTION
Replace all references to `gemini-2.5-flash` with `gemini-flash-latest` across READMEs, sample apps, and test apps to use the latest model alias.