### PR TITLE
feat!: pass middleware context with GenkitAI to factories

### DIFF
--- a/docs/generate-middleware.md
+++ b/docs/generate-middleware.md
@@ -120,7 +120,7 @@ class LoggerPlugin extends GenkitPlugin {
       // name should be reasonably unique to avoid conflicts with other plugins.
       name: 'logger',
       configSchema: LoggerOptions.$schema,
-      create: ([LoggerOptions? config]) => LoggerMiddleware(
+      create: (config, ctx) => LoggerMiddleware(
         enableColor: config?.enableColor ?? false,
         maxLogLength: config?.maxLogLength ?? 1000,
       ),
@@ -170,6 +170,75 @@ void main() {
     ],
   );
 }
+```
+
+## Accessing AI from Middleware (Middleware Context)
+
+The `create` callback you pass to `defineMiddleware` receives two positional
+arguments: the resolved `config`, and a `GenerateMiddlewareContext` (`ctx`).
+
+```dart
+create: (config, ctx) => LoggerMiddleware(...),
+```
+
+If you don't need the context, name the second parameter `_` and ignore it.
+
+The context carries an ephemeral `GenkitAI` instance via `ctx.ai`. This lets a
+middleware run its own AI operations (`generate`, `generateStream`, `embed`,
+etc.) at request time. This is useful for middleware that needs to call a model
+itself, for example an AI risk/safety classifier that scores or filters a
+request, a summarization or guardrail middleware, or a routing middleware that
+asks a model to pick a downstream model.
+
+```dart
+class RiskClassifierPlugin extends GenkitPlugin {
+  @override
+  String get name => 'risk_classifier';
+
+  @override
+  List<GenerateMiddlewareDef> middleware() => [
+    defineMiddleware<RiskClassifierOptions>(
+      name: 'risk_classifier',
+      configSchema: RiskClassifierOptions.$schema,
+      // Pass the ephemeral GenkitAI to the middleware via the context.
+      create: (config, ctx) =>
+          RiskClassifierMiddleware(config, ai: ctx.ai),
+    ),
+  ];
+}
+
+class RiskClassifierMiddleware extends GenerateMiddleware {
+  RiskClassifierMiddleware(this.config, {required this.ai});
+
+  final RiskClassifierOptions? config;
+  final GenkitAI ai;
+
+  @override
+  Future<GenerateResponseHelper> generate(
+    GenerateActionOptions options,
+    ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    Future<GenerateResponseHelper> Function(
+      GenerateActionOptions options,
+      ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    ) next,
+  ) async {
+    // Run a nested generate to classify the request before continuing.
+    final verdict = await ai.generate(
+      prompt: 'Classify the risk of this request: $options',
+    );
+    if (verdict.text.contains('BLOCK')) {
+      throw GenkitException('Request blocked by risk classifier');
+    }
+    return next(options, ctx);
+  }
+}
+```
+
+The same `ctx.ai` also exposes the active registry, so a middleware can resolve
+other registered actions (models, tools, agents, etc.) by name:
+
+```dart
+final agent = await ctx.ai.registry.lookupAction('agent', 'researcher');
 ```
 
 ## Lifecycle and Stateful Middleware

--- a/packages/genkit/lib/genkit.dart
+++ b/packages/genkit/lib/genkit.dart
@@ -62,6 +62,7 @@ export 'src/core/action.dart' show Action, ActionFnArg, ActionMetadata;
 export 'src/core/dynamic_action_provider.dart' show DynamicActionProvider;
 export 'src/core/flow.dart';
 export 'src/exception.dart' show GenkitException, StatusCodes;
+export 'src/genkit_ai.dart' show GenkitAI;
 export 'src/genkit_class.dart';
 export 'src/schema_extensions.dart';
 export 'src/types.dart';

--- a/packages/genkit/lib/genkit.dart
+++ b/packages/genkit/lib/genkit.dart
@@ -29,6 +29,7 @@ export 'src/ai/generate_bidi.dart' show GenerateBidiSession;
 export 'src/ai/generate_middleware.dart'
     show
         GenerateMiddleware,
+        GenerateMiddlewareContext,
         GenerateMiddlewareDef,
         GenerateMiddlewareRef,
         defineMiddleware,

--- a/packages/genkit/lib/plugin.dart
+++ b/packages/genkit/lib/plugin.dart
@@ -25,6 +25,7 @@ export 'package:genkit/src/ai/embedder.dart'
 export 'package:genkit/src/ai/generate_middleware.dart'
     show
         GenerateMiddleware,
+        GenerateMiddlewareContext,
         GenerateMiddlewareDef,
         GenerateMiddlewareRef,
         GenerateTurnState,
@@ -39,6 +40,7 @@ export 'package:genkit/src/ai/tool.dart' show Tool, ToolFn, ToolFnArgs;
 export 'package:genkit/src/core/action.dart'
     show Action, ActionFnArg, ActionMetadata;
 export 'package:genkit/src/core/plugin.dart' show GenkitPlugin;
+export 'package:genkit/src/core/registry.dart' show Registry;
 export 'package:genkit/src/exception.dart' show GenkitException, StatusCodes;
 export 'package:genkit/src/schema_extensions.dart';
 export 'package:genkit/src/types.dart';

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -18,6 +18,7 @@ import '../core/action.dart';
 import '../core/dynamic_action_provider.dart';
 import '../core/registry.dart';
 import '../exception.dart';
+import '../genkit_ai.dart';
 import '../o11y/instrumentation.dart';
 import '../schema.dart';
 import '../schema_extensions.dart';
@@ -108,7 +109,9 @@ abstract class GenerateConfig {}
             ? def.configSchema!.parse(config)
             : config;
 
-        resolvedMiddleware.add(def.create(parsedConfig, (registry: registry)));
+        resolvedMiddleware.add(
+          def.create(parsedConfig, (ai: GenkitAI(registry))),
+        );
       } else {
         throw GenkitException(
           'Invalid middleware type: ${mw.runtimeType}. Expected GenerateMiddleware or GenerateMiddlewareRef.',

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -108,7 +108,7 @@ abstract class GenerateConfig {}
             ? def.configSchema!.parse(config)
             : config;
 
-        resolvedMiddleware.add(def.create(parsedConfig));
+        resolvedMiddleware.add(def.create(parsedConfig, (registry: registry)));
       } else {
         throw GenkitException(
           'Invalid middleware type: ${mw.runtimeType}. Expected GenerateMiddleware or GenerateMiddlewareRef.',

--- a/packages/genkit/lib/src/ai/generate_middleware.dart
+++ b/packages/genkit/lib/src/ai/generate_middleware.dart
@@ -15,7 +15,7 @@
 import 'package:schemantic/schemantic.dart';
 
 import '../core/action.dart';
-import '../core/registry.dart';
+import '../genkit_ai.dart';
 import '../types.dart';
 import 'generate_types.dart';
 import 'tool.dart';
@@ -84,10 +84,12 @@ abstract class GenerateMiddleware {
 
 /// Ambient dependencies handed to a middleware factory at instantiation time.
 ///
-/// The `registry` field is the active action registry, letting a middleware
-/// resolve other registered actions (models, tools, agents, etc.) by name when
-/// it is created.
-typedef GenerateMiddlewareContext = ({Registry registry});
+/// The `ai` field is an ephemeral [GenkitAI] instance backed by the active
+/// action registry. It lets a middleware run nested AI operations (e.g.
+/// [GenkitAI.generate], [GenkitAI.embed]) and resolve other registered actions
+/// (models, tools, agents, etc.) by name when it is created. The underlying
+/// registry is available via `ai.registry`.
+typedef GenerateMiddlewareContext = ({GenkitAI ai});
 
 abstract interface class GenerateMiddlewareDef<CustomOptions> {
   String get name;

--- a/packages/genkit/lib/src/ai/generate_middleware.dart
+++ b/packages/genkit/lib/src/ai/generate_middleware.dart
@@ -15,6 +15,7 @@
 import 'package:schemantic/schemantic.dart';
 
 import '../core/action.dart';
+import '../core/registry.dart';
 import '../types.dart';
 import 'generate_types.dart';
 import 'tool.dart';
@@ -81,12 +82,22 @@ abstract class GenerateMiddleware {
   }
 }
 
+/// Ambient dependencies handed to a middleware factory at instantiation time.
+///
+/// The `registry` field is the active action registry, letting a middleware
+/// resolve other registered actions (models, tools, agents, etc.) by name when
+/// it is created.
+typedef GenerateMiddlewareContext = ({Registry registry});
+
 abstract interface class GenerateMiddlewareDef<CustomOptions> {
   String get name;
   SchemanticType<CustomOptions>? get configSchema;
   Map<String, Object?>? get configJsonSchema;
 
-  GenerateMiddleware create([CustomOptions? config]);
+  GenerateMiddleware create(
+    CustomOptions? config,
+    GenerateMiddlewareContext ctx,
+  );
 }
 
 class _GenerateMiddlewareDef<CustomOptions>
@@ -95,7 +106,11 @@ class _GenerateMiddlewareDef<CustomOptions>
   final String name;
   @override
   final SchemanticType<CustomOptions>? configSchema;
-  final GenerateMiddleware Function([CustomOptions? config]) _create;
+  final GenerateMiddleware Function(
+    CustomOptions? config,
+    GenerateMiddlewareContext ctx,
+  )
+  _create;
 
   _GenerateMiddlewareDef(this.name, this._create, this.configSchema);
 
@@ -103,12 +118,19 @@ class _GenerateMiddlewareDef<CustomOptions>
   Map<String, Object?>? get configJsonSchema => configSchema?.jsonSchema();
 
   @override
-  GenerateMiddleware create([CustomOptions? config]) => _create(config);
+  GenerateMiddleware create(
+    CustomOptions? config,
+    GenerateMiddlewareContext ctx,
+  ) => _create(config, ctx);
 }
 
 GenerateMiddlewareDef<CustomOptions> defineMiddleware<CustomOptions>({
   required String name,
-  required GenerateMiddleware Function([CustomOptions? config]) create,
+  required GenerateMiddleware Function(
+    CustomOptions? config,
+    GenerateMiddlewareContext ctx,
+  )
+  create,
   SchemanticType<CustomOptions>? configSchema,
 }) {
   return _GenerateMiddlewareDef<CustomOptions>(name, create, configSchema);

--- a/packages/genkit/lib/src/ai/middleware/retry.dart
+++ b/packages/genkit/lib/src/ai/middleware/retry.dart
@@ -49,7 +49,7 @@ class RetryPlugin extends GenkitPlugin {
     defineMiddleware<RetryOptions>(
       name: 'retry',
       configSchema: RetryOptions.$schema,
-      create: ([RetryOptions? config]) => RetryMiddleware(
+      create: (config, ctx) => RetryMiddleware(
         maxRetries: config?.maxRetries ?? 3,
         statuses: config?.statuses ?? RetryMiddleware.defaultRetryStatuses,
         initialDelayMs: config?.initialDelayMs ?? 1000,

--- a/packages/genkit/lib/src/genkit_ai.dart
+++ b/packages/genkit/lib/src/genkit_ai.dart
@@ -1,0 +1,345 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:schemantic/schemantic.dart';
+
+import 'ai/embedder.dart';
+import 'ai/generate.dart';
+import 'ai/generate_bidi.dart';
+import 'ai/generate_middleware.dart';
+import 'ai/generate_types.dart';
+import 'ai/model.dart';
+import 'ai/tool.dart';
+import 'core/action.dart';
+import 'core/registry.dart';
+import 'exception.dart';
+import 'o11y/instrumentation.dart';
+import 'schema.dart';
+import 'types.dart';
+
+/// Encapsulates Genkit's AI APIs.
+///
+/// [GenkitAI] exposes the model-orchestration veneer ([generate],
+/// [generateStream], [generateBidi], [embed], [embedMany], [run]) on top of a
+/// [Registry]. It only requires a registry to operate, making it cheap to
+/// create ephemeral, throwaway instances (the registry holds all the state).
+/// The full framework entry point `Genkit` extends this class to add plugin
+/// loading, the reflection server, and the various `define*` methods.
+base class GenkitAI {
+  /// The action registry backing this instance.
+  final Registry registry;
+
+  GenkitAI(this.registry);
+
+  /// Runs an AI operation within a new trace span.
+  Future<Output> run<Output>(String name, Future<Output> Function() fn) {
+    return runInNewSpan(name, (_) => fn());
+  }
+
+  /// The tool resolution logic.
+  ///
+  /// Returns a new registry with embedded tools if necessary.
+  ({Registry registry, List<String>? toolNames}) _resolveTools(
+    Registry registry, {
+    List<Tool>? tools,
+    List<String>? toolNames,
+  }) {
+    if ((tools == null || tools.isEmpty) &&
+        (toolNames == null || toolNames.isEmpty)) {
+      return (registry: registry, toolNames: null);
+    }
+
+    final resolvedToolNames = <String>[...?toolNames];
+
+    if (tools == null || tools.isEmpty) {
+      return (registry: registry, toolNames: resolvedToolNames);
+    }
+
+    final childRegistry = Registry.childOf(registry);
+    for (final tool in tools) {
+      childRegistry.register(tool);
+      if (!resolvedToolNames.contains(tool.name)) {
+        resolvedToolNames.add(tool.name);
+      }
+    }
+    return (registry: childRegistry, toolNames: resolvedToolNames);
+  }
+
+  /// Starts a bi-directional generator session.
+  Future<GenerateBidiSession> generateBidi({
+    required String model,
+    dynamic config,
+    List<Tool>? tools,
+    List<String>? toolNames,
+    String? system,
+  }) {
+    final resolved = _resolveTools(
+      registry,
+      tools: tools,
+      toolNames: toolNames,
+    );
+    return runGenerateBidi(
+      resolved.registry,
+      modelName: model,
+      config: config,
+      tools: resolved.toolNames,
+      system: system,
+    );
+  }
+
+  /// Generates a response using the specified model and context.
+  Future<GenerateResponseHelper<Output>> generate<CustomOptions, Output>({
+    String? system,
+    String? prompt,
+    List<Message>? messages,
+    ModelRef<CustomOptions>? model,
+    CustomOptions? config,
+    List<Tool>? tools,
+    List<String>? toolNames,
+    String? toolChoice,
+    bool? returnToolRequests,
+    int? maxTurns,
+    SchemanticType<Output>? outputSchema,
+    String? outputFormat,
+    bool? outputConstrained,
+    String? outputInstructions,
+    bool? outputNoInstructions,
+    String? outputContentType,
+    Map<String, dynamic>? context,
+    StreamingCallback<GenerateResponseChunk<Output>>? onChunk,
+    List<GenerateMiddlewareRef>? use,
+
+    /// Optional data to resume an interrupted generation session.
+    ///
+    /// The list should contain [InterruptResponse]s for each interrupted tool request
+    /// that is providing an explicit output reply.
+    ///
+    /// Example (providing a response):
+    /// ```dart
+    /// interruptRespond: [
+    ///   InterruptResponse(interruptPart, 'User Answer')
+    /// ]
+    /// ```
+    List<InterruptResponse>? interruptRespond,
+
+    /// Optional list of tool requests to restart during an interrupted generation session.
+    ///
+    /// Restarts the execution of the specified tool part instead of providing a reply.
+    /// Example:
+    /// ```dart
+    /// interruptRestart: [interruptPart]
+    /// ```
+    List<ToolRequestPart>? interruptRestart,
+  }) async {
+    if (outputInstructions != null && outputNoInstructions == true) {
+      throw ArgumentError(
+        'Cannot set both outputInstructions and outputNoInstructions to true.',
+      );
+    }
+
+    GenerateActionOutputConfig? outputConfig;
+    if (outputSchema != null ||
+        outputFormat != null ||
+        outputConstrained != null ||
+        outputInstructions != null ||
+        outputNoInstructions != null ||
+        outputContentType != null) {
+      outputConfig = GenerateActionOutputConfig.fromJson({
+        'format': ?outputFormat,
+        if (outputSchema != null)
+          'jsonSchema': toJsonSchema(type: outputSchema),
+        'constrained': ?outputConstrained,
+        'instructions': ?outputInstructions,
+        'contentType': ?outputContentType,
+        if (outputNoInstructions == true) 'instructions': false,
+      });
+    }
+    final resolved = _resolveTools(
+      registry,
+      tools: tools,
+      toolNames: toolNames,
+    );
+    final rawResponse = await generateHelper(
+      resolved.registry,
+      system: system,
+      prompt: prompt,
+      messages: messages,
+      model: model,
+      config: config,
+      tools: resolved.toolNames,
+      toolChoice: toolChoice,
+      returnToolRequests: returnToolRequests,
+      maxTurns: maxTurns,
+      output: outputConfig,
+      context: context,
+      middleware: use
+          ?.map<GenerateMiddlewareOneof>(
+            (mw) => (middlewareRef: mw, middlewareInstance: null),
+          )
+          .toList(),
+      resume: interruptRespond,
+      restart: interruptRestart,
+      onChunk: onChunk == null
+          ? null
+          : (c) {
+              if (outputSchema != null) {
+                onChunk.call(
+                  GenerateResponseChunk<Output>(
+                    c.rawChunk,
+                    previousChunks: List.from(c.previousChunks),
+                    output: c.output != null
+                        ? outputSchema.parse(c.output)
+                        : null,
+                  ),
+                );
+              } else {
+                onChunk.call(
+                  GenerateResponseChunk<Output>(
+                    c.rawChunk,
+                    previousChunks: List.from(c.previousChunks),
+                    output: c.output as Output?,
+                  ),
+                );
+              }
+            },
+    );
+    if (outputSchema != null) {
+      return GenerateResponseHelper(
+        rawResponse.rawResponse,
+        output: outputSchema.parse(rawResponse.output),
+      );
+    } else {
+      return GenerateResponseHelper(
+        rawResponse.rawResponse,
+        request: rawResponse.modelRequest,
+        output: rawResponse.output as Output?,
+      );
+    }
+  }
+
+  /// Streams a response from the specified model.
+  ActionStream<GenerateResponseChunk<Output>, GenerateResponseHelper<Output>>
+  generateStream<CustomOptions, Output>({
+    String? system,
+    String? prompt,
+    List<Message>? messages,
+    ModelRef<CustomOptions>? model,
+    CustomOptions? config,
+    List<Tool>? tools,
+    List<String>? toolNames,
+    String? toolChoice,
+    bool? returnToolRequests,
+    int? maxTurns,
+    SchemanticType<Output>? outputSchema,
+    String? outputFormat,
+    bool? outputConstrained,
+    String? outputInstructions,
+    bool? outputNoInstructions,
+    String? outputContentType,
+    Map<String, dynamic>? context,
+    List<GenerateMiddlewareRef>? use,
+    List<InterruptResponse>? interruptRespond,
+    List<ToolRequestPart>? interruptRestart,
+  }) {
+    final streamController = StreamController<GenerateResponseChunk<Output>>();
+    final actionStream =
+        ActionStream<
+          GenerateResponseChunk<Output>,
+          GenerateResponseHelper<Output>
+        >(streamController.stream);
+
+    generate(
+          system: system,
+          prompt: prompt,
+          messages: messages,
+          model: model,
+          config: config,
+          tools: tools,
+          toolNames: toolNames,
+          toolChoice: toolChoice,
+          returnToolRequests: returnToolRequests,
+          maxTurns: maxTurns,
+          outputSchema: outputSchema,
+          outputFormat: outputFormat,
+          outputConstrained: outputConstrained,
+          outputInstructions: outputInstructions,
+          outputNoInstructions: outputNoInstructions,
+          outputContentType: outputContentType,
+          use: use,
+          interruptRespond: interruptRespond,
+          interruptRestart: interruptRestart,
+          onChunk: (chunk) {
+            if (streamController.isClosed) return;
+            streamController.add(chunk);
+          },
+        )
+        .then((result) {
+          actionStream.setResult(result);
+          if (!streamController.isClosed) {
+            streamController.close();
+          }
+        })
+        .catchError((Object e, StackTrace s) {
+          actionStream.setError(e, s);
+          if (!streamController.isClosed) {
+            streamController.addError(e, s);
+            streamController.close();
+          }
+        });
+
+    return actionStream;
+  }
+
+  /// Embeds multiple documents using the specified embedder.
+  Future<List<Embedding>> embedMany<CustomOptions>({
+    required EmbedderRef<CustomOptions> embedder,
+    required List<DocumentData> documents,
+    CustomOptions? options,
+  }) async {
+    final action = await registry.lookupAction('embedder', embedder.name);
+    if (action == null) {
+      throw GenkitException(
+        'Embedder ${embedder.name} not found',
+        status: StatusCodes.NOT_FOUND,
+      );
+    }
+
+    final resolvedOptions = options is Map
+        ? options as Map<String, dynamic>
+        : (options as dynamic)?.toJson() as Map<String, dynamic>?;
+
+    final req = EmbedRequest(input: documents, options: resolvedOptions);
+
+    final response = await action(req) as EmbedResponse;
+    return response.embeddings;
+  }
+
+  /// Embeds a single document or a list of documents.
+  Future<List<Embedding>> embed<CustomOptions>({
+    required EmbedderRef<CustomOptions> embedder,
+    DocumentData? document,
+    List<DocumentData>? documents,
+    CustomOptions? options,
+  }) async {
+    final docs = documents ?? (document != null ? [document] : []);
+    if (docs.isEmpty) {
+      throw ArgumentError(
+        'Either document or documents must be provided to embed.',
+      );
+    }
+    return embedMany(embedder: embedder, documents: docs, options: options);
+  }
+}

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -22,9 +22,7 @@ import 'ai/embedder.dart';
 import 'ai/evaluator.dart';
 import 'ai/formatters/formatters.dart';
 import 'ai/generate.dart';
-import 'ai/generate_bidi.dart';
 import 'ai/generate_middleware.dart';
-import 'ai/generate_types.dart';
 import 'ai/model.dart';
 import 'ai/prompt.dart';
 import 'ai/prompt_loader.dart';
@@ -39,9 +37,8 @@ import 'core/plugin.dart';
 import 'core/reflection.dart';
 import 'core/registry.dart';
 import 'exception.dart';
-import 'o11y/instrumentation.dart';
+import 'genkit_ai.dart';
 import 'o11y/otlp_http_exporter.dart' show configureCollectorExporter;
-import 'schema.dart';
 import 'types.dart';
 import 'utils.dart' as utils;
 
@@ -52,11 +49,13 @@ import 'utils.dart' as utils;
 /// methods to create AI actions, such as [defineFlow], [defineTool],
 /// [definePrompt], and [defineResource].
 ///
+/// It extends [GenkitAI], inheriting the model-orchestration veneer
+/// ([generate], [generateStream], [generateBidi], [embed], [embedMany], [run]).
+///
 /// If `isDevEnv` is true or the `GENKIT_ENV` environment variable is set to
 /// 'dev', initializing [Genkit] also starts a local reflection server that
 /// communicates with the Genkit Developer UI.
-final class Genkit {
-  final Registry registry = Registry();
+final class Genkit extends GenkitAI {
   ReflectionServerHandle? _reflectionServer;
 
   late final GenerateAction _generateAction;
@@ -73,7 +72,7 @@ final class Genkit {
     /// Defaults to `'./prompts'`. Set to `null` to disable automatic
     /// prompt loading.
     String? promptDir = './prompts',
-  }) {
+  }) : super(Registry()) {
     configureCollectorExporter();
 
     // Initialize dotprompt registry with schema resolver wired to the registry
@@ -119,11 +118,6 @@ final class Genkit {
     if (_reflectionServer != null) {
       await _reflectionServer!.stop();
     }
-  }
-
-  /// Runs an AI operation within a new trace span.
-  Future<Output> run<Output>(String name, Future<Output> Function() fn) {
-    return runInNewSpan(name, (_) => fn());
   }
 
   /// Defines a new strongly-typed Genkit flow.
@@ -481,299 +475,5 @@ final class Genkit {
     );
     registry.register(evaluator);
     return evaluator;
-  }
-
-  /// Embeds multiple documents using the specified embedder.
-  Future<List<Embedding>> embedMany<CustomOptions>({
-    required EmbedderRef<CustomOptions> embedder,
-    required List<DocumentData> documents,
-    CustomOptions? options,
-  }) async {
-    final action = await registry.lookupAction('embedder', embedder.name);
-    if (action == null) {
-      throw GenkitException(
-        'Embedder ${embedder.name} not found',
-        status: StatusCodes.NOT_FOUND,
-      );
-    }
-
-    final resolvedOptions = options is Map
-        ? options as Map<String, dynamic>
-        : (options as dynamic)?.toJson() as Map<String, dynamic>?;
-
-    final req = EmbedRequest(input: documents, options: resolvedOptions);
-
-    final response = await action(req) as EmbedResponse;
-    return response.embeddings;
-  }
-
-  /// Embeds a single document or a list of documents.
-  Future<List<Embedding>> embed<CustomOptions>({
-    required EmbedderRef<CustomOptions> embedder,
-    DocumentData? document,
-    List<DocumentData>? documents,
-    CustomOptions? options,
-  }) async {
-    final docs = documents ?? (document != null ? [document] : []);
-    if (docs.isEmpty) {
-      throw ArgumentError(
-        'Either document or documents must be provided to embed.',
-      );
-    }
-    return embedMany(embedder: embedder, documents: docs, options: options);
-  }
-
-  /// Starts a bi-directional generator session.
-  Future<GenerateBidiSession> generateBidi({
-    required String model,
-    dynamic config,
-    List<Tool>? tools,
-    List<String>? toolNames,
-    String? system,
-  }) {
-    final resolved = _resolveTools(
-      registry,
-      tools: tools,
-      toolNames: toolNames,
-    );
-    return runGenerateBidi(
-      resolved.registry,
-      modelName: model,
-      config: config,
-      tools: resolved.toolNames,
-      system: system,
-    );
-  }
-
-  /// The tool resolution logic.
-  ///
-  /// Returns a new registry with embedded tools if necessary.
-  ({Registry registry, List<String>? toolNames}) _resolveTools(
-    Registry registry, {
-    List<Tool>? tools,
-    List<String>? toolNames,
-  }) {
-    if ((tools == null || tools.isEmpty) &&
-        (toolNames == null || toolNames.isEmpty)) {
-      return (registry: registry, toolNames: null);
-    }
-
-    final resolvedToolNames = <String>[...?toolNames];
-
-    if (tools == null || tools.isEmpty) {
-      return (registry: registry, toolNames: resolvedToolNames);
-    }
-
-    final childRegistry = Registry.childOf(registry);
-    for (final tool in tools) {
-      childRegistry.register(tool);
-      if (!resolvedToolNames.contains(tool.name)) {
-        resolvedToolNames.add(tool.name);
-      }
-    }
-    return (registry: childRegistry, toolNames: resolvedToolNames);
-  }
-
-  /// Generates a response using the specified model and context.
-  Future<GenerateResponseHelper<Output>> generate<CustomOptions, Output>({
-    String? system,
-    String? prompt,
-    List<Message>? messages,
-    ModelRef<CustomOptions>? model,
-    CustomOptions? config,
-    List<Tool>? tools,
-    List<String>? toolNames,
-    String? toolChoice,
-    bool? returnToolRequests,
-    int? maxTurns,
-    SchemanticType<Output>? outputSchema,
-    String? outputFormat,
-    bool? outputConstrained,
-    String? outputInstructions,
-    bool? outputNoInstructions,
-    String? outputContentType,
-    Map<String, dynamic>? context,
-    StreamingCallback<GenerateResponseChunk<Output>>? onChunk,
-    List<GenerateMiddlewareRef>? use,
-
-    /// Optional data to resume an interrupted generation session.
-    ///
-    /// The list should contain [InterruptResponse]s for each interrupted tool request
-    /// that is providing an explicit output reply.
-    ///
-    /// Example (providing a response):
-    /// ```dart
-    /// interruptRespond: [
-    ///   InterruptResponse(interruptPart, 'User Answer')
-    /// ]
-    /// ```
-    List<InterruptResponse>? interruptRespond,
-
-    /// Optional list of tool requests to restart during an interrupted generation session.
-    ///
-    /// Restarts the execution of the specified tool part instead of providing a reply.
-    /// Example:
-    /// ```dart
-    /// interruptRestart: [interruptPart]
-    /// ```
-    List<ToolRequestPart>? interruptRestart,
-  }) async {
-    if (outputInstructions != null && outputNoInstructions == true) {
-      throw ArgumentError(
-        'Cannot set both outputInstructions and outputNoInstructions to true.',
-      );
-    }
-
-    GenerateActionOutputConfig? outputConfig;
-    if (outputSchema != null ||
-        outputFormat != null ||
-        outputConstrained != null ||
-        outputInstructions != null ||
-        outputNoInstructions != null ||
-        outputContentType != null) {
-      outputConfig = GenerateActionOutputConfig.fromJson({
-        'format': ?outputFormat,
-        if (outputSchema != null)
-          'jsonSchema': toJsonSchema(type: outputSchema),
-        'constrained': ?outputConstrained,
-        'instructions': ?outputInstructions,
-        'contentType': ?outputContentType,
-        if (outputNoInstructions == true) 'instructions': false,
-      });
-    }
-    final resolved = _resolveTools(
-      registry,
-      tools: tools,
-      toolNames: toolNames,
-    );
-    final rawResponse = await generateHelper(
-      resolved.registry,
-      system: system,
-      prompt: prompt,
-      messages: messages,
-      model: model,
-      config: config,
-      tools: resolved.toolNames,
-      toolChoice: toolChoice,
-      returnToolRequests: returnToolRequests,
-      maxTurns: maxTurns,
-      output: outputConfig,
-      context: context,
-      middleware: use
-          ?.map<GenerateMiddlewareOneof>(
-            (mw) => (middlewareRef: mw, middlewareInstance: null),
-          )
-          .toList(),
-      resume: interruptRespond,
-      restart: interruptRestart,
-      onChunk: onChunk == null
-          ? null
-          : (c) {
-              if (outputSchema != null) {
-                onChunk.call(
-                  GenerateResponseChunk<Output>(
-                    c.rawChunk,
-                    previousChunks: List.from(c.previousChunks),
-                    output: c.output != null
-                        ? outputSchema.parse(c.output)
-                        : null,
-                  ),
-                );
-              } else {
-                onChunk.call(
-                  GenerateResponseChunk<Output>(
-                    c.rawChunk,
-                    previousChunks: List.from(c.previousChunks),
-                    output: c.output as Output?,
-                  ),
-                );
-              }
-            },
-    );
-    if (outputSchema != null) {
-      return GenerateResponseHelper(
-        rawResponse.rawResponse,
-        output: outputSchema.parse(rawResponse.output),
-      );
-    } else {
-      return GenerateResponseHelper(
-        rawResponse.rawResponse,
-        request: rawResponse.modelRequest,
-        output: rawResponse.output as Output?,
-      );
-    }
-  }
-
-  /// Streams a response from the specified model.
-  ActionStream<GenerateResponseChunk<Output>, GenerateResponseHelper<Output>>
-  generateStream<CustomOptions, Output>({
-    String? system,
-    String? prompt,
-    List<Message>? messages,
-    ModelRef<CustomOptions>? model,
-    CustomOptions? config,
-    List<Tool>? tools,
-    List<String>? toolNames,
-    String? toolChoice,
-    bool? returnToolRequests,
-    int? maxTurns,
-    SchemanticType<Output>? outputSchema,
-    String? outputFormat,
-    bool? outputConstrained,
-    String? outputInstructions,
-    bool? outputNoInstructions,
-    String? outputContentType,
-    Map<String, dynamic>? context,
-    List<GenerateMiddlewareRef>? use,
-    List<InterruptResponse>? interruptRespond,
-    List<ToolRequestPart>? interruptRestart,
-  }) {
-    final streamController = StreamController<GenerateResponseChunk<Output>>();
-    final actionStream =
-        ActionStream<
-          GenerateResponseChunk<Output>,
-          GenerateResponseHelper<Output>
-        >(streamController.stream);
-
-    generate(
-          system: system,
-          prompt: prompt,
-          messages: messages,
-          model: model,
-          config: config,
-          tools: tools,
-          toolNames: toolNames,
-          toolChoice: toolChoice,
-          returnToolRequests: returnToolRequests,
-          maxTurns: maxTurns,
-          outputSchema: outputSchema,
-          outputFormat: outputFormat,
-          outputConstrained: outputConstrained,
-          outputInstructions: outputInstructions,
-          outputNoInstructions: outputNoInstructions,
-          outputContentType: outputContentType,
-          use: use,
-          interruptRespond: interruptRespond,
-          interruptRestart: interruptRestart,
-          onChunk: (chunk) {
-            if (streamController.isClosed) return;
-            streamController.add(chunk);
-          },
-        )
-        .then((result) {
-          actionStream.setResult(result);
-          if (!streamController.isClosed) {
-            streamController.close();
-          }
-        })
-        .catchError((Object e, StackTrace s) {
-          actionStream.setError(e, s);
-          if (!streamController.isClosed) {
-            streamController.addError(e, s);
-            streamController.close();
-          }
-        });
-
-    return actionStream;
   }
 }

--- a/packages/genkit/test/ai/middleware_test.dart
+++ b/packages/genkit/test/ai/middleware_test.dart
@@ -278,6 +278,90 @@ void main() {
       expect(result.text, 'echo: intercepted: original');
     });
 
+    test('should pass a GenkitAI instance in the middleware context', () async {
+      GenerateMiddlewareContext? capturedCtx;
+
+      final mw = defineMiddleware(
+        name: 'ctx-capture-mw',
+        create: (config, ctx) {
+          capturedCtx = ctx;
+          return TestMiddleware(<String>[], 'ctx-capture-mw');
+        },
+      );
+
+      genkit = Genkit(
+        isDevEnv: false,
+        plugins: [
+          MiddlewarePlugin([mw]),
+        ],
+      );
+
+      genkit.defineModel(
+        name: 'ctx-model',
+        fn: (req, ctx) async => ModelResponse(
+          finishReason: FinishReason.stop,
+          message: Message(
+            role: Role.model,
+            content: [TextPart(text: 'ok')],
+          ),
+        ),
+      );
+
+      await genkit.generate(
+        model: modelRef('ctx-model'),
+        prompt: 'hi',
+        use: [middlewareRef(name: 'ctx-capture-mw')],
+      );
+
+      expect(capturedCtx, isNotNull);
+      expect(capturedCtx!.ai, isA<GenkitAI>());
+      // The ephemeral GenkitAI is backed by the active generation registry.
+      expect(capturedCtx!.ai.registry, isNotNull);
+    });
+
+    test('middleware can run nested AI operations via context', () async {
+      genkit = Genkit(isDevEnv: false);
+
+      genkit.defineModel(
+        name: 'nested-model',
+        fn: (req, ctx) async {
+          final text = req.messages.last.content.first.text!;
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [TextPart(text: 'nested: $text')],
+            ),
+          );
+        },
+      );
+
+      String? nestedResult;
+      final mw = defineMiddleware(
+        name: 'nested-mw',
+        create: (config, ctx) => FunctionMiddleware(
+          generateFn: (envelope, mctx, next) async {
+            // Use the GenkitAI passed in the context to run a nested generate.
+            final nested = await ctx.ai.generate(
+              model: modelRef('nested-model'),
+              prompt: 'from-middleware',
+            );
+            nestedResult = nested.text;
+            return next(envelope, mctx);
+          },
+        ),
+      );
+      genkit.registry.registerValue('middleware', mw.name, mw);
+
+      await genkit.generate(
+        model: modelRef('nested-model'),
+        prompt: 'outer',
+        use: [middlewareRef(name: 'nested-mw')],
+      );
+
+      expect(nestedResult, 'nested: from-middleware');
+    });
+
     test('should resolve and execute registered middleware refs', () async {
       final log = <String>[];
 

--- a/packages/genkit/test/ai/middleware_test.dart
+++ b/packages/genkit/test/ai/middleware_test.dart
@@ -124,11 +124,11 @@ void main() {
       final log = <String>[];
       final mw1 = defineMiddleware(
         name: 'mw1',
-        create: ([c]) => TestMiddleware(log, 'mw1'),
+        create: (c, ctx) => TestMiddleware(log, 'mw1'),
       );
       final mw2 = defineMiddleware(
         name: 'mw2',
-        create: ([c]) => TestMiddleware(log, 'mw2'),
+        create: (c, ctx) => TestMiddleware(log, 'mw2'),
       );
 
       genkit = Genkit(
@@ -246,7 +246,7 @@ void main() {
     test('should intercept model request', () async {
       final interceptor = defineMiddleware(
         name: 'interceptor',
-        create: ([_]) => InterceptorMiddleware(),
+        create: (_, _) => InterceptorMiddleware(),
       );
       genkit = Genkit(
         isDevEnv: false,
@@ -284,7 +284,8 @@ void main() {
       // Register a middleware definition manually (as a plugin would).
       final def = defineMiddleware<dynamic>(
         name: 'reg-mw',
-        create: ([config]) => TestMiddleware(log, 'reg-mw-${config ?? 'none'}'),
+        create: (config, ctx) =>
+            TestMiddleware(log, 'reg-mw-${config ?? 'none'}'),
       );
       genkit.registry.registerValue('middleware', def.name, def);
 
@@ -336,7 +337,7 @@ void main() {
 
       final mw = defineMiddleware(
         name: 'injected-tool-mw',
-        create: ([_]) => ToolInjectingMiddleware([injectedTool]),
+        create: (_, _) => ToolInjectingMiddleware([injectedTool]),
       );
       genkit = Genkit(
         isDevEnv: false,
@@ -389,7 +390,7 @@ void main() {
       final mw1 = TestMiddleware(log, 'mw1');
       var toolCallCount = 0;
 
-      final mdef1 = defineMiddleware(name: 'mw1', create: ([_]) => mw1);
+      final mdef1 = defineMiddleware(name: 'mw1', create: (_, _) => mw1);
 
       genkit = Genkit(
         isDevEnv: false,
@@ -501,7 +502,7 @@ void main() {
 
         final envChecker = defineMiddleware(
           name: 'env-checker',
-          create: ([_]) => FunctionMiddleware(
+          create: (_, _) => FunctionMiddleware(
             generateFn: (envelope, ctx, next) async {
               receivedIndex = envelope.messageIndex;
               receivedTurn = envelope.currentTurn;
@@ -518,7 +519,7 @@ void main() {
         var checkTurn = -1;
         final envValidator = defineMiddleware(
           name: 'env-validator',
-          create: ([_]) => FunctionMiddleware(
+          create: (_, _) => FunctionMiddleware(
             generateFn: (envelope, ctx, next) async {
               checkIndex = envelope.messageIndex;
               checkTurn = envelope.currentTurn;
@@ -603,7 +604,7 @@ void main() {
         final capturedOptions = <GenerateActionOptions>[];
         final middleware = defineMiddleware(
           name: 'captureOptions',
-          create: ([config]) => _CaptureMiddleware(capturedOptions),
+          create: (config, ctx) => _CaptureMiddleware(capturedOptions),
         );
         genkit.registry.registerValue(
           'middleware',
@@ -633,7 +634,7 @@ void main() {
         final capturedOptions = <GenerateActionOptions>[];
         final middleware = defineMiddleware(
           name: 'captureOptionsResume',
-          create: ([config]) => _CaptureMiddleware(capturedOptions),
+          create: (config, ctx) => _CaptureMiddleware(capturedOptions),
         );
         genkit.registry.registerValue(
           'middleware',
@@ -723,7 +724,7 @@ void main() {
         final capturedOptions = <GenerateActionOptions>[];
         final middleware = defineMiddleware(
           name: 'captureOptionsMiddleware',
-          create: ([config]) => _CaptureMiddleware(capturedOptions),
+          create: (config, ctx) => _CaptureMiddleware(capturedOptions),
         );
         genkit.registry.registerValue(
           'middleware',
@@ -761,7 +762,7 @@ void main() {
           final capturedOptions = <GenerateActionOptions>[];
           final middleware = defineMiddleware(
             name: 'captureOptionsAction',
-            create: ([config]) => _CaptureMiddleware(capturedOptions),
+            create: (config, ctx) => _CaptureMiddleware(capturedOptions),
           );
           genkit.registry.registerValue(
             'middleware',

--- a/packages/genkit/test/core/reflection_v1_test.dart
+++ b/packages/genkit/test/core/reflection_v1_test.dart
@@ -108,7 +108,7 @@ void main() {
     test('GET /api/values for middleware', () async {
       final def = defineMiddleware<dynamic>(
         name: 'retry',
-        create: ([config]) => throw UnimplementedError(),
+        create: (config, ctx) => throw UnimplementedError(),
       );
       registry.registerValue('middleware', def.name, def);
 

--- a/packages/genkit/test/core/reflection_v2_test.dart
+++ b/packages/genkit/test/core/reflection_v2_test.dart
@@ -114,7 +114,7 @@ void main() {
     test('should handle listValues for middleware', () async {
       final def = defineMiddleware<dynamic>(
         name: 'retry',
-        create: ([config]) => throw UnimplementedError(),
+        create: (config, ctx) => throw UnimplementedError(),
       );
       registry.registerValue('middleware', def.name, def);
 

--- a/packages/genkit_middleware/lib/src/filesystem_middleware.dart
+++ b/packages/genkit_middleware/lib/src/filesystem_middleware.dart
@@ -79,7 +79,7 @@ class FilesystemPlugin extends GenkitPlugin {
     defineMiddleware<FilesystemOptions>(
       name: 'filesystem',
       configSchema: FilesystemOptions.$schema,
-      create: ([FilesystemOptions? config]) {
+      create: (config, ctx) {
         if (config == null) {
           throw ArgumentError(
             'filesystem middleware requires a rootDirectory option',

--- a/packages/genkit_middleware/lib/src/skills_middleware.dart
+++ b/packages/genkit_middleware/lib/src/skills_middleware.dart
@@ -44,7 +44,7 @@ class SkillsPlugin extends GenkitPlugin {
     defineMiddleware<SkillsPluginOptions>(
       name: 'skills',
       configSchema: SkillsPluginOptions.$schema,
-      create: ([SkillsPluginOptions? config]) =>
+      create: (config, ctx) =>
           SkillsMiddleware(config?.skillPaths ?? const ['skills']),
     ),
   ];

--- a/packages/genkit_middleware/lib/src/tool_approval_middleware.dart
+++ b/packages/genkit_middleware/lib/src/tool_approval_middleware.dart
@@ -36,7 +36,7 @@ class ToolApprovalPlugin extends GenkitPlugin {
     defineMiddleware<ToolApprovalOptions>(
       name: 'toolApproval',
       configSchema: ToolApprovalOptions.$schema,
-      create: ([ToolApprovalOptions? config]) {
+      create: (config, ctx) {
         final options =
             config ?? ToolApprovalOptions(approved: approvedTools ?? []);
         return ToolApprovalMiddleware(options);


### PR DESCRIPTION
Middleware factories created via `defineMiddleware` now receive a __context__ argument carrying an ephemeral `GenkitAI` instance, in addition to their config. This lets a middleware run its own AI operations (`generate`, `generateStream`, `embed`, etc.) at request time.

The primary motivation is to enable middleware that needs to call the model itself — for example an AI risk/safety classifier that runs a `generate` to score or filter a request or response, a summarization/guardrail middleware, or a routing middleware that asks a model to pick a downstream model. Previously the factory only received config, so a middleware had no way to run AI operations.

As a secondary benefit, the same `GenkitAI` exposes the active registry (`ctx.ai.registry`), so a middleware can also resolve other registered actions (models, tools, agents, etc.) by name — e.g. porting the JS `agents` middleware, which resolves sub-agents from the registry by name (`/agent/<name>`).

### `GenkitAI`: a registry-only AI veneer

To make the context useful without handing middleware the full framework entry point, this PR introduces a new `GenkitAI` base class that mirrors the Genkit JS `GenkitAI` pattern:

- `GenkitAI` holds only a `Registry` and exposes the model-orchestration veneer: `generate`, `generateStream`, `generateBidi`, `embed`, `embedMany`, and `run`.
- Because it only needs a registry (which holds all the state), `GenkitAI` is cheap to construct as an ephemeral, throwaway instance.
- `Genkit` now `extends GenkitAI`, adding the framework features on top: plugin loading, the reflection server, and the various `define*` methods. The model-orchestration methods are inherited from `GenkitAI`, so the public `Genkit` API is unchanged.
- The generate pipeline constructs an ephemeral `GenkitAI(registry)` from the active registry and passes it to middleware factories via the context.

### What changed

- New `base class GenkitAI` (`src/genkit_ai.dart`) holding a `Registry` and the model-orchestration veneer (`generate`, `generateStream`, `generateBidi`, `embed`, `embedMany`, `run`).
- `Genkit` now `extends GenkitAI`; the veneer methods moved out of `Genkit` into `GenkitAI`.
- New record type `GenerateMiddlewareContext = ({GenkitAI ai})`.
- `GenerateMiddlewareDef.create` and the `defineMiddleware(create: ...)` factory signature now take a second positional argument of that type.
- The generate pipeline passes an ephemeral `GenkitAI(registry)` through when instantiating middleware.
- `GenkitAI` and `GenerateMiddlewareContext` are exported from `package:genkit/genkit.dart`.
- Updated built-in middlewares (`retry`, `skills`, `tool_approval`, `filesystem`) and tests.

### ⚠️ BREAKING CHANGE

The `create` callback passed to `defineMiddleware` now takes a __second positional parameter__ (the context). Any custom middleware that calls `defineMiddleware` must update its `create` callback signature, or it will fail to compile.

Note: `config` also changes from an *optional positional* (`[config]`) to a *required positional* (`config`), since Dart cannot declare a required positional after an optional one. You don't need to pass it — the framework always does — but the lambda must declare it positionally.

### Migration

Add a second parameter to your `create` callback. If you don't need it, name it `ctx` (or `_`) and ignore it.

__Before__

```dart
defineMiddleware<MyOptions>(
  name: 'my_mw',
  configSchema: MyOptions.$schema,
  create: ([MyOptions? config]) => MyMiddleware(config),
);
```

__After__

```dart
defineMiddleware<MyOptions>(
  name: 'my_mw',
  configSchema: MyOptions.$schema,
  create: (config, ctx) => MyMiddleware(config),
);
```

__Using the context__ (the reason for this change) — e.g. an AI risk classifier that calls `generate`:

```dart
defineMiddleware<MyOptions>(
  name: 'risk_classifier',
  configSchema: MyOptions.$schema,
  create: (config, ctx) => RiskClassifierMiddleware(config, ai: ctx.ai),
);

class RiskClassifierMiddleware extends GenerateMiddleware {
  RiskClassifierMiddleware(this.config, {required this.ai});
  final MyOptions? config;
  final GenkitAI ai;

  @override
  Future<GenerateResponseHelper> generate(envelope, ctx, next) async {
    // Run a nested generate to classify the request before continuing.
    final verdict = await ai.generate(
      prompt: 'Classify the risk of this request: ${envelope.request}',
    );
    if (verdict.text.contains('BLOCK')) {
      throw GenkitException('Request blocked by risk classifier');
    }
    return next(envelope, ctx);
  }
}
```

The same `ctx.ai` also exposes the registry if you need to resolve actions by name:

```dart
final agent = await ctx.ai.registry.lookupAction('agent', 'researcher');
```
