### PR TITLE
feat(ollama): wire the plugin (model, embedder, discovery)

### DIFF
--- a/packages/genkit_ollama/lib/genkit_ollama.dart
+++ b/packages/genkit_ollama/lib/genkit_ollama.dart
@@ -12,8 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
+
+import 'package:genkit/plugin.dart';
+import 'package:http/http.dart' as http;
+
+import 'src/chat.dart' as chat;
+import 'src/ollama_plugin.dart';
+
 export 'src/chat.dart' show OllamaChatOptions;
 export 'src/converters.dart' show GenkitConverter;
+export 'src/ollama_plugin.dart' show OllamaPlugin, defaultOllamaBaseUrl;
 export 'src/utils.dart'
     show
         embeddingDimensionsFromShow,
@@ -23,3 +32,103 @@ export 'src/utils.dart'
 
 /// Default plugin / namespace name used when no custom name is provided.
 const String defaultOllamaNamespace = 'ollama';
+
+/// Signature for an async callback that returns HTTP headers per request.
+///
+/// Use this to inject short-lived auth tokens when talking to a remote or
+/// proxied Ollama deployment.
+typedef OllamaHeadersProvider = FutureOr<Map<String, String>> Function();
+
+/// Defines a model to register eagerly with optional capability metadata.
+///
+/// On-demand resolution (via [OllamaPluginHandle.model]) covers most cases;
+/// use this to pin a model and its [info] at init time.
+class CustomModelDefinition {
+  /// The model identifier, e.g. `'llama3.2'`.
+  final String name;
+
+  /// Optional capability metadata. When null, a generic profile is used.
+  final ModelInfo? info;
+
+  /// Creates a custom model definition.
+  const CustomModelDefinition({required this.name, this.info});
+}
+
+/// Defines an embedder to register eagerly.
+class OllamaEmbedderDefinition {
+  /// The embedding model identifier, e.g. `'nomic-embed-text'`.
+  final String name;
+
+  /// Optional embedding dimension. When null, it is discovered via `/api/show`
+  /// during [OllamaPluginHandle.call]'s `list()`, or left unset.
+  final int? dimensions;
+
+  /// Creates an embedder definition.
+  const OllamaEmbedderDefinition({required this.name, this.dimensions});
+}
+
+/// Public constant handle for the Ollama plugin.
+///
+/// ```dart
+/// final ai = Genkit(plugins: [ollama()]);
+///
+/// final response = await ai.generate(
+///   model: ollama.model('llama3.2'),
+///   prompt: 'Hello!',
+/// );
+/// ```
+const OllamaPluginHandle ollama = OllamaPluginHandle();
+
+/// Handle class for configuring and referencing Ollama models and embedders.
+///
+/// Typically accessed via the top-level [ollama] constant.
+class OllamaPluginHandle {
+  /// Creates a new [OllamaPluginHandle].
+  const OllamaPluginHandle();
+
+  /// Creates the plugin instance.
+  ///
+  /// [baseUrl] defaults to a local server (`http://localhost:11434`). Provide
+  /// [headers] for static headers, or [headersProvider] for per-request auth.
+  GenkitPlugin call({
+    String name = defaultOllamaNamespace,
+    String? baseUrl,
+    Map<String, String>? headers,
+    OllamaHeadersProvider? headersProvider,
+    List<CustomModelDefinition>? models,
+    List<OllamaEmbedderDefinition>? embedders,
+    http.Client? httpClient,
+  }) {
+    return OllamaPlugin(
+      name: name,
+      baseUrl: baseUrl,
+      headers: headers,
+      headersProvider: headersProvider,
+      customModels: models ?? const [],
+      customEmbedders: embedders ?? const [],
+      httpClient: httpClient,
+    );
+  }
+
+  /// Returns a reference to an Ollama chat model.
+  ///
+  /// The [namespace] defaults to [defaultOllamaNamespace]; pass a custom value
+  /// when the plugin was created with a custom name.
+  ModelRef<chat.OllamaChatOptions> model(
+    String name, {
+    String namespace = defaultOllamaNamespace,
+  }) {
+    return modelRef(
+      '$namespace/$name',
+      customOptions: chat.chatModelOptionsSchema(),
+    );
+  }
+
+  /// Returns a reference to an Ollama embedder.
+  EmbedderRef<dynamic> embedder(
+    String name, {
+    String namespace = defaultOllamaNamespace,
+  }) {
+    return embedderRef('$namespace/$name');
+  }
+}

--- a/packages/genkit_ollama/lib/src/ollama_plugin.dart
+++ b/packages/genkit_ollama/lib/src/ollama_plugin.dart
@@ -1,0 +1,342 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+import 'package:http/http.dart' as http;
+import 'package:ollama_dart/ollama_dart.dart' as sdk;
+
+import '../genkit_ollama.dart';
+import 'chat.dart' as chat;
+
+/// Default address of a local Ollama server.
+const String defaultOllamaBaseUrl = 'http://localhost:11434';
+
+/// Core Genkit plugin implementation for the Ollama API.
+///
+/// Models and embedders can be referenced directly (via [ollama]) and are
+/// resolved on demand. Local models are also discoverable via [list], which
+/// reads `/api/tags` and enriches each entry with accurate capability metadata
+/// from `/api/show`.
+class OllamaPlugin extends GenkitPlugin {
+  final String _pluginName;
+
+  @override
+  String get name => _pluginName;
+
+  /// Base URL of the Ollama server. Defaults to [defaultOllamaBaseUrl].
+  final String baseUrl;
+
+  /// Static headers sent with every request.
+  final Map<String, String>? headers;
+
+  /// Async callback returning headers (e.g. a bearer token) per request.
+  final OllamaHeadersProvider? headersProvider;
+
+  /// Models registered eagerly at init time, beyond on-demand resolution.
+  final List<CustomModelDefinition> customModels;
+
+  /// Embedders registered eagerly at init time.
+  final List<OllamaEmbedderDefinition> customEmbedders;
+
+  /// Optional HTTP client for dependency injection and testing.
+  final http.Client? httpClient;
+
+  /// Creates an [OllamaPlugin].
+  OllamaPlugin({
+    String name = defaultOllamaNamespace,
+    String? baseUrl,
+    this.headers,
+    this.headersProvider,
+    this.customModels = const [],
+    this.customEmbedders = const [],
+    this.httpClient,
+  }) : _pluginName = name,
+       baseUrl = baseUrl ?? defaultOllamaBaseUrl {
+    if (name.isEmpty || name.contains('/')) {
+      throw GenkitException(
+        'Plugin name must be non-empty and must not contain "/". Got: "$name"',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+  }
+
+  @override
+  Future<List<Action>> init() async {
+    final actions = <Action>[];
+    for (final model in customModels) {
+      actions.add(_createModel(model.name, model.info));
+    }
+    for (final embedder in customEmbedders) {
+      actions.add(_createEmbedder(embedder.name, embedder.dimensions));
+    }
+    return actions;
+  }
+
+  @override
+  Action? resolve(String actionType, String name) {
+    if (actionType == 'model') {
+      return _createModel(name, null);
+    }
+    if (actionType == 'embedder') {
+      return _createEmbedder(name, null);
+    }
+    return null;
+  }
+
+  @override
+  Future<List<ActionMetadata<dynamic, dynamic, dynamic, dynamic>>>
+  list() async {
+    final client = await _buildClient();
+    try {
+      final tags = await client.models.list();
+      final summaries = tags.models ?? const [];
+
+      final metadataResults = await Future.wait(
+        summaries.map((summary) async {
+          final modelId = summary.model;
+          if (modelId == null || modelId.isEmpty) return null;
+          try {
+            final show = await client.models.show(
+              request: sdk.ShowRequest(model: modelId),
+            );
+            if (isEmbedderShow(show)) {
+              return _embedderMetadata(
+                modelId,
+                embeddingDimensionsFromShow(show),
+              );
+            }
+            return modelMetadata(
+              '$_pluginName/$modelId',
+              modelInfo: modelInfoFromShow(modelId, show),
+              customOptions: chat.chatModelOptionsSchema(),
+            );
+          } catch (_) {
+            // Fall back to a generic profile when /api/show fails.
+            return modelMetadata(
+              '$_pluginName/$modelId',
+              modelInfo: genericModelInfo(modelId),
+              customOptions: chat.chatModelOptionsSchema(),
+            );
+          }
+        }),
+      );
+
+      return metadataResults
+          .whereType<ActionMetadata<dynamic, dynamic, dynamic, dynamic>>()
+          .toList();
+    } catch (e, stackTrace) {
+      throw GenkitException(
+        'Error listing models from $_pluginName. '
+        'Make sure the Ollama server is running at $baseUrl. ($e)',
+        underlyingException: e,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      if (httpClient == null) client.close();
+    }
+  }
+
+  Future<sdk.OllamaClient> _buildClient() async {
+    final resolvedHeaders = <String, String>{
+      ...?headers,
+      ...?(await headersProvider?.call()),
+    };
+    return sdk.OllamaClient(
+      config: sdk.OllamaConfig(
+        baseUrl: baseUrl,
+        defaultHeaders: resolvedHeaders,
+      ),
+      httpClient: httpClient,
+    );
+  }
+
+  /// Builds embedder discovery metadata, including the auto-detected embedding
+  /// [dimensions] from `/api/show` when available.
+  ActionMetadata<dynamic, dynamic, dynamic, dynamic> _embedderMetadata(
+    String modelId,
+    int? dimensions,
+  ) {
+    final name = '$_pluginName/$modelId';
+    return ActionMetadata(
+      name: name,
+      description: name,
+      actionType: 'embedder',
+      metadata: {
+        'label': name,
+        'description': name,
+        'model': {
+          'label': name,
+          'dimensions': ?dimensions,
+          'supports': {
+            'input': ['text'],
+          },
+        },
+      },
+    );
+  }
+
+  Model _createModel(String modelName, ModelInfo? info) {
+    final modelInfo = info ?? genericModelInfo(modelName);
+
+    return Model(
+      name: '$_pluginName/$modelName',
+      customOptions: chat.chatModelOptionsSchema(),
+      metadata: {'model': modelInfo.toJson()},
+      fn: (req, ctx) async {
+        final modelRequest = req!;
+        final options = chat.parseChatModelOptions(modelRequest.config);
+        final tools = modelRequest.tools;
+
+        final request = sdk.ChatRequest(
+          model: modelName,
+          messages: GenkitConverter.toOllamaMessages(modelRequest.messages),
+          tools: (tools != null && tools.isNotEmpty)
+              ? tools.map(GenkitConverter.toOllamaTool).toList()
+              : null,
+          format: GenkitConverter.buildResponseFormat(modelRequest.output),
+          options: GenkitConverter.buildModelOptions(options),
+          keepAlive: GenkitConverter.buildKeepAlive(options.keepAlive),
+          stream: ctx.streamingRequested,
+        );
+
+        final client = await _buildClient();
+        try {
+          if (ctx.streamingRequested) {
+            return await _generateStream(client, request, ctx.sendChunk);
+          }
+          final response = await client.chat.create(request: request);
+          return ModelResponse(
+            finishReason: GenkitConverter.mapDoneReason(response.doneReason),
+            message: GenkitConverter.fromOllamaMessage(response.message),
+            raw: response.toJson(),
+          );
+        } catch (e, stackTrace) {
+          throw _wrapError(
+            e,
+            stackTrace,
+            'Ollama API error for model "$modelName". '
+            'Make sure the Ollama server is running at $baseUrl '
+            'and the model is pulled.',
+          );
+        } finally {
+          if (httpClient == null) client.close();
+        }
+      },
+    );
+  }
+
+  /// Wraps an arbitrary error into a [GenkitException], rethrowing existing
+  /// ones and mapping the Ollama SDK's HTTP status onto a [StatusCodes].
+  GenkitException _wrapError(Object e, StackTrace stackTrace, String message) {
+    if (e is GenkitException) return e;
+    StatusCodes? status;
+    if (e is sdk.ApiException) {
+      status = StatusCodes.fromHttpStatus(e.statusCode);
+    }
+    return GenkitException(
+      '$message ($e)',
+      status: status,
+      underlyingException: e,
+      stackTrace: stackTrace,
+    );
+  }
+
+  Future<ModelResponse> _generateStream(
+    sdk.OllamaClient client,
+    sdk.ChatRequest request,
+    void Function(ModelResponseChunk) sendChunk,
+  ) async {
+    final textBuffer = StringBuffer();
+    sdk.ChatResponseMessage? lastMessage;
+    sdk.DoneReason? doneReason;
+    sdk.ChatStreamEvent? lastEvent;
+
+    await for (final event in client.chat.createStream(request: request)) {
+      lastEvent = event;
+      final message = event.message;
+      if (message != null) {
+        lastMessage = message;
+        final content = message.content;
+        if (content != null && content.isNotEmpty) {
+          textBuffer.write(content);
+          sendChunk(
+            ModelResponseChunk(index: 0, content: [TextPart(text: content)]),
+          );
+        }
+      }
+      if (event.doneReason != null) doneReason = event.doneReason;
+    }
+
+    // Reconstruct the aggregated message: streamed text plus any tool calls
+    // surfaced on the final event.
+    final aggregated = sdk.ChatResponseMessage(
+      role: sdk.MessageRole.assistant,
+      content: textBuffer.toString(),
+      toolCalls: lastMessage?.toolCalls,
+    );
+
+    return ModelResponse(
+      finishReason: GenkitConverter.mapDoneReason(doneReason),
+      message: GenkitConverter.fromOllamaMessage(aggregated),
+      raw: lastEvent?.toJson(),
+    );
+  }
+
+  Embedder _createEmbedder(String embedderName, int? dimensions) {
+    return Embedder(
+      name: '$_pluginName/$embedderName',
+      metadata: {
+        'model': {
+          'label': '$_pluginName/$embedderName',
+          'dimensions': ?dimensions,
+          'supports': {
+            'input': ['text'],
+          },
+        },
+      },
+      fn: (req, ctx) async {
+        final embedRequest = req!;
+        final texts = embedRequest.input
+            .map(GenkitConverter.documentText)
+            .toList();
+
+        final client = await _buildClient();
+        try {
+          final response = await client.embeddings.create(
+            request: sdk.EmbedRequest(
+              model: embedderName,
+              input: sdk.EmbedInput.list(texts),
+            ),
+          );
+          final vectors = response.embeddings ?? const [];
+          return EmbedResponse(
+            embeddings: vectors
+                .map((vector) => Embedding(embedding: vector))
+                .toList(),
+          );
+        } catch (e, stackTrace) {
+          throw _wrapError(
+            e,
+            stackTrace,
+            'Ollama embedding error for model "$embedderName". '
+            'Make sure the Ollama server is running at $baseUrl '
+            'and the model is pulled.',
+          );
+        } finally {
+          if (httpClient == null) client.close();
+        }
+      },
+    );
+  }
+}

--- a/packages/genkit_ollama/test/ollama_plugin_chat_test.dart
+++ b/packages/genkit_ollama/test/ollama_plugin_chat_test.dart
@@ -1,0 +1,363 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_ollama/genkit_ollama.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Builds a [MockClient] that records requests and replies with [chatBody] for
+/// `/api/chat` and [embedBody] for `/api/embed`.
+MockClient _mockClient({
+  Map<String, dynamic>? chatBody,
+  Map<String, dynamic>? embedBody,
+  List<http.Request>? captured,
+}) {
+  return MockClient((request) async {
+    captured?.add(request);
+    final path = request.url.path;
+    if (path.endsWith('/api/chat')) {
+      return http.Response(
+        jsonEncode(chatBody ?? const {}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (path.endsWith('/api/embed')) {
+      return http.Response(
+        jsonEncode(embedBody ?? const {}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('not found: $path', 404);
+  });
+}
+
+OllamaPlugin _plugin(http.Client client) =>
+    ollama(httpClient: client) as OllamaPlugin;
+
+void main() {
+  group('model generate (non-streaming)', () {
+    test('returns the assistant message', () async {
+      final plugin = _plugin(
+        _mockClient(
+          chatBody: {
+            'model': 'llama3.2',
+            'message': {'role': 'assistant', 'content': 'Hello there!'},
+            'done': true,
+            'done_reason': 'stop',
+          },
+        ),
+      );
+      final model = plugin.resolve('model', 'llama3.2')!;
+
+      final result = await model.call(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'hi')],
+            ),
+          ],
+        ),
+      );
+
+      final response = result as ModelResponse;
+      expect(response.message!.text, 'Hello there!');
+      expect(response.finishReason, FinishReason.stop);
+    });
+
+    test('sends options, stop list, and format on the request', () async {
+      final captured = <http.Request>[];
+      final plugin = _plugin(
+        _mockClient(
+          captured: captured,
+          chatBody: {
+            'message': {'role': 'assistant', 'content': 'ok'},
+            'done': true,
+            'done_reason': 'stop',
+          },
+        ),
+      );
+      final model = plugin.resolve('model', 'llama3.2')!;
+
+      await model.call(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'hi')],
+            ),
+          ],
+          config: {
+            'temperature': 0.5,
+            'numCtx': 4096,
+            'stop': ['END', 'STOP'],
+          },
+          output: OutputConfig(format: 'json'),
+        ),
+      );
+
+      final body = jsonDecode(captured.single.body) as Map<String, dynamic>;
+      final options = body['options'] as Map<String, dynamic>;
+      expect(options['temperature'], 0.5);
+      expect(options['num_ctx'], 4096);
+      // Stop sequences are a real list, not a joined string.
+      expect(options['stop'], ['END', 'STOP']);
+      expect(body['format'], 'json');
+    });
+
+    test('maps tool calls in the response', () async {
+      final plugin = _plugin(
+        _mockClient(
+          chatBody: {
+            'message': {
+              'role': 'assistant',
+              'content': '',
+              'tool_calls': [
+                {
+                  'function': {
+                    'name': 'getWeather',
+                    'arguments': {'city': 'NY'},
+                  },
+                },
+              ],
+            },
+            'done': true,
+            'done_reason': 'stop',
+          },
+        ),
+      );
+      final model = plugin.resolve('model', 'llama3.2')!;
+
+      final result =
+          await model.call(
+                ModelRequest(
+                  messages: [
+                    Message(
+                      role: Role.user,
+                      content: [TextPart(text: 'hi')],
+                    ),
+                  ],
+                ),
+              )
+              as ModelResponse;
+
+      final part = result.message!.content.single;
+      expect(part.isToolRequest, isTrue);
+      expect(part.toolRequest!.name, 'getWeather');
+    });
+  });
+
+  group('embedder', () {
+    test('returns embedding vectors', () async {
+      final plugin = _plugin(
+        _mockClient(
+          embedBody: {
+            'model': 'nomic-embed-text',
+            'embeddings': [
+              [0.1, 0.2, 0.3],
+            ],
+          },
+        ),
+      );
+      final embedder = plugin.resolve('embedder', 'nomic-embed-text')!;
+
+      final result =
+          await embedder.call(
+                EmbedRequest(
+                  input: [
+                    DocumentData(content: [TextPart(text: 'hello')]),
+                  ],
+                ),
+              )
+              as EmbedResponse;
+
+      expect(result.embeddings.single.embedding, [0.1, 0.2, 0.3]);
+    });
+  });
+
+  group('list', () {
+    test('discovers embedders with auto-detected dimensions', () async {
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path.endsWith('/api/tags')) {
+          return http.Response(
+            jsonEncode({
+              'models': [
+                {'model': 'nomic-embed-text', 'name': 'nomic-embed-text'},
+              ],
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        if (path.endsWith('/api/show')) {
+          return http.Response(
+            jsonEncode({
+              'capabilities': ['embedding'],
+              'model_info': {'bert.embedding_length': 768},
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('not found: $path', 404);
+      });
+
+      final metadata = await _plugin(client).list();
+      final embedder = metadata.firstWhere(
+        (m) => m.name == 'ollama/nomic-embed-text',
+      );
+      final model = embedder.metadata['model'] as Map<String, dynamic>;
+      expect(model['dimensions'], 768);
+    });
+  });
+
+  group('streaming', () {
+    test('forwards chunks and aggregates the final message', () async {
+      // Ollama streams newline-delimited JSON objects.
+      final ndjson = [
+        jsonEncode({
+          'message': {'role': 'assistant', 'content': 'Hello'},
+          'done': false,
+        }),
+        jsonEncode({
+          'message': {'role': 'assistant', 'content': ' world'},
+          'done': true,
+          'done_reason': 'stop',
+        }),
+      ].join('\n');
+
+      final client = MockClient((request) async {
+        return http.Response(
+          ndjson,
+          200,
+          headers: {'content-type': 'application/x-ndjson'},
+        );
+      });
+      final model = _plugin(client).resolve('model', 'llama3.2')!;
+
+      final chunks = <String>[];
+      final result =
+          await model.call(
+                ModelRequest(
+                  messages: [
+                    Message(
+                      role: Role.user,
+                      content: [TextPart(text: 'hi')],
+                    ),
+                  ],
+                ),
+                onChunk: (chunk) {
+                  final c = chunk as ModelResponseChunk;
+                  for (final part in c.content) {
+                    if (part.isText) chunks.add(part.text!);
+                  }
+                },
+              )
+              as ModelResponse;
+
+      expect(chunks, ['Hello', ' world']);
+      expect(result.message!.text, 'Hello world');
+      expect(result.finishReason, FinishReason.stop);
+    });
+  });
+
+  group('error wrapping', () {
+    test(
+      'maps an Ollama HTTP error to a GenkitException with status',
+      () async {
+        final client = MockClient((request) async {
+          return http.Response(
+            jsonEncode({'error': 'model "nope" not found'}),
+            404,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+        final model = _plugin(client).resolve('model', 'nope')!;
+
+        await expectLater(
+          model.call(
+            ModelRequest(
+              messages: [
+                Message(
+                  role: Role.user,
+                  content: [TextPart(text: 'hi')],
+                ),
+              ],
+            ),
+          ),
+          throwsA(
+            isA<GenkitException>().having(
+              (e) => e.status,
+              'status',
+              StatusCodes.NOT_FOUND,
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('headers', () {
+    test(
+      'merges static headers with an async provider (provider wins)',
+      () async {
+        final captured = <http.Request>[];
+        final client = MockClient((request) async {
+          captured.add(request);
+          return http.Response(
+            jsonEncode({
+              'message': {'role': 'assistant', 'content': 'ok'},
+              'done': true,
+              'done_reason': 'stop',
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final plugin =
+            ollama(
+                  httpClient: client,
+                  headers: {'X-Static': '1', 'X-Override': 'static'},
+                  headersProvider: () async => {'X-Override': 'provider'},
+                )
+                as OllamaPlugin;
+
+        await plugin
+            .resolve('model', 'llama3.2')!
+            .call(
+              ModelRequest(
+                messages: [
+                  Message(
+                    role: Role.user,
+                    content: [TextPart(text: 'hi')],
+                  ),
+                ],
+              ),
+            );
+
+        final headers = captured.single.headers;
+        expect(headers['x-static'], '1');
+        expect(headers['x-override'], 'provider');
+      },
+    );
+  });
+}

--- a/packages/genkit_ollama/test/ollama_plugin_core_test.dart
+++ b/packages/genkit_ollama/test/ollama_plugin_core_test.dart
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_ollama/genkit_ollama.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Plugin Handle', () {
+    test('creates a plugin instance', () {
+      expect(ollama(), isNotNull);
+    });
+
+    test('creates a plugin instance with a custom base URL', () {
+      expect(ollama(baseUrl: 'http://remote:11434'), isNotNull);
+    });
+
+    test('rejects an empty name', () {
+      expect(
+        () => ollama(name: ''),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
+    test('rejects a name containing a slash', () {
+      expect(() => ollama(name: 'a/b'), throwsA(isA<GenkitException>()));
+    });
+
+    test('creates a model reference', () {
+      expect(ollama.model('llama3.2').name, 'ollama/llama3.2');
+    });
+
+    test('creates a model reference with a custom namespace', () {
+      expect(
+        ollama.model('llama3.2', namespace: 'local').name,
+        'local/llama3.2',
+      );
+    });
+
+    test('creates an embedder reference', () {
+      expect(
+        ollama.embedder('nomic-embed-text').name,
+        'ollama/nomic-embed-text',
+      );
+    });
+
+    test('defaults the base URL to localhost', () {
+      final plugin = ollama() as OllamaPlugin;
+      expect(plugin.baseUrl, defaultOllamaBaseUrl);
+    });
+  });
+
+  group('init', () {
+    test('registers configured models and embedders', () async {
+      final plugin =
+          ollama(
+                models: [const CustomModelDefinition(name: 'llama3.2')],
+                embedders: [
+                  const OllamaEmbedderDefinition(
+                    name: 'nomic-embed-text',
+                    dimensions: 768,
+                  ),
+                ],
+              )
+              as OllamaPlugin;
+      final actions = await plugin.init();
+      final names = actions.map((a) => a.name).toList();
+      expect(names, contains('ollama/llama3.2'));
+      expect(names, contains('ollama/nomic-embed-text'));
+    });
+  });
+}


### PR DESCRIPTION
## genkit_ollama (4/N): plugin wiring (model, embedder, discovery)

Assembles the converters (2/N) and capability helpers (3/N) into the working
plugin.

**Base:** `feat/genkit_ollama-utils` (3/N). Part of the `genkit_ollama` series.

### What's here
- `OllamaPlugin` with `init` / `resolve` / `list`. Discovery reads `/api/tags`
  then enriches each model via `/api/show` concurrently; a failing `/api/show`
  falls back to a generic profile per model (one bad model won't break the list).
- Chat generation, streaming (forwards chunks, aggregates the final message and
  tool calls) and non-streaming.
- Tools, vision, constrained output, embeddings (discovered embedders expose
  auto-detected dimensions).
- Per-request client lifecycle with `http.Client` injection; the client is only
  closed when the plugin owns it.
- Errors wrapped into `GenkitException`, mapping the SDK's HTTP status onto
  `StatusCodes` (e.g. 404 → NOT_FOUND).
- Public `ollama` handle: `ollama()`, `ollama.model(...)`, `ollama.embedder(...)`,
  static `headers` + async `headersProvider` for authenticated remote servers.

### Tests
Mocked end-to-end via an injected `http.Client`: non-stream chat, options/stop/
format serialization, tool-call responses, streaming (NDJSON), embeddings,
discovery with auto-dimensions, error→status mapping, and header merge.

---

### Series (review bottom-up)
| PR | Scope |
|----|-------|
| #305 | 1/5 — scaffold + `OllamaChatOptions` schema |
| #306 | 2/5 — Genkit ⇄ ollama_dart converters |
| #307 | 3/5 — `/api/show` capability + dimension helpers |
| #308 | 4/5 — plugin wiring (model, embedder, discovery) |
| #309 | 5/5 — example, README, CHANGELOG, live tests |
