### PR TITLE
docs(ollama): example, README, CHANGELOG, live tests

### DIFF
--- a/packages/genkit_ollama/CHANGELOG.md
+++ b/packages/genkit_ollama/CHANGELOG.md
@@ -1,0 +1,12 @@
+## 0.1.0
+
+- Initial release of the Genkit Ollama plugin.
+- Chat generation with real-time streaming.
+- Tool/function calling.
+- Vision (multimodal image) input.
+- Text embeddings with automatic dimension discovery via `/api/show`.
+- Constrained (JSON-schema) output.
+- Per-model capability metadata from `/api/show` and dynamic model discovery
+  via `/api/tags`.
+- Configurable `baseUrl`, static headers, and an async headers provider for
+  authenticated remote servers.

--- a/packages/genkit_ollama/README.md
+++ b/packages/genkit_ollama/README.md
@@ -1,0 +1,123 @@
+# Genkit Ollama Plugin
+
+Run local LLMs and embedding models with [Genkit](https://genkit.dev) via an
+[Ollama](https://ollama.com) server.
+
+Supports chat, real-time streaming, tool/function calling, vision (multimodal)
+input, text embeddings, constrained (JSON-schema) output, and dynamic model
+discovery.
+
+## Setup
+
+1. Install Ollama: https://ollama.com/download
+2. Start the server and pull a model:
+
+   ```sh
+   ollama serve
+   ollama pull llama3.2
+   ollama pull nomic-embed-text   # for embeddings
+   ```
+
+3. Add the dependency:
+
+   ```sh
+   dart pub add genkit_ollama
+   ```
+
+## Usage
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_ollama/genkit_ollama.dart';
+
+final ai = Genkit(plugins: [ollama()]);
+
+final response = await ai.generate(
+  model: ollama.model('llama3.2'),
+  prompt: 'Hello!',
+);
+print(response.text);
+```
+
+By default the plugin connects to `http://localhost:11434`. Point it elsewhere
+with `baseUrl`:
+
+```dart
+ollama(baseUrl: 'http://my-server:11434');
+```
+
+### Streaming
+
+```dart
+final stream = ai.generateStream(
+  model: ollama.model('llama3.2'),
+  prompt: 'Tell me a story.',
+);
+await for (final chunk in stream) {
+  stdout.write(chunk.text);
+}
+```
+
+### Configuration
+
+`ollama.model` accepts an `OllamaChatOptions` config, including two Ollama knobs
+(`numCtx`, `keepAlive`) beyond the common generation options:
+
+```dart
+await ai.generate(
+  model: ollama.model('llama3.2'),
+  prompt: 'Summarize this.',
+  config: OllamaChatOptions(
+    temperature: 0.6,
+    topK: 40,
+    topP: 0.9,
+    numCtx: 8192,       // context window size
+    keepAlive: '5m',    // keep the model loaded for 5 minutes
+    stop: ['\n\n'],
+  ),
+);
+```
+
+### Embeddings
+
+The embedding dimension is discovered automatically from the server; you can
+also declare it explicitly.
+
+```dart
+final embeddings = await ai.embed(
+  embedder: ollama.embedder('nomic-embed-text'),
+  document: DocumentData(content: [TextPart(text: 'Hello Genkit')]),
+);
+```
+
+To declare the dimension explicitly (e.g. when targeting a server that doesn't
+report it), register the embedder on the plugin:
+
+```dart
+ollama(
+  embedders: [
+    OllamaEmbedderDefinition(name: 'nomic-embed-text', dimensions: 768),
+  ],
+);
+```
+
+### Remote / authenticated servers
+
+Provide static headers, or an async provider for short-lived tokens:
+
+```dart
+ollama(
+  baseUrl: 'https://ollama.example.com',
+  headersProvider: () async => {'Authorization': 'Bearer ${await fetchToken()}'},
+);
+```
+
+## Capabilities
+
+Model capabilities (`tools`, `vision`/`media`, `constrained`, ...) are read
+per-model from Ollama's `/api/show`, so each model advertises only what it
+actually supports.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/packages/genkit_ollama/example/example.dart
+++ b/packages/genkit_ollama/example/example.dart
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Runnable example for the Genkit Ollama plugin.
+//
+// Prerequisites:
+//   ollama serve
+//   ollama pull llama3.2          # chat + tools
+//   ollama pull nomic-embed-text  # embeddings
+//
+// Run with:
+//   dart run example/example.dart
+
+import 'dart:io';
+import 'dart:math';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_ollama/genkit_ollama.dart';
+import 'package:schemantic/schemantic.dart';
+
+part 'example.g.dart';
+
+@Schema()
+abstract class $WeatherToolInput {
+  /// City name to look up.
+  String get location;
+}
+
+@Schema()
+abstract class $WeatherToolOutput {
+  double get temperature;
+  String get condition;
+}
+
+Future<void> main() async {
+  final ai = Genkit(plugins: [ollama()]);
+
+  final getWeather = ai.defineTool(
+    name: 'getWeather',
+    description: 'Get the current weather for a location.',
+    inputSchema: WeatherToolInput.$schema,
+    outputSchema: WeatherToolOutput.$schema,
+    fn: (input, _) async {
+      final random = Random();
+      return WeatherToolOutput(
+        temperature: 15 + random.nextInt(20).toDouble(),
+        condition: ['sunny', 'cloudy', 'rainy'][random.nextInt(3)],
+      );
+    },
+  );
+
+  // 1. Streamed chat.
+  stdout.writeln('--- Streamed chat ---');
+  final stream = ai.generateStream(
+    model: ollama.model('llama3.2'),
+    prompt: 'Tell me a one-sentence joke about Dart.',
+  );
+  await for (final chunk in stream) {
+    stdout.write(chunk.text);
+  }
+  stdout.writeln('\n');
+
+  // 2. Tool calling.
+  stdout.writeln('--- Tool calling ---');
+  final toolResponse = await ai.generate(
+    model: ollama.model('llama3.2'),
+    prompt: "What's the weather in Boston?",
+    toolNames: [getWeather.name],
+  );
+  stdout.writeln('${toolResponse.text}\n');
+
+  // 3. Embeddings.
+  stdout.writeln('--- Embeddings ---');
+  final embeddings = await ai.embed(
+    embedder: ollama.embedder('nomic-embed-text'),
+    document: DocumentData(content: [TextPart(text: 'Hello Genkit')]),
+  );
+  stdout.writeln('vector length: ${embeddings.first.embedding.length}');
+}

--- a/packages/genkit_ollama/example/example.g.dart
+++ b/packages/genkit_ollama/example/example.g.dart
@@ -1,0 +1,151 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+part of 'example.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+base class WeatherToolInput {
+  /// Creates a [WeatherToolInput] from a JSON map.
+  factory WeatherToolInput.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  WeatherToolInput._(this._json);
+
+  WeatherToolInput({required String location}) {
+    _json = {'location': location};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [WeatherToolInput].
+  static const SchemanticType<WeatherToolInput> $schema =
+      _WeatherToolInputTypeFactory();
+
+  /// City name to look up.
+  String get location {
+    return _json['location'] as String;
+  }
+
+  /// City name to look up.
+  set location(String value) {
+    _json['location'] = value;
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [WeatherToolInput] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _WeatherToolInputTypeFactory
+    extends SchemanticType<WeatherToolInput> {
+  const _WeatherToolInputTypeFactory();
+
+  @override
+  WeatherToolInput parse(Object? json) {
+    return WeatherToolInput._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'WeatherToolInput',
+    definition: $Schema
+        .object(
+          properties: {'location': $Schema.string()},
+          required: ['location'],
+        )
+        .value,
+    dependencies: [],
+  );
+}
+
+base class WeatherToolOutput {
+  /// Creates a [WeatherToolOutput] from a JSON map.
+  factory WeatherToolOutput.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  WeatherToolOutput._(this._json);
+
+  WeatherToolOutput({required double temperature, required String condition}) {
+    _json = {'temperature': temperature, 'condition': condition};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [WeatherToolOutput].
+  static const SchemanticType<WeatherToolOutput> $schema =
+      _WeatherToolOutputTypeFactory();
+
+  double get temperature {
+    return (_json['temperature'] as num).toDouble();
+  }
+
+  set temperature(double value) {
+    _json['temperature'] = value;
+  }
+
+  String get condition {
+    return _json['condition'] as String;
+  }
+
+  set condition(String value) {
+    _json['condition'] = value;
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [WeatherToolOutput] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _WeatherToolOutputTypeFactory
+    extends SchemanticType<WeatherToolOutput> {
+  const _WeatherToolOutputTypeFactory();
+
+  @override
+  WeatherToolOutput parse(Object? json) {
+    return WeatherToolOutput._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'WeatherToolOutput',
+    definition: $Schema
+        .object(
+          properties: {
+            'temperature': $Schema.number(),
+            'condition': $Schema.string(),
+          },
+          required: ['temperature', 'condition'],
+        )
+        .value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_ollama/test/integration_test.dart
+++ b/packages/genkit_ollama/test/integration_test.dart
@@ -1,0 +1,112 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Live integration tests against a real Ollama server.
+//
+// These are skipped unless `OLLAMA_LIVE_TEST` is set. They require a running
+// Ollama server and the models below pulled:
+//
+//   ollama serve
+//   ollama pull llama3.2:1b
+//   ollama pull nomic-embed-text
+//
+// Run with:
+//   OLLAMA_LIVE_TEST=1 dart test test/integration_test.dart
+//
+// Override the models via OLLAMA_CHAT_MODEL / OLLAMA_EMBED_MODEL and the server
+// via OLLAMA_BASE_URL.
+@Timeout(Duration(minutes: 5))
+library;
+
+import 'dart:io';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_ollama/genkit_ollama.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final env = Platform.environment;
+  if (env['OLLAMA_LIVE_TEST'] == null) {
+    print('Skipping live Ollama tests (set OLLAMA_LIVE_TEST=1 to enable).');
+    return;
+  }
+
+  final baseUrl = env['OLLAMA_BASE_URL'];
+  final chatModel = env['OLLAMA_CHAT_MODEL'] ?? 'llama3.2:1b';
+  final embedModel = env['OLLAMA_EMBED_MODEL'] ?? 'nomic-embed-text';
+
+  late OllamaPlugin plugin;
+  setUp(() => plugin = ollama(baseUrl: baseUrl) as OllamaPlugin);
+
+  test('non-streaming generate', () async {
+    final model = plugin.resolve('model', chatModel)!;
+    final result =
+        await model.call(
+              ModelRequest(
+                messages: [
+                  Message(
+                    role: Role.user,
+                    content: [TextPart(text: 'Reply with the word: pong')],
+                  ),
+                ],
+              ),
+            )
+            as ModelResponse;
+    expect(result.message!.text, isNotEmpty);
+  });
+
+  test('streaming generate emits chunks', () async {
+    final model = plugin.resolve('model', chatModel)!;
+    final chunks = <String>[];
+    final result =
+        await model.call(
+              ModelRequest(
+                messages: [
+                  Message(
+                    role: Role.user,
+                    content: [TextPart(text: 'Count from 1 to 5.')],
+                  ),
+                ],
+              ),
+              onChunk: (chunk) {
+                final modelChunk = chunk as ModelResponseChunk;
+                for (final part in modelChunk.content) {
+                  if (part.isText) chunks.add(part.text!);
+                }
+              },
+            )
+            as ModelResponse;
+    expect(chunks, isNotEmpty);
+    expect(result.message!.text, isNotEmpty);
+  });
+
+  test('embedder returns a vector', () async {
+    final embedder = plugin.resolve('embedder', embedModel)!;
+    final result =
+        await embedder.call(
+              EmbedRequest(
+                input: [
+                  DocumentData(content: [TextPart(text: 'hello world')]),
+                ],
+              ),
+            )
+            as EmbedResponse;
+    expect(result.embeddings.single.embedding, isNotEmpty);
+  });
+
+  test('list discovers local models', () async {
+    final metadata = await plugin.list();
+    expect(metadata, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## genkit_ollama (5/N): example, README, CHANGELOG, live tests

Docs and runnable example for the plugin. No new code paths.

**Base:** `feat/genkit_ollama-plugin` (4/N). Part of the `genkit_ollama` series.

### What's here
- `example/example.dart` — runnable: streamed chat, a tool round-trip, and an
  embedder call.
- `README.md` — install, usage, streaming, config (incl. `numCtx`/`keepAlive`),
  embeddings (auto + explicit dimensions), remote/authenticated servers, and the
  per-model capability behaviour.
- `CHANGELOG.md` — 0.1.0.
- `test/integration_test.dart` — live tests gated by `OLLAMA_LIVE_TEST` (no
  network on a normal `dart test`), with model/host overridable via env.

---

### Series (review bottom-up)
| PR | Scope |
|----|-------|
| #305 | 1/5 — scaffold + `OllamaChatOptions` schema |
| #306 | 2/5 — Genkit ⇄ ollama_dart converters |
| #307 | 3/5 — `/api/show` capability + dimension helpers |
| #308 | 4/5 — plugin wiring (model, embedder, discovery) |
| #309 | 5/5 — example, README, CHANGELOG, live tests |
