### PR TITLE
feat(genkit_firebase_ai): Support Vertex AI Gemini API

### DIFF
--- a/packages/genkit_firebase_ai/README.md
+++ b/packages/genkit_firebase_ai/README.md
@@ -24,8 +24,9 @@ void main() async {
 
 ### Configuration
 
-You can optionally pass in `FirebaseApp`, `FirebaseAppCheck`, `FirebaseAuth` 
-instances, and `useLimitedUseAppCheckTokens` flag when initializing the plugin:
+You can optionally pass in `FirebaseApp`, `FirebaseAppCheck`, `FirebaseAuth`,
+`FirebaseAiProvider` instances, and `useLimitedUseAppCheckTokens` flag when
+initializing the plugin.
 
 ```dart
 final firebasePlugin = firebaseAI(
@@ -33,6 +34,7 @@ final firebasePlugin = firebaseAI(
   appCheck: FirebaseAppCheck.instanceFor(app: Firebase.app('my-app')),
   auth: FirebaseAuth.instanceFor(app: Firebase.app('my-app')),
   useLimitedUseAppCheckTokens: true,
+  provider: FirebaseAiProvider.vertexAI(location: 'us-central1'),
 );
 
 final ai = Genkit(plugins: [firebasePlugin]);

--- a/packages/genkit_firebase_ai/README.md
+++ b/packages/genkit_firebase_ai/README.md
@@ -33,8 +33,8 @@ final firebasePlugin = firebaseAI(
   app: Firebase.app('my-app'),
   appCheck: FirebaseAppCheck.instanceFor(app: Firebase.app('my-app')),
   auth: FirebaseAuth.instanceFor(app: Firebase.app('my-app')),
-  useLimitedUseAppCheckTokens: true,
   provider: FirebaseAiProvider.vertexAI(location: 'us-central1'),
+  useLimitedUseAppCheckTokens: true,
 );
 
 final ai = Genkit(plugins: [firebasePlugin]);

--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
@@ -161,6 +161,24 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
        _auth = auth,
        _useLimitedUseAppCheckTokens = useLimitedUseAppCheckTokens;
 
+  fai.FirebaseAI _getFirebaseAI() {
+    return switch (provider) {
+      _VertexAIProvider(:final location) => fai.FirebaseAI.vertexAI(
+        app: _app,
+        appCheck: _appCheck,
+        auth: _auth,
+        useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
+        location: location,
+      ),
+      _GoogleAIProvider() => fai.FirebaseAI.googleAI(
+        app: _app,
+        appCheck: _appCheck,
+        auth: _auth,
+        useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
+      ),
+    };
+  }
+
   @override
   Future<List<Action>> init() async {
     return [
@@ -189,21 +207,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
             ? GeminiOptions()
             : GeminiOptions.$schema.parse(req.config!);
 
-        final instance = switch (provider) {
-          _VertexAIProvider(:final location) => fai.FirebaseAI.vertexAI(
-            app: _app,
-            appCheck: _appCheck,
-            auth: _auth,
-            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
-            location: location,
-          ),
-          _GoogleAIProvider() => fai.FirebaseAI.googleAI(
-            app: _app,
-            appCheck: _appCheck,
-            auth: _auth,
-            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
-          ),
-        };
+        final instance = _getFirebaseAI();
         final model = instance.generativeModel(
           model: modelName,
           generationConfig: toGeminiSettings(
@@ -332,21 +336,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
               ?.toDouble(),
         );
 
-        final instance = switch (provider) {
-          _VertexAIProvider(:final location) => fai.FirebaseAI.vertexAI(
-            app: _app,
-            appCheck: _appCheck,
-            auth: _auth,
-            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
-            location: location,
-          ),
-          _GoogleAIProvider() => fai.FirebaseAI.googleAI(
-            app: _app,
-            appCheck: _appCheck,
-            auth: _auth,
-            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
-          ),
-        };
+        final instance = _getFirebaseAI();
         final model = instance.liveGenerativeModel(
           model: modelName,
           liveGenerationConfig: liveConfig,

--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
@@ -145,7 +145,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
   final fac.FirebaseAppCheck? _appCheck;
   final fauth.FirebaseAuth? _auth;
   final bool? _useLimitedUseAppCheckTokens;
-  final FirebaseAiProvider provider;
+  final FirebaseAiProvider _provider;
 
   @override
   String get name => 'firebaseai';
@@ -155,14 +155,15 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
     fac.FirebaseAppCheck? appCheck,
     fauth.FirebaseAuth? auth,
     bool? useLimitedUseAppCheckTokens,
-    this.provider = const FirebaseAiProvider.googleAI(),
+    FirebaseAiProvider provider = const FirebaseAiProvider.googleAI(),
   }) : _app = app,
        _appCheck = appCheck,
        _auth = auth,
-       _useLimitedUseAppCheckTokens = useLimitedUseAppCheckTokens;
+       _useLimitedUseAppCheckTokens = useLimitedUseAppCheckTokens,
+       _provider = provider;
 
-  fai.FirebaseAI _getFirebaseAI() {
-    return switch (provider) {
+  fai.FirebaseAI get _firebaseAI {
+    return switch (_provider) {
       _VertexAIProvider(:final location) => fai.FirebaseAI.vertexAI(
         app: _app,
         appCheck: _appCheck,
@@ -207,8 +208,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
             ? GeminiOptions()
             : GeminiOptions.$schema.parse(req.config!);
 
-        final instance = _getFirebaseAI();
-        final model = instance.generativeModel(
+        final model = _firebaseAI.generativeModel(
           model: modelName,
           generationConfig: toGeminiSettings(
             options,
@@ -336,8 +336,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
               ?.toDouble(),
         );
 
-        final instance = _getFirebaseAI();
-        final model = instance.liveGenerativeModel(
+        final model = _firebaseAI.liveGenerativeModel(
           model: modelName,
           liveGenerationConfig: liveConfig,
           tools: tools,

--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
@@ -93,6 +93,24 @@ abstract class $LiveGenerationConfig {
   double? get frequencyPenalty;
 }
 
+sealed class FirebaseAiProvider {
+  const FirebaseAiProvider();
+
+  const factory FirebaseAiProvider.googleAI() = _GoogleAIProvider;
+  const factory FirebaseAiProvider.vertexAI({String? location}) =
+      _VertexAIProvider;
+}
+
+class _GoogleAIProvider extends FirebaseAiProvider {
+  const _GoogleAIProvider();
+}
+
+class _VertexAIProvider extends FirebaseAiProvider {
+  final String? location;
+
+  const _VertexAIProvider({this.location});
+}
+
 const FirebaseGenAiPluginHandle firebaseAI = FirebaseGenAiPluginHandle();
 
 class FirebaseGenAiPluginHandle {
@@ -103,12 +121,14 @@ class FirebaseGenAiPluginHandle {
     fac.FirebaseAppCheck? appCheck,
     fauth.FirebaseAuth? auth,
     bool? useLimitedUseAppCheckTokens,
+    FirebaseAiProvider provider = const FirebaseAiProvider.googleAI(),
   }) {
     return _FirebaseGenAiPlugin(
       app: app,
       appCheck: appCheck,
       auth: auth,
       useLimitedUseAppCheckTokens: useLimitedUseAppCheckTokens,
+      provider: provider,
     );
   }
 
@@ -125,6 +145,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
   final fac.FirebaseAppCheck? _appCheck;
   final fauth.FirebaseAuth? _auth;
   final bool? _useLimitedUseAppCheckTokens;
+  final FirebaseAiProvider provider;
 
   @override
   String get name => 'firebaseai';
@@ -134,6 +155,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
     fac.FirebaseAppCheck? appCheck,
     fauth.FirebaseAuth? auth,
     bool? useLimitedUseAppCheckTokens,
+    this.provider = const FirebaseAiProvider.googleAI(),
   }) : _app = app,
        _appCheck = appCheck,
        _auth = auth,
@@ -167,12 +189,21 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
             ? GeminiOptions()
             : GeminiOptions.$schema.parse(req.config!);
 
-        final instance = fai.FirebaseAI.googleAI(
-          app: _app,
-          appCheck: _appCheck,
-          auth: _auth,
-          useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
-        );
+        final instance = switch (provider) {
+          _VertexAIProvider(:final location) => fai.FirebaseAI.vertexAI(
+            app: _app,
+            appCheck: _appCheck,
+            auth: _auth,
+            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
+            location: location,
+          ),
+          _GoogleAIProvider() => fai.FirebaseAI.googleAI(
+            app: _app,
+            appCheck: _appCheck,
+            auth: _auth,
+            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
+          ),
+        };
         final model = instance.generativeModel(
           model: modelName,
           generationConfig: toGeminiSettings(
@@ -301,12 +332,21 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
               ?.toDouble(),
         );
 
-        final instance = fai.FirebaseAI.googleAI(
-          app: _app,
-          appCheck: _appCheck,
-          auth: _auth,
-          useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
-        );
+        final instance = switch (provider) {
+          _VertexAIProvider(:final location) => fai.FirebaseAI.vertexAI(
+            app: _app,
+            appCheck: _appCheck,
+            auth: _auth,
+            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
+            location: location,
+          ),
+          _GoogleAIProvider() => fai.FirebaseAI.googleAI(
+            app: _app,
+            appCheck: _appCheck,
+            auth: _auth,
+            useLimitedUseAppCheckTokens: _useLimitedUseAppCheckTokens,
+          ),
+        };
         final model = instance.liveGenerativeModel(
           model: modelName,
           liveGenerationConfig: liveConfig,


### PR DESCRIPTION
Fixes https://github.com/genkit-ai/genkit-dart/issues/295

The Firebase AI Logic SDK supports two Gemini API providers:
* Gemini Developer API, and
* Vertex AI Gemini API

Prior to this change the `genkit_firebase_ai` package was hardcoding "Gemini Developer API" as API provider. This change enables consumers of the package to optionally use the "Vertex AI Gemini API".