### PR TITLE
fix(genkit_openai): send non-image media as OpenAI file content parts

### DIFF
--- a/packages/genkit_openai/lib/src/converters.dart
+++ b/packages/genkit_openai/lib/src/converters.dart
@@ -101,15 +101,29 @@ abstract final class GenkitConverter {
     }
     if (part.isMedia) {
       final media = part.media!;
+      final mimeType = media.contentType ?? 'image/png';
+      final isImage = mimeType.toLowerCase().startsWith('image/');
+
       if (media.url.startsWith('data:')) {
         // Parse data URI: data:<mediaType>;base64,<data>
         final commaIdx = media.url.indexOf(',');
         final base64Data = media.url.substring(commaIdx + 1);
-        final mimeType = media.contentType ?? 'image/png';
-        return sdk.ContentPart.imageBase64(
+        if (isImage) {
+          return sdk.ContentPart.imageBase64(
+            data: base64Data,
+            mediaType: mimeType,
+            detail: _mapVisualDetailLevel(visualDetailLevel),
+          );
+        }
+        // Non-image documents (e.g. application/pdf) must be sent as a `file`
+        // content part. Routing them through image_url makes the API reject
+        // them with "Invalid MIME type. Only image types are supported."
+        // OpenAI infers the document type from the filename extension, and
+        // Genkit's Media carries no filename, so one is synthesized.
+        return sdk.ContentPart.fileData(
           data: base64Data,
           mediaType: mimeType,
-          detail: _mapVisualDetailLevel(visualDetailLevel),
+          filename: _filenameForMimeType(mimeType),
         );
       }
       return sdk.ContentPart.imageUrl(
@@ -118,6 +132,25 @@ abstract final class GenkitConverter {
       );
     }
     throw UnimplementedError('Unsupported part type: $part');
+  }
+
+  /// Derives a synthetic filename for an OpenAI `file` content part.
+  ///
+  /// OpenAI infers a document's type from its filename extension, but Genkit's
+  /// [Media] does not carry a filename, so one is derived from the MIME type.
+  static String _filenameForMimeType(String mimeType) {
+    final ext = switch (mimeType.toLowerCase()) {
+      'application/pdf' => 'pdf',
+      'text/plain' => 'txt',
+      'text/csv' => 'csv',
+      'application/json' => 'json',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document' =>
+        'docx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' =>
+        'xlsx',
+      _ => mimeType.contains('/') ? mimeType.split('/').last : 'bin',
+    };
+    return 'document.$ext';
   }
 
   /// Map visual detail level string to enum

--- a/packages/genkit_openai/lib/src/converters.dart
+++ b/packages/genkit_openai/lib/src/converters.dart
@@ -104,7 +104,10 @@ abstract final class GenkitConverter {
       // The MIME type may include parameters (e.g. "application/pdf;
       // charset=utf-8"). Strip them so matching and extension derivation work
       // against the base type.
-      final mimeType = (media.contentType ?? 'image/png').split(';').first.trim();
+      final mimeType = (media.contentType ?? 'image/png')
+          .split(';')
+          .first
+          .trim();
       final isImage = mimeType.toLowerCase().startsWith('image/');
 
       if (media.url.startsWith('data:')) {

--- a/packages/genkit_openai/lib/src/converters.dart
+++ b/packages/genkit_openai/lib/src/converters.dart
@@ -101,7 +101,10 @@ abstract final class GenkitConverter {
     }
     if (part.isMedia) {
       final media = part.media!;
-      final mimeType = media.contentType ?? 'image/png';
+      // The MIME type may include parameters (e.g. "application/pdf;
+      // charset=utf-8"). Strip them so matching and extension derivation work
+      // against the base type.
+      final mimeType = (media.contentType ?? 'image/png').split(';').first.trim();
       final isImage = mimeType.toLowerCase().startsWith('image/');
 
       if (media.url.startsWith('data:')) {

--- a/packages/genkit_openai/test/openai_plugin_converter_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_converter_test.dart
@@ -205,6 +205,28 @@ void main() {
       });
     });
 
+    test('strips MIME type parameters when deriving the filename', () {
+      final part = MediaPart(
+        media: Media(
+          url: 'data:application/pdf;charset=utf-8;base64,JVBERi0xLjcK',
+          contentType: 'application/pdf; charset=utf-8',
+        ),
+      );
+
+      final result = GenkitConverter.toOpenAIContentPart(part, null);
+
+      // The "; charset=utf-8" parameter must not leak into the extension or
+      // produce an invalid filename like "document.pdf; charset=utf-8". The
+      // base media type is also what gets sent to the API.
+      expect(result.toJson(), {
+        'type': 'file',
+        'file': {
+          'file_data': 'data:application/pdf;base64,JVBERi0xLjcK',
+          'filename': 'document.pdf',
+        },
+      });
+    });
+
     test('keeps image data URI as an image_url content part', () {
       final part = MediaPart(
         media: Media(

--- a/packages/genkit_openai/test/openai_plugin_converter_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_converter_test.dart
@@ -183,6 +183,46 @@ void main() {
         },
       });
     });
+
+    test('converts non-image data URI (PDF) to a file content part', () {
+      final part = MediaPart(
+        media: Media(
+          url: 'data:application/pdf;base64,JVBERi0xLjcK',
+          contentType: 'application/pdf',
+        ),
+      );
+
+      final result = GenkitConverter.toOpenAIContentPart(part, null);
+
+      // Non-image documents must be sent as a `file` part; image_url would be
+      // rejected with "Invalid MIME type. Only image types are supported."
+      expect(result.toJson(), {
+        'type': 'file',
+        'file': {
+          'file_data': 'data:application/pdf;base64,JVBERi0xLjcK',
+          'filename': 'document.pdf',
+        },
+      });
+    });
+
+    test('keeps image data URI as an image_url content part', () {
+      final part = MediaPart(
+        media: Media(
+          url: 'data:image/png;base64,iVBORw0KGgo=',
+          contentType: 'image/png',
+        ),
+      );
+
+      final result = GenkitConverter.toOpenAIContentPart(part, null);
+
+      expect(result.toJson(), {
+        'type': 'image_url',
+        'image_url': {
+          'url': 'data:image/png;base64,iVBORw0KGgo=',
+          'detail': 'auto',
+        },
+      });
+    });
   });
 
   group('GenkitConverter.toOpenAITool', () {


### PR DESCRIPTION
The content-part converter mapped every MediaPart to an image_url part, so PDFs and other non-image documents were rejected by the OpenAI API with "Invalid MIME type. Only image types are supported."

Branch non-image data URIs to ContentPart.fileData (the OpenAI `file` content part). OpenAI infers the document type from the filename extension, which Genkit's Media does not carry, so synthesize one from the MIME type. Image and remote-URL handling are unchanged.