### PR TITLE
feat(ollama): scaffold genkit_ollama package + config schema

### DIFF
--- a/packages/genkit_ollama/LICENSE
+++ b/packages/genkit_ollama/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Google LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/genkit_ollama/build.yaml
+++ b/packages/genkit_ollama/build.yaml
@@ -1,0 +1,23 @@
+# Read about `build.yaml` at https://pub.dev/packages/build_config
+targets:
+  $default:
+    builders:
+      source_gen|combining_builder:
+        options:
+          header: |-
+            // Copyright 2025 Google LLC
+            //
+            // Licensed under the Apache License, Version 2.0 (the "License");
+            // you may not use this file except in compliance with the License.
+            // You may obtain a copy of the License at
+            //
+            //     http://www.apache.org/licenses/LICENSE-2.0
+            //
+            // Unless required by applicable law or agreed to in writing, software
+            // distributed under the License is distributed on an "AS IS" BASIS,
+            // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            // See the License for the specific language governing permissions and
+            // limitations under the License.
+
+            // GENERATED CODE - DO NOT MODIFY BY HAND
+            // dart format width=80

--- a/packages/genkit_ollama/lib/genkit_ollama.dart
+++ b/packages/genkit_ollama/lib/genkit_ollama.dart
@@ -1,0 +1,18 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'src/chat.dart' show OllamaChatOptions;
+
+/// Default plugin / namespace name used when no custom name is provided.
+const String defaultOllamaNamespace = 'ollama';

--- a/packages/genkit_ollama/lib/src/chat.dart
+++ b/packages/genkit_ollama/lib/src/chat.dart
@@ -1,0 +1,82 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:schemantic/schemantic.dart';
+
+part 'chat.g.dart';
+
+/// Chat-specific options for Ollama models.
+///
+/// Mirrors the subset of Ollama's runtime options that map cleanly onto
+/// Genkit's generation config, plus two Ollama-specific knobs (`numCtx` and
+/// `keepAlive`) that are commonly tuned but absent from the JS plugin.
+///
+/// See https://github.com/ollama/ollama/blob/main/docs/modelfile.md and the
+/// `/api/chat` options block for the full meaning of each field.
+@Schema()
+abstract class $OllamaChatOptions {
+  /// Sampling temperature. Higher is more creative. Ollama default: 0.8.
+  ///
+  /// Ollama accepts values above 1.0; the JS plugin caps at 1.0, which rejects
+  /// otherwise-valid configs.
+  @DoubleField(minimum: 0.0, maximum: 2.0)
+  double? get temperature;
+
+  /// Top-k sampling. Ollama default: 40.
+  int? get topK;
+
+  /// Nucleus (top-p) sampling. Ollama default: 0.9.
+  @DoubleField(minimum: 0.0, maximum: 1.0)
+  double? get topP;
+
+  /// Maximum number of tokens to generate (Ollama `num_predict`).
+  int? get maxOutputTokens;
+
+  /// Stop sequences. Generation halts when any is produced.
+  List<String>? get stop;
+
+  /// Random seed for deterministic sampling.
+  int? get seed;
+
+  /// Size of the context window in tokens (Ollama `num_ctx`).
+  ///
+  /// Not exposed by the JS plugin; one of the most commonly tuned Ollama knobs.
+  int? get numCtx;
+
+  /// How long the model stays loaded in memory after the request, e.g. `'5m'`,
+  /// `'0'` to unload immediately, or `'-1'` to keep loaded indefinitely.
+  ///
+  /// Accepts the same values as Ollama's `keep_alive` field.
+  String? get keepAlive;
+}
+
+/// Internal alias for [OllamaChatOptions] used within the plugin.
+typedef ChatModelOptions = OllamaChatOptions;
+
+/// Returns true when the output config requests JSON-structured output
+/// (format is `'json'` or contentType is `'application/json'`).
+bool isJsonStructuredOutput(String? format, String? contentType) {
+  return format == 'json' || contentType == 'application/json';
+}
+
+/// Returns the custom options schema for Ollama chat models.
+SchemanticType<ChatModelOptions> chatModelOptionsSchema() =>
+    OllamaChatOptions.$schema;
+
+/// Parses chat-model options from action config.
+ChatModelOptions parseChatModelOptions(Map<String, dynamic>? config) {
+  return config != null
+      ? OllamaChatOptions.$schema.parse(config)
+      : OllamaChatOptions();
+}

--- a/packages/genkit_ollama/lib/src/chat.g.dart
+++ b/packages/genkit_ollama/lib/src/chat.g.dart
@@ -1,0 +1,234 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+part of 'chat.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+/// Chat-specific options for Ollama models.
+///
+/// Mirrors the subset of Ollama's runtime options that map cleanly onto
+/// Genkit's generation config, plus two Ollama-specific knobs (`numCtx` and
+/// `keepAlive`) that are commonly tuned but absent from the JS plugin.
+///
+/// See https://github.com/ollama/ollama/blob/main/docs/modelfile.md and the
+/// `/api/chat` options block for the full meaning of each field.
+base class OllamaChatOptions {
+  /// Creates a [OllamaChatOptions] from a JSON map.
+  factory OllamaChatOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  OllamaChatOptions._(this._json);
+
+  OllamaChatOptions({
+    double? temperature,
+    int? topK,
+    double? topP,
+    int? maxOutputTokens,
+    List<String>? stop,
+    int? seed,
+    int? numCtx,
+    String? keepAlive,
+  }) {
+    _json = {
+      'temperature': ?temperature,
+      'topK': ?topK,
+      'topP': ?topP,
+      'maxOutputTokens': ?maxOutputTokens,
+      'stop': ?stop,
+      'seed': ?seed,
+      'numCtx': ?numCtx,
+      'keepAlive': ?keepAlive,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [OllamaChatOptions].
+  static const SchemanticType<OllamaChatOptions> $schema =
+      _OllamaChatOptionsTypeFactory();
+
+  /// Sampling temperature. Higher is more creative. Ollama default: 0.8.
+  ///
+  /// Ollama accepts values above 1.0; the JS plugin caps at 1.0, which rejects
+  /// otherwise-valid configs.
+  double? get temperature {
+    return (_json['temperature'] as num?)?.toDouble();
+  }
+
+  /// Sampling temperature. Higher is more creative. Ollama default: 0.8.
+  ///
+  /// Ollama accepts values above 1.0; the JS plugin caps at 1.0, which rejects
+  /// otherwise-valid configs.
+  set temperature(double? value) {
+    if (value == null) {
+      _json.remove('temperature');
+    } else {
+      _json['temperature'] = value;
+    }
+  }
+
+  /// Top-k sampling. Ollama default: 40.
+  int? get topK {
+    return _json['topK'] as int?;
+  }
+
+  /// Top-k sampling. Ollama default: 40.
+  set topK(int? value) {
+    if (value == null) {
+      _json.remove('topK');
+    } else {
+      _json['topK'] = value;
+    }
+  }
+
+  /// Nucleus (top-p) sampling. Ollama default: 0.9.
+  double? get topP {
+    return (_json['topP'] as num?)?.toDouble();
+  }
+
+  /// Nucleus (top-p) sampling. Ollama default: 0.9.
+  set topP(double? value) {
+    if (value == null) {
+      _json.remove('topP');
+    } else {
+      _json['topP'] = value;
+    }
+  }
+
+  /// Maximum number of tokens to generate (Ollama `num_predict`).
+  int? get maxOutputTokens {
+    return _json['maxOutputTokens'] as int?;
+  }
+
+  /// Maximum number of tokens to generate (Ollama `num_predict`).
+  set maxOutputTokens(int? value) {
+    if (value == null) {
+      _json.remove('maxOutputTokens');
+    } else {
+      _json['maxOutputTokens'] = value;
+    }
+  }
+
+  /// Stop sequences. Generation halts when any is produced.
+  List<String>? get stop {
+    return (_json['stop'] as List?)?.cast<String>();
+  }
+
+  /// Stop sequences. Generation halts when any is produced.
+  set stop(List<String>? value) {
+    if (value == null) {
+      _json.remove('stop');
+    } else {
+      _json['stop'] = value;
+    }
+  }
+
+  /// Random seed for deterministic sampling.
+  int? get seed {
+    return _json['seed'] as int?;
+  }
+
+  /// Random seed for deterministic sampling.
+  set seed(int? value) {
+    if (value == null) {
+      _json.remove('seed');
+    } else {
+      _json['seed'] = value;
+    }
+  }
+
+  /// Size of the context window in tokens (Ollama `num_ctx`).
+  ///
+  /// Not exposed by the JS plugin; one of the most commonly tuned Ollama knobs.
+  int? get numCtx {
+    return _json['numCtx'] as int?;
+  }
+
+  /// Size of the context window in tokens (Ollama `num_ctx`).
+  ///
+  /// Not exposed by the JS plugin; one of the most commonly tuned Ollama knobs.
+  set numCtx(int? value) {
+    if (value == null) {
+      _json.remove('numCtx');
+    } else {
+      _json['numCtx'] = value;
+    }
+  }
+
+  /// How long the model stays loaded in memory after the request, e.g. `'5m'`,
+  /// `'0'` to unload immediately, or `'-1'` to keep loaded indefinitely.
+  ///
+  /// Accepts the same values as Ollama's `keep_alive` field.
+  String? get keepAlive {
+    return _json['keepAlive'] as String?;
+  }
+
+  /// How long the model stays loaded in memory after the request, e.g. `'5m'`,
+  /// `'0'` to unload immediately, or `'-1'` to keep loaded indefinitely.
+  ///
+  /// Accepts the same values as Ollama's `keep_alive` field.
+  set keepAlive(String? value) {
+    if (value == null) {
+      _json.remove('keepAlive');
+    } else {
+      _json['keepAlive'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [OllamaChatOptions] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _OllamaChatOptionsTypeFactory
+    extends SchemanticType<OllamaChatOptions> {
+  const _OllamaChatOptionsTypeFactory();
+
+  @override
+  OllamaChatOptions parse(Object? json) {
+    return OllamaChatOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'OllamaChatOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'temperature': $Schema.number(minimum: 0.0, maximum: 2.0),
+            'topK': $Schema.integer(),
+            'topP': $Schema.number(minimum: 0.0, maximum: 1.0),
+            'maxOutputTokens': $Schema.integer(),
+            'stop': $Schema.list(items: $Schema.string()),
+            'seed': $Schema.integer(),
+            'numCtx': $Schema.integer(),
+            'keepAlive': $Schema.string(),
+          },
+        )
+        .value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_ollama/pubspec.yaml
+++ b/packages/genkit_ollama/pubspec.yaml
@@ -1,0 +1,23 @@
+name: genkit_ollama
+description: Ollama plugin for Genkit Dart. Run local LLMs and embedding models via an Ollama server, with chat, streaming, tools, vision, and constrained output.
+resolution: workspace
+version: 0.1.0
+repository: https://github.com/genkit-ai/genkit-dart
+license: Apache-2.0
+
+environment:
+  sdk: ^3.10.0
+
+dependencies:
+  genkit: ^0.14.1
+  http: ^1.6.0
+  meta: ^1.17.0
+  ollama_dart: ^2.3.0
+  schemantic: ^0.2.0
+
+dev_dependencies:
+  build_runner: ^2.10.5
+  build_test: ^3.5.5
+  mockito: ^5.4.4
+  schemantic_builder: ^0.1.0
+  test: ^1.29.0

--- a/packages/genkit_ollama/test/ollama_chat_options_test.dart
+++ b/packages/genkit_ollama/test/ollama_chat_options_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit_ollama/genkit_ollama.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OllamaChatOptions', () {
+    test('parses common and Ollama-specific fields', () {
+      final options = OllamaChatOptions.$schema.parse({
+        'temperature': 0.7,
+        'topK': 40,
+        'topP': 0.9,
+        'maxOutputTokens': 256,
+        'numCtx': 4096,
+        'keepAlive': '5m',
+        'stop': ['END'],
+      });
+      expect(options.temperature, 0.7);
+      expect(options.topK, 40);
+      expect(options.numCtx, 4096);
+      expect(options.keepAlive, '5m');
+      expect(options.stop, ['END']);
+    });
+
+    test('creates empty options', () {
+      final options = OllamaChatOptions();
+      expect(options.temperature, isNull);
+      expect(options.numCtx, isNull);
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ workspace:
   - packages/genkit_vertex_auth
   - packages/genkit_openai
   - packages/genkit_anthropic
+  - packages/genkit_ollama
   - packages/genkit_shelf
   - packages/genkit_chrome
   - packages/schemantic
@@ -76,7 +77,7 @@ melos:
     build-gen-plugins:
       exec: dart run build_runner build
       packageFilters:
-        scope: "{genkit_anthropic,genkit_chrome,genkit_firebase_ai,genkit_google_genai,genkit_mcp,genkit_openai}"
+        scope: "{genkit_anthropic,genkit_chrome,genkit_firebase_ai,genkit_google_genai,genkit_mcp,genkit_ollama,genkit_openai}"
       description: Run build_runner for plugins.
 
     build-gen-testapps:


### PR DESCRIPTION
## genkit_ollama (1/N): scaffold + config schema

First PR introducing a new **`genkit_ollama`** plugin: run local LLMs and
embedding models through an [Ollama](https://ollama.com) server, with chat +
streaming, tool calling, vision input, embeddings, constrained (JSON-schema)
output, and dynamic model discovery.

There is no existing Dart Ollama plugin, so this is a ground-up build modelled on
`genkit_openai` / `genkit_anthropic`.

> **This PR is scaffold-only:** package skeleton, workspace wiring, and the
> `OllamaChatOptions` config schema. No runtime behaviour yet — that lands in the
> follow-up PRs below. Reviewable in isolation; `analyze`/`test`/`format` are
> green.

---

## Series

The plugin is split into small, self-contained PRs so each can be reviewed on its
own. Reviewing bottom-up keeps each diff small and isolates the load-bearing
decisions.

| PR | Scope |
|----|-------|
| **#305 (this)** | 1/5 — scaffold + `OllamaChatOptions` schema |
| #306 | 2/5 — Genkit ⇄ ollama_dart converters |
| #307 | 3/5 — `/api/show` capability + dimension helpers |
| #308 | 4/5 — plugin wiring (model, embedder, discovery) |
| #309 | 5/5 — example, README, CHANGELOG, live tests |

The two decisions most worth scrutiny land in #306 (converter shape) and #307
(capability strategy).

---

## Design decisions

### Built on the `ollama_dart` SDK (not raw HTTP)
Depends on [`ollama_dart`](https://pub.dev/packages/ollama_dart) `^2.3.0` rather
than hand-rolling HTTP. It's by the same author as `openai_dart` /
`anthropic_sdk_dart` that the sibling Dart plugins already use, so it's the
idiomatic Dart choice — typed requests/responses, built-in NDJSON streaming, and
`http.Client` injection for deterministic tests.

### Per-model capabilities from `/api/show`
Discovery queries each model's real `capabilities` array
(`completion`/`tools`/`vision`/`embedding`) and maps it onto Genkit's `supports`
flags, with a generic fallback for older servers — rather than advertising one
blanket capability profile for every model.

### Auto-discovered embedder dimensions
Embedder dimensions are read from `/api/show`'s `model_info`
(`<arch>.embedding_length`) instead of being hand-declared (an explicit override
is still accepted).

### Chat-only
Only `/api/chat` is implemented, not the legacy `/api/generate`. Chat is a
capability superset (tools, system role, multiturn, media), so a separate
generate path would add converter/test surface with no extra capability.

### Config
`OllamaChatOptions` covers the common generation options plus `numCtx` (context
window) and `keepAlive` — two commonly-tuned Ollama knobs. `temperature` allows
up to `2.0`.

### Constrained output, auth
Genkit `output.schema` maps to Ollama's `format` for JSON-schema-constrained
decoding. Static headers plus an async `headersProvider` support authenticated
remote servers.

---

## Testing
`dart analyze`, `dart test`, and `dart format --set-exit-if-changed` are green.
Conversion logic and capability mapping are unit-tested; the plugin layer has
mocked end-to-end tests (chat, streaming, tools, embeddings, discovery, error
mapping, header merge) via an injected `http.Client`; live integration tests are
env-gated (`OLLAMA_LIVE_TEST=1`). (Behaviour + tests arrive in the follow-up PRs;
this PR is scaffold-only.)
