### PR TITLE
feat(ollama): Genkit <-> ollama_dart converters

### DIFF
--- a/packages/genkit_ollama/lib/genkit_ollama.dart
+++ b/packages/genkit_ollama/lib/genkit_ollama.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 export 'src/chat.dart' show OllamaChatOptions;
+export 'src/converters.dart' show GenkitConverter;
 
 /// Default plugin / namespace name used when no custom name is provided.
 const String defaultOllamaNamespace = 'ollama';

--- a/packages/genkit_ollama/lib/src/converters.dart
+++ b/packages/genkit_ollama/lib/src/converters.dart
@@ -1,0 +1,239 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:ollama_dart/ollama_dart.dart' as sdk;
+
+import 'chat.dart';
+
+/// Converts between Genkit and `ollama_dart` request/response shapes.
+abstract final class GenkitConverter {
+  /// Converts Genkit [messages] to Ollama chat messages.
+  ///
+  /// A single Genkit tool message may carry several tool responses; each is
+  /// expanded into its own Ollama `tool` message.
+  static List<sdk.ChatMessage> toOllamaMessages(List<Message> messages) {
+    final result = <sdk.ChatMessage>[];
+    for (final message in messages) {
+      if (message.role == Role.tool) {
+        final toolResponses = message.content
+            .where((p) => p.isToolResponse)
+            .map((p) => p.toolResponse!)
+            .toList();
+        if (toolResponses.isEmpty) {
+          throw ArgumentError(
+            'Tool message must contain at least one ToolResponsePart',
+          );
+        }
+        for (final toolResponse in toolResponses) {
+          result.add(
+            sdk.ChatMessage.tool(_encodeToolOutput(toolResponse.output)),
+          );
+        }
+      } else {
+        result.add(toOllamaMessage(message));
+      }
+    }
+    return result;
+  }
+
+  /// Converts a single non-tool Genkit [msg] to an Ollama chat message.
+  static sdk.ChatMessage toOllamaMessage(Message msg) {
+    if (msg.role == Role.system) {
+      return sdk.ChatMessage.system(msg.text);
+    }
+    if (msg.role == Role.user) {
+      final images = <String>[];
+      final textBuffer = StringBuffer();
+      for (final part in msg.content) {
+        if (part.isText) {
+          textBuffer.write(part.text);
+        } else if (part.isMedia) {
+          images.add(_toOllamaImage(part.media!));
+        } else {
+          throw UnimplementedError(
+            'Unsupported part type in user message: $part',
+          );
+        }
+      }
+      return sdk.ChatMessage.user(
+        textBuffer.toString(),
+        images: images.isNotEmpty ? images : null,
+      );
+    }
+    if (msg.role == Role.model) {
+      final toolCalls = _extractToolCalls(msg.content);
+      final textBuffer = StringBuffer();
+      for (final part in msg.content) {
+        if (part.isText) textBuffer.write(part.text);
+      }
+      return sdk.ChatMessage.assistant(
+        textBuffer.toString(),
+        toolCalls: toolCalls.isNotEmpty ? toolCalls : null,
+      );
+    }
+    if (msg.role == Role.tool) {
+      throw ArgumentError(
+        'Tool messages must be handled by toOllamaMessages(), '
+        'not toOllamaMessage()',
+      );
+    }
+    throw UnimplementedError('Unsupported role: ${msg.role}');
+  }
+
+  /// Ollama accepts images as bare base64 strings; strip any data-URI prefix.
+  static String _toOllamaImage(Media media) {
+    final url = media.url;
+    if (url.startsWith('data:')) {
+      final commaIdx = url.indexOf(',');
+      if (commaIdx != -1) return url.substring(commaIdx + 1);
+    }
+    return url;
+  }
+
+  static String _encodeToolOutput(Object? output) {
+    return output is String ? output : jsonEncode(output);
+  }
+
+  static List<sdk.ToolCall> _extractToolCalls(List<Part> content) {
+    final toolCalls = <sdk.ToolCall>[];
+    for (final part in content) {
+      if (part.isToolRequest) {
+        final req = part.toolRequest!;
+        toolCalls.add(
+          sdk.ToolCall(
+            function: sdk.ToolCallFunction(
+              name: req.name,
+              arguments: req.input ?? const {},
+            ),
+          ),
+        );
+      }
+    }
+    return toolCalls;
+  }
+
+  /// Converts a Genkit tool definition to Ollama's tool schema.
+  static sdk.ToolDefinition toOllamaTool(ToolDefinition tool) {
+    var parameters = tool.inputSchema;
+    if (parameters == null) {
+      parameters = {'type': 'object', 'properties': <String, dynamic>{}};
+    } else if (!parameters.containsKey('type')) {
+      parameters = {'type': 'object', ...parameters};
+    }
+    return sdk.ToolDefinition(
+      function: sdk.ToolFunction(
+        name: tool.name,
+        description: tool.description,
+        parameters: parameters,
+      ),
+    );
+  }
+
+  /// Converts an Ollama response message to a Genkit [Message].
+  static Message fromOllamaMessage(sdk.ChatResponseMessage? msg) {
+    final parts = <Part>[];
+    if (msg != null) {
+      final content = msg.content;
+      if (content != null && content.isNotEmpty) {
+        parts.add(TextPart(text: content));
+      }
+      final toolCalls = msg.toolCalls;
+      if (toolCalls != null) {
+        var index = 0;
+        for (final call in toolCalls) {
+          final fn = call.function;
+          if (fn == null) continue;
+          // Ollama does not return tool-call IDs. Synthesize a stable per-call
+          // ref so that multiple same-named calls in one response don't collide
+          // in Genkit's tool tracking (it otherwise falls back to the name).
+          parts.add(
+            ToolRequestPart(
+              toolRequest: ToolRequest(
+                ref: 'tool_call_$index',
+                name: fn.name,
+                input: fn.arguments,
+              ),
+            ),
+          );
+          index++;
+        }
+      }
+    }
+    return Message(role: Role.model, content: parts);
+  }
+
+  /// Maps an Ollama done reason to a Genkit [FinishReason].
+  static FinishReason mapDoneReason(sdk.DoneReason? reason) {
+    return switch (reason) {
+      sdk.DoneReason.stop => FinishReason.stop,
+      sdk.DoneReason.length => FinishReason.length,
+      sdk.DoneReason.load || sdk.DoneReason.unload => FinishReason.other,
+      null => FinishReason.stop,
+    };
+  }
+
+  /// Builds Ollama [sdk.ModelOptions] from parsed chat options.
+  ///
+  /// Stop sequences are passed as a proper list (the JS plugin joins them with
+  /// the empty string, which corrupts multi-sequence stops).
+  static sdk.ModelOptions? buildModelOptions(ChatModelOptions options) {
+    final stop = options.stop;
+    final modelOptions = sdk.ModelOptions(
+      temperature: options.temperature,
+      topK: options.topK,
+      topP: options.topP,
+      seed: options.seed,
+      numCtx: options.numCtx,
+      numPredict: options.maxOutputTokens,
+      stop: (stop != null && stop.isNotEmpty)
+          ? sdk.StopSequence.list(stop)
+          : null,
+    );
+    return modelOptions;
+  }
+
+  /// Builds an Ollama response format from a Genkit output config.
+  ///
+  /// Returns a schema-constrained format when a schema is present, a plain JSON
+  /// format for `format: 'json'`, or null otherwise.
+  static sdk.ResponseFormat? buildResponseFormat(OutputConfig? output) {
+    if (output == null) return null;
+    if (!isJsonStructuredOutput(output.format, output.contentType)) {
+      return null;
+    }
+    final schema = output.schema;
+    if (schema != null) {
+      return sdk.ResponseFormat.schema(schema);
+    }
+    return const sdk.ResponseFormat.json();
+  }
+
+  /// Parses Ollama's `keep_alive` value, which may be a duration string
+  /// (`'5m'`) or a number (`0`, `-1`).
+  static sdk.KeepAlive? buildKeepAlive(String? keepAlive) {
+    if (keepAlive == null) return null;
+    final asNumber = num.tryParse(keepAlive);
+    return asNumber != null
+        ? sdk.KeepAlive.number(asNumber)
+        : sdk.KeepAlive.duration(keepAlive);
+  }
+
+  /// Extracts the plain-text content of an embedder input document.
+  static String documentText(DocumentData doc) {
+    return doc.content.where((p) => p.isText).map((p) => p.text ?? '').join();
+  }
+}

--- a/packages/genkit_ollama/test/ollama_converters_test.dart
+++ b/packages/genkit_ollama/test/ollama_converters_test.dart
@@ -1,0 +1,389 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_ollama/genkit_ollama.dart';
+import 'package:ollama_dart/ollama_dart.dart' as sdk;
+import 'package:test/test.dart';
+
+void main() {
+  group('toOllamaMessages', () {
+    test('maps a system message', () {
+      final result = GenkitConverter.toOllamaMessages([
+        Message(
+          role: Role.system,
+          content: [TextPart(text: 'be brief')],
+        ),
+      ]);
+      expect(result, hasLength(1));
+      expect(result.first.role, sdk.MessageRole.system);
+      expect(result.first.content, 'be brief');
+    });
+
+    test('maps a user message with text', () {
+      final result = GenkitConverter.toOllamaMessages([
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hello')],
+        ),
+      ]);
+      expect(result.first.role, sdk.MessageRole.user);
+      expect(result.first.content, 'hello');
+      expect(result.first.images, isNull);
+    });
+
+    test('throws on an unsupported part in a user message', () {
+      expect(
+        () => GenkitConverter.toOllamaMessages([
+          Message(
+            role: Role.user,
+            content: [
+              ToolResponsePart(
+                toolResponse: ToolResponse(name: 'x', output: 1),
+              ),
+            ],
+          ),
+        ]),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('strips data-URI prefix from image media', () {
+      final result = GenkitConverter.toOllamaMessages([
+        Message(
+          role: Role.user,
+          content: [
+            TextPart(text: 'describe'),
+            MediaPart(
+              media: Media(
+                url: 'data:image/png;base64,AAAA',
+                contentType: 'image/png',
+              ),
+            ),
+          ],
+        ),
+      ]);
+      expect(result.first.images, ['AAAA']);
+    });
+
+    test('maps an assistant message with tool calls', () {
+      final result = GenkitConverter.toOllamaMessages([
+        Message(
+          role: Role.model,
+          content: [
+            ToolRequestPart(
+              toolRequest: ToolRequest(
+                name: 'getWeather',
+                input: {'city': 'NY'},
+              ),
+            ),
+          ],
+        ),
+      ]);
+      final toolCalls = result.first.toolCalls;
+      expect(toolCalls, hasLength(1));
+      expect(toolCalls!.first.function?.name, 'getWeather');
+      expect(toolCalls.first.function?.arguments, {'city': 'NY'});
+    });
+
+    test('expands a tool message with multiple responses', () {
+      final result = GenkitConverter.toOllamaMessages([
+        Message(
+          role: Role.tool,
+          content: [
+            ToolResponsePart(
+              toolResponse: ToolResponse(name: 'a', output: {'v': 1}),
+            ),
+            ToolResponsePart(
+              toolResponse: ToolResponse(name: 'b', output: 'plain'),
+            ),
+          ],
+        ),
+      ]);
+      expect(result, hasLength(2));
+      expect(result[0].role, sdk.MessageRole.tool);
+      expect(result[0].content, jsonEncode({'v': 1}));
+      // String output is passed through verbatim, not double-encoded.
+      expect(result[1].content, 'plain');
+    });
+
+    test('passes a bare (non-data-URI) image through unchanged', () {
+      final result = GenkitConverter.toOllamaMessages([
+        Message(
+          role: Role.user,
+          content: [
+            MediaPart(
+              media: Media(url: 'AAAA', contentType: 'image/png'),
+            ),
+          ],
+        ),
+      ]);
+      expect(result.first.images, ['AAAA']);
+    });
+
+    test('keeps text and tool calls together in a model message', () {
+      final result = GenkitConverter.toOllamaMessages([
+        Message(
+          role: Role.model,
+          content: [
+            TextPart(text: 'calling tool'),
+            ToolRequestPart(
+              toolRequest: ToolRequest(
+                name: 'getWeather',
+                input: {'city': 'NY'},
+              ),
+            ),
+          ],
+        ),
+      ]);
+      expect(result.first.content, 'calling tool');
+      expect(result.first.toolCalls, hasLength(1));
+    });
+
+    test('throws on a tool message with no tool responses', () {
+      expect(
+        () => GenkitConverter.toOllamaMessages([
+          Message(
+            role: Role.tool,
+            content: [TextPart(text: 'oops')],
+          ),
+        ]),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('toOllamaTool', () {
+    test('wraps a tool definition', () {
+      final tool = GenkitConverter.toOllamaTool(
+        ToolDefinition(
+          name: 'getWeather',
+          description: 'gets weather',
+          inputSchema: {
+            'type': 'object',
+            'properties': {
+              'city': {'type': 'string'},
+            },
+          },
+        ),
+      );
+      expect(tool.function.name, 'getWeather');
+      expect(tool.function.description, 'gets weather');
+      expect(tool.function.parameters['type'], 'object');
+    });
+
+    test('defaults missing schema to an object schema', () {
+      final tool = GenkitConverter.toOllamaTool(
+        ToolDefinition(name: 't', description: 'd'),
+      );
+      expect(tool.function.parameters['type'], 'object');
+    });
+
+    test('injects a type when the schema omits it, keeping other keys', () {
+      final tool = GenkitConverter.toOllamaTool(
+        ToolDefinition(
+          name: 't',
+          description: 'd',
+          inputSchema: {
+            'properties': {
+              'city': {'type': 'string'},
+            },
+          },
+        ),
+      );
+      expect(tool.function.parameters['type'], 'object');
+      expect(tool.function.parameters['properties'], isNotNull);
+    });
+  });
+
+  group('fromOllamaMessage', () {
+    test('maps text content', () {
+      final msg = GenkitConverter.fromOllamaMessage(
+        sdk.ChatResponseMessage(
+          role: sdk.MessageRole.assistant,
+          content: 'hi there',
+        ),
+      );
+      expect(msg.role, Role.model);
+      expect(msg.text, 'hi there');
+    });
+
+    test('yields an empty model message for null or empty content', () {
+      final fromNull = GenkitConverter.fromOllamaMessage(null);
+      expect(fromNull.role, Role.model);
+      expect(fromNull.content, isEmpty);
+
+      final fromEmpty = GenkitConverter.fromOllamaMessage(
+        sdk.ChatResponseMessage(role: sdk.MessageRole.assistant, content: ''),
+      );
+      expect(fromEmpty.content, isEmpty);
+    });
+
+    test('maps tool calls into tool-request parts', () {
+      final msg = GenkitConverter.fromOllamaMessage(
+        sdk.ChatResponseMessage(
+          role: sdk.MessageRole.assistant,
+          content: '',
+          toolCalls: [
+            sdk.ToolCall(
+              function: sdk.ToolCallFunction(
+                name: 'getWeather',
+                arguments: {'city': 'NY'},
+              ),
+            ),
+          ],
+        ),
+      );
+      final part = msg.content.single;
+      expect(part.isToolRequest, isTrue);
+      expect(part.toolRequest!.name, 'getWeather');
+      expect(part.toolRequest!.input, {'city': 'NY'});
+    });
+
+    test('assigns a distinct ref to each tool call', () {
+      final msg = GenkitConverter.fromOllamaMessage(
+        sdk.ChatResponseMessage(
+          role: sdk.MessageRole.assistant,
+          content: '',
+          toolCalls: [
+            sdk.ToolCall(
+              function: sdk.ToolCallFunction(name: 'get', arguments: {'i': 1}),
+            ),
+            sdk.ToolCall(
+              function: sdk.ToolCallFunction(name: 'get', arguments: {'i': 2}),
+            ),
+          ],
+        ),
+      );
+      final refs = msg.content.map((p) => p.toolRequest!.ref).toList();
+      expect(refs, ['tool_call_0', 'tool_call_1']);
+      // Same-named calls get distinct refs, avoiding tracking collisions.
+      expect(refs.toSet(), hasLength(2));
+    });
+  });
+
+  group('buildModelOptions', () {
+    test('passes stop sequences as a list (not joined)', () {
+      final options = GenkitConverter.buildModelOptions(
+        OllamaChatOptions.$schema.parse({
+          'stop': ['END', 'STOP'],
+          'temperature': 0.5,
+          'numCtx': 4096,
+          'maxOutputTokens': 256,
+        }),
+      );
+      expect(options!.stop, isA<sdk.StopList>());
+      expect((options.stop as sdk.StopList).values, ['END', 'STOP']);
+      expect(options.temperature, 0.5);
+      expect(options.numCtx, 4096);
+      expect(options.numPredict, 256);
+    });
+
+    test('omits stop when empty', () {
+      final options = GenkitConverter.buildModelOptions(OllamaChatOptions());
+      expect(options!.stop, isNull);
+    });
+  });
+
+  group('buildResponseFormat', () {
+    test('returns null without structured output', () {
+      expect(GenkitConverter.buildResponseFormat(null), isNull);
+      expect(
+        GenkitConverter.buildResponseFormat(OutputConfig(format: 'text')),
+        isNull,
+      );
+    });
+
+    test('returns a JSON format for format=json without schema', () {
+      final format = GenkitConverter.buildResponseFormat(
+        OutputConfig(format: 'json'),
+      );
+      expect(format, isA<sdk.JsonFormat>());
+    });
+
+    test('returns a schema format when a schema is present', () {
+      final format = GenkitConverter.buildResponseFormat(
+        OutputConfig(
+          format: 'json',
+          schema: {
+            'type': 'object',
+            'properties': {
+              'x': {'type': 'string'},
+            },
+          },
+        ),
+      );
+      expect(format, isA<sdk.SchemaFormat>());
+    });
+  });
+
+  group('buildKeepAlive', () {
+    test('parses numeric values', () {
+      expect(GenkitConverter.buildKeepAlive('0'), isA<sdk.KeepAliveNumber>());
+      expect(GenkitConverter.buildKeepAlive('-1'), isA<sdk.KeepAliveNumber>());
+    });
+
+    test('parses duration strings', () {
+      expect(
+        GenkitConverter.buildKeepAlive('5m'),
+        isA<sdk.KeepAliveDuration>(),
+      );
+    });
+
+    test('returns null when unset', () {
+      expect(GenkitConverter.buildKeepAlive(null), isNull);
+    });
+  });
+
+  group('mapDoneReason', () {
+    test('maps known reasons', () {
+      expect(
+        GenkitConverter.mapDoneReason(sdk.DoneReason.stop),
+        FinishReason.stop,
+      );
+      expect(
+        GenkitConverter.mapDoneReason(sdk.DoneReason.length),
+        FinishReason.length,
+      );
+      expect(GenkitConverter.mapDoneReason(null), FinishReason.stop);
+    });
+
+    test('maps load/unload to other', () {
+      expect(
+        GenkitConverter.mapDoneReason(sdk.DoneReason.load),
+        FinishReason.other,
+      );
+      expect(
+        GenkitConverter.mapDoneReason(sdk.DoneReason.unload),
+        FinishReason.other,
+      );
+    });
+  });
+
+  group('documentText', () {
+    test('joins text parts', () {
+      final text = GenkitConverter.documentText(
+        DocumentData(
+          content: [
+            TextPart(text: 'foo'),
+            TextPart(text: 'bar'),
+          ],
+        ),
+      );
+      expect(text, 'foobar');
+    });
+  });
+}


### PR DESCRIPTION
## genkit_ollama (2/N): Genkit ⇄ ollama_dart converters

The pure conversion layer between Genkit types and the `ollama_dart` SDK. No
network or plugin wiring — that arrives in a later PR. Fully unit-tested.

**Base:** `feat/genkit_ollama` (1/N scaffold). Part of the `genkit_ollama` series.

### What's here
- Message/part conversion for all roles (system/user/model/tool), expanding a
  multi-response tool message into one Ollama `tool` message each.
- Vision: image media stripped of any `data:` URI prefix to bare base64.
- Tool calls in both directions; responses get a distinct synthetic `ref`
  (`tool_call_<index>`) so multiple same-named calls don't collide in tracking.
- `buildModelOptions` — stop sequences passed as a **list** (not joined into one
  string), plus `numCtx`, `numPredict`, temperature/topK/topP/seed.
- `buildResponseFormat` — Genkit `output.schema` → Ollama `format` (JSON /
  JSON-schema constrained decoding).
- `buildKeepAlive` (duration string vs numeric) and `mapDoneReason`.
- Unsupported parts in a *user* message throw (consistent with the sibling
  OpenAI converter) rather than being silently dropped.

### Tests
Unit tests cover every conversion path: roles, images, tools (incl. distinct
refs), stop-as-list, format (json vs schema), keepAlive coercion, done-reason
mapping, and the throw/skip edge cases.

---

### Series (review bottom-up)
| PR | Scope |
|----|-------|
| #305 | 1/5 — scaffold + `OllamaChatOptions` schema |
| #306 | 2/5 — Genkit ⇄ ollama_dart converters |
| #307 | 3/5 — `/api/show` capability + dimension helpers |
| #308 | 4/5 — plugin wiring (model, embedder, discovery) |
| #309 | 5/5 — example, README, CHANGELOG, live tests |
