### PR TITLE
feat(ollama): /api/show capability + dimension helpers

### DIFF
--- a/packages/genkit_ollama/lib/genkit_ollama.dart
+++ b/packages/genkit_ollama/lib/genkit_ollama.dart
@@ -14,6 +14,12 @@
 
 export 'src/chat.dart' show OllamaChatOptions;
 export 'src/converters.dart' show GenkitConverter;
+export 'src/utils.dart'
+    show
+        embeddingDimensionsFromShow,
+        genericModelInfo,
+        isEmbedderShow,
+        modelInfoFromShow;
 
 /// Default plugin / namespace name used when no custom name is provided.
 const String defaultOllamaNamespace = 'ollama';

--- a/packages/genkit_ollama/lib/src/utils.dart
+++ b/packages/genkit_ollama/lib/src/utils.dart
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:ollama_dart/ollama_dart.dart' as sdk;
+
+/// Generic capability profile used when `/api/show` does not report a
+/// `capabilities` array (older Ollama servers).
+///
+/// Conservatively assumes a chat model: multiturn + system role + tools, no
+/// vision. Constrained output is enabled because Ollama applies `format` at the
+/// server regardless of model.
+ModelInfo genericModelInfo(String model) {
+  return ModelInfo(
+    label: model,
+    supports: const {
+      'multiturn': true,
+      'systemRole': true,
+      'tools': true,
+      'media': false,
+      'constrained': true,
+    },
+  );
+}
+
+/// Builds an accurate [ModelInfo] from an Ollama `/api/show` response.
+///
+/// Maps Ollama's `capabilities` array to Genkit's `supports` flags. Falls back
+/// to [genericModelInfo] when capabilities are absent.
+ModelInfo modelInfoFromShow(String model, sdk.ShowResponse show) {
+  final capabilities = show.capabilities;
+  if (capabilities == null || capabilities.isEmpty) {
+    return genericModelInfo(model);
+  }
+  final caps = capabilities.map((c) => c.toLowerCase()).toSet();
+  return ModelInfo(
+    label: model,
+    supports: {
+      'multiturn': caps.contains('completion'),
+      'systemRole': true,
+      'tools': caps.contains('tools'),
+      'media': caps.contains('vision'),
+      // Ollama applies `format` constrained decoding for any completion model.
+      'constrained': caps.contains('completion'),
+    },
+  );
+}
+
+/// Returns true when an Ollama `/api/show` response describes an embedding
+/// model.
+bool isEmbedderShow(sdk.ShowResponse show) {
+  final caps = show.capabilities;
+  return caps != null && caps.any((c) => c.toLowerCase() == 'embedding');
+}
+
+/// Extracts the embedding dimension from an Ollama `/api/show` response.
+///
+/// Ollama exposes this under a `model_info` key shaped like
+/// `<architecture>.embedding_length` (e.g. `bert.embedding_length`). Returns
+/// null when not reported.
+int? embeddingDimensionsFromShow(sdk.ShowResponse show) {
+  final info = show.modelInfo;
+  if (info == null) return null;
+  for (final entry in info.entries) {
+    if (entry.key.endsWith('.embedding_length')) {
+      final value = entry.value;
+      if (value is int) return value;
+      if (value is num) return value.toInt();
+      if (value is String) return int.tryParse(value);
+    }
+  }
+  return null;
+}

--- a/packages/genkit_ollama/test/ollama_utils_test.dart
+++ b/packages/genkit_ollama/test/ollama_utils_test.dart
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit_ollama/genkit_ollama.dart';
+import 'package:ollama_dart/ollama_dart.dart' as sdk;
+import 'package:test/test.dart';
+
+void main() {
+  group('modelInfoFromShow', () {
+    test('maps capabilities to supports flags', () {
+      final info = modelInfoFromShow(
+        'llama3.2',
+        sdk.ShowResponse(capabilities: ['completion', 'tools']),
+      );
+      final supports = info.supports!;
+      expect(supports['multiturn'], isTrue);
+      expect(supports['tools'], isTrue);
+      expect(supports['media'], isFalse);
+      expect(supports['constrained'], isTrue);
+    });
+
+    test('flags vision models as media-capable', () {
+      final info = modelInfoFromShow(
+        'llava',
+        sdk.ShowResponse(capabilities: ['completion', 'vision']),
+      );
+      expect(info.supports!['media'], isTrue);
+    });
+
+    test('falls back to a generic profile without capabilities', () {
+      final info = modelInfoFromShow('mystery', sdk.ShowResponse());
+      expect(info.supports!['tools'], isTrue);
+      expect(info.supports!['media'], isFalse);
+    });
+  });
+
+  group('isEmbedderShow', () {
+    test('detects the embedding capability', () {
+      expect(
+        isEmbedderShow(sdk.ShowResponse(capabilities: ['embedding'])),
+        isTrue,
+      );
+      expect(
+        isEmbedderShow(sdk.ShowResponse(capabilities: ['completion'])),
+        isFalse,
+      );
+    });
+
+    test('returns false when capabilities are absent', () {
+      expect(isEmbedderShow(sdk.ShowResponse()), isFalse);
+    });
+  });
+
+  group('embeddingDimensionsFromShow', () {
+    test('reads <arch>.embedding_length', () {
+      final dims = embeddingDimensionsFromShow(
+        sdk.ShowResponse(modelInfo: {'bert.embedding_length': 768}),
+      );
+      expect(dims, 768);
+    });
+
+    test('coerces num and string values to int', () {
+      expect(
+        embeddingDimensionsFromShow(
+          sdk.ShowResponse(modelInfo: {'bert.embedding_length': 768.0}),
+        ),
+        768,
+      );
+      expect(
+        embeddingDimensionsFromShow(
+          sdk.ShowResponse(modelInfo: {'bert.embedding_length': '768'}),
+        ),
+        768,
+      );
+    });
+
+    test('returns null when absent', () {
+      expect(embeddingDimensionsFromShow(sdk.ShowResponse()), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## genkit_ollama (3/N): /api/show capability + dimension helpers

Per-model metadata helpers used by model/embedder discovery (wired up in the next
PR). Pure functions, unit-tested.

**Base:** `feat/genkit_ollama-converters` (2/N). Part of the `genkit_ollama` series.

### What's here
- `modelInfoFromShow` — maps Ollama's `/api/show` `capabilities` array
  (`completion`/`tools`/`vision`/`embedding`) onto Genkit's `supports` flags,
  with a `genericModelInfo` fallback for older servers that don't report
  capabilities.
- `isEmbedderShow` — detects embedding models via the `embedding` capability.
- `embeddingDimensionsFromShow` — reads `<arch>.embedding_length` from
  `model_info` (with num/string coercion), so embedder dimensions are
  auto-discovered rather than hand-declared.

### Why per-model
Ollama models are heterogeneous (vision-only, tool-capable, embedding-only).
Reading real capabilities per model keeps the advertised `supports` accurate
instead of applying one blanket profile.

---

### Series (review bottom-up)
| PR | Scope |
|----|-------|
| #305 | 1/5 — scaffold + `OllamaChatOptions` schema |
| #306 | 2/5 — Genkit ⇄ ollama_dart converters |
| #307 | 3/5 — `/api/show` capability + dimension helpers |
| #308 | 4/5 — plugin wiring (model, embedder, discovery) |
| #309 | 5/5 — example, README, CHANGELOG, live tests |
