### PR TITLE
feat(vertexai): curated known-model metadata + P0 Gemini 3.x registrations

### DIFF
--- a/packages/genkit_google_genai/lib/common.dart
+++ b/packages/genkit_google_genai/lib/common.dart
@@ -17,4 +17,5 @@ library;
 
 export 'src/api_client.dart';
 export 'src/common_plugin.dart';
+export 'src/known_models.dart';
 export 'src/model.dart';

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -40,11 +40,24 @@ final commonModelInfo = ModelInfo(
 abstract class CommonGoogleGenPlugin extends GenkitPlugin {
   Future<GenerativeLanguageBaseClient> getApiClient([String? requestApiKey]);
 
+  /// Curated per-model capability metadata exposed by this plugin, keyed by
+  /// bare model name.
+  ///
+  /// Model names not present here still resolve; they fall back to
+  /// [commonModelInfo]. Override in concrete plugins to advertise accurate
+  /// capabilities for known models.
+  Map<String, ModelInfo> get knownModels => const {};
+
+  /// Returns the capability metadata for [modelName], falling back to
+  /// [commonModelInfo] for names not in [knownModels].
+  ModelInfo modelInfoFor(String modelName) =>
+      knownModels[modelName] ?? commonModelInfo;
+
   Model createModel(String modelName, SchemanticType customOptions) {
     return Model(
       name: '$name/$modelName',
       customOptions: customOptions,
-      metadata: {'model': commonModelInfo.toJson()},
+      metadata: {'model': modelInfoFor(modelName).toJson()},
       fn: (req, ctx) async {
         gcl.GenerationConfig generationConfig;
         List<gcl.SafetySetting>? safetySettings;

--- a/packages/genkit_google_genai/lib/src/known_models.dart
+++ b/packages/genkit_google_genai/lib/src/known_models.dart
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+
+/// Builds the [ModelInfo] for a multimodal Gemini model.
+///
+/// Mirrors the `Multimodal` capability preset the Go plugin uses for its
+/// curated model list: multiturn chat, media input/output, tool calling and
+/// native constrained generation.
+ModelInfo multimodalModelInfo(String label) => ModelInfo(
+  label: label,
+  supports: {
+    'multiturn': true,
+    'media': true,
+    'tools': true,
+    'toolChoice': true,
+    'systemRole': true,
+    'constrained': true,
+  },
+  stage: 'stable',
+);
+
+/// Curated capability metadata for known Gemini models, keyed by bare model
+/// name (no plugin prefix).
+///
+/// Models are still resolved from raw strings; this map only enriches known
+/// names with per-model metadata instead of the shared `commonModelInfo`
+/// fallback. Plugins expose a subset via `CommonGoogleGenPlugin.knownModels`.
+final knownGeminiModels = <String, ModelInfo>{
+  'gemini-3.5-flash': multimodalModelInfo('Gemini 3.5 Flash'),
+  'gemini-3.1-flash-lite': multimodalModelInfo('Gemini 3.1 Flash Lite'),
+  'gemini-3.1-flash-image': multimodalModelInfo('Gemini 3.1 Flash Image'),
+  'gemini-3-pro-image': multimodalModelInfo('Gemini 3 Pro Image'),
+};

--- a/packages/genkit_google_genai/lib/src/known_models.dart
+++ b/packages/genkit_google_genai/lib/src/known_models.dart
@@ -21,14 +21,16 @@ import 'package:genkit/plugin.dart';
 /// native constrained generation.
 ModelInfo multimodalModelInfo(String label) => ModelInfo(
   label: label,
-  supports: {
+  // Unmodifiable: curated entries are shared across every resolution of the
+  // model, so accidental mutation through action metadata must fail loudly.
+  supports: Map.unmodifiable({
     'multiturn': true,
     'media': true,
     'tools': true,
     'toolChoice': true,
     'systemRole': true,
     'constrained': true,
-  },
+  }),
   stage: 'stable',
 );
 

--- a/packages/genkit_vertexai/lib/src/known_models.dart
+++ b/packages/genkit_vertexai/lib/src/known_models.dart
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+import 'package:genkit_google_genai/common.dart';
+
+/// Gemini models the Vertex AI plugin curates capability metadata for.
+///
+/// Any other model name still resolves dynamically with the common fallback
+/// metadata; this list only controls which names get accurate per-model
+/// `supports` and appear in listings even when model discovery omits them.
+const vertexAiKnownModelNames = [
+  'gemini-3.5-flash',
+  'gemini-3.1-flash-lite',
+  'gemini-3.1-flash-image',
+  'gemini-3-pro-image',
+];
+
+/// Curated capability metadata for the Vertex AI plugin, keyed by bare model
+/// name.
+final vertexAiKnownModels = <String, ModelInfo>{
+  for (final name in vertexAiKnownModelNames) name: knownGeminiModels[name]!,
+};

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -43,7 +43,7 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
   String get name => 'vertexai';
 
   @override
-  Map<String, ModelInfo> get knownModels => vertexAiKnownModels;
+  final Map<String, ModelInfo> knownModels = vertexAiKnownModels;
 
   @override
   Future<GenerativeLanguageBaseClient> getApiClient([

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -20,6 +20,7 @@ import 'package:meta/meta.dart';
 
 import 'auth.dart';
 import 'embedders.dart';
+import 'known_models.dart';
 
 @visibleForTesting
 class VertexAiPluginImpl extends CommonGoogleGenPlugin {
@@ -40,6 +41,9 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
 
   @override
   String get name => 'vertexai';
+
+  @override
+  Map<String, ModelInfo> get knownModels => vertexAiKnownModels;
 
   @override
   Future<GenerativeLanguageBaseClient> getApiClient([
@@ -88,6 +92,7 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
       );
       final publisherModels = (res['publisherModels'] as List?) ?? [];
 
+      final discoveredNames = <String>{};
       final models = publisherModels
           .where((m) {
             final modelMap = m as Map<String, dynamic>;
@@ -97,23 +102,35 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
           .map((m) {
             final modelMap = m as Map<String, dynamic>;
             final modelName = (modelMap['name'] as String).split('/').last;
+            discoveredNames.add(modelName);
             final isTts = modelName.contains('-tts');
             return modelMetadata(
               '$name/$modelName',
               customOptions: isTts
                   ? GeminiTtsOptions.$schema
                   : GeminiOptions.$schema,
-              modelInfo: commonModelInfo,
+              modelInfo: modelInfoFor(modelName),
             );
           })
           .toList();
+
+      // Curated models are listed even when model discovery omits them.
+      final curated = knownModels.entries
+          .where((entry) => !discoveredNames.contains(entry.key))
+          .map(
+            (entry) => modelMetadata(
+              '$name/${entry.key}',
+              customOptions: GeminiOptions.$schema,
+              modelInfo: entry.value,
+            ),
+          );
 
       final embedders = listVertexEmbedders(
         pluginName: name,
         publisherModels: publisherModels,
       );
 
-      return [...models, ...embedders];
+      return [...models, ...curated, ...embedders];
     } catch (e, stack) {
       if (e is GenkitException) rethrow;
       logger.warning('Failed to list models: $e', e, stack);

--- a/packages/genkit_vertexai/lib/src/vertex_api_client.dart
+++ b/packages/genkit_vertexai/lib/src/vertex_api_client.dart
@@ -120,7 +120,9 @@ class VertexAiPluginImpl extends CommonGoogleGenPlugin {
           .map(
             (entry) => modelMetadata(
               '$name/${entry.key}',
-              customOptions: GeminiOptions.$schema,
+              customOptions: entry.key.contains('-tts')
+                  ? GeminiTtsOptions.$schema
+                  : GeminiOptions.$schema,
               modelInfo: entry.value,
             ),
           );

--- a/packages/genkit_vertexai/test/known_models_test.dart
+++ b/packages/genkit_vertexai/test/known_models_test.dart
@@ -1,0 +1,104 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/common.dart';
+import 'package:genkit_vertexai/src/known_models.dart';
+import 'package:genkit_vertexai/src/vertex_api_client.dart';
+import 'package:test/test.dart';
+
+import 'test_http_client.dart';
+
+void main() {
+  VertexAiPluginImpl plugin({MockHttpClient? client}) => VertexAiPluginImpl(
+    projectId: 'my-project',
+    location: 'us-central1',
+    authClient: client ?? MockHttpClient(),
+  );
+
+  Map<String, dynamic> modelInfoOf(Action action) =>
+      (action.metadata['model'] as Map).cast<String, dynamic>();
+
+  group('known model resolution', () {
+    for (final name in vertexAiKnownModelNames) {
+      test('$name resolves with curated metadata', () {
+        final action = plugin().resolve('model', name);
+
+        expect(action, isNotNull);
+        final info = modelInfoOf(action!);
+        expect(info['label'], knownGeminiModels[name]!.label);
+        expect(info['stage'], 'stable');
+        expect(
+          (info['supports'] as Map).cast<String, dynamic>(),
+          knownGeminiModels[name]!.supports,
+        );
+      });
+    }
+
+    test('unknown model falls back to common metadata', () {
+      final action = plugin().resolve('model', 'gemini-unknown-model');
+
+      expect(action, isNotNull);
+      final info = modelInfoOf(action!);
+      expect(info['supports'], commonModelInfo.supports);
+      expect(info.containsKey('stage'), isFalse);
+      // Model defaults the label to the action name when not curated.
+      expect(info['label'], 'vertexai/gemini-unknown-model');
+    });
+  });
+
+  group('list', () {
+    test('includes curated models missing from discovery', () async {
+      final actions = await plugin().list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(names, contains('vertexai/gemini-1.5-pro'));
+      for (final name in vertexAiKnownModelNames) {
+        expect(names, contains('vertexai/$name'));
+      }
+
+      final curated = actions.firstWhere(
+        (a) => a.name == 'vertexai/gemini-3.5-flash',
+      );
+      final info = (curated.metadata['model'] as Map).cast<String, dynamic>();
+      expect(info['label'], 'Gemini 3.5 Flash');
+      expect(info['stage'], 'stable');
+    });
+
+    test('does not duplicate curated models returned by discovery', () async {
+      final client = MockHttpClient(
+        publisherModelsResponse:
+            '{"publisherModels": ['
+            '{"name": "publishers/google/models/gemini-3.5-flash"}, '
+            '{"name": "publishers/google/models/gemini-1.5-pro"}]}',
+      );
+      final actions = await plugin(client: client).list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(
+        names.where((n) => n == 'vertexai/gemini-3.5-flash'),
+        hasLength(1),
+      );
+
+      // Discovered entry still carries the curated metadata.
+      final discovered = actions.firstWhere(
+        (a) => a.name == 'vertexai/gemini-3.5-flash',
+      );
+      final info = (discovered.metadata['model'] as Map)
+          .cast<String, dynamic>();
+      expect(info['label'], 'Gemini 3.5 Flash');
+      expect(info['stage'], 'stable');
+    });
+  });
+}

--- a/packages/genkit_vertexai/test/known_models_test.dart
+++ b/packages/genkit_vertexai/test/known_models_test.dart
@@ -63,7 +63,7 @@ void main() {
       final actions = await plugin().list();
       final names = actions.map((a) => a.name).toList();
 
-      expect(names, contains('vertexai/gemini-1.5-pro'));
+      expect(names, contains('vertexai/gemini-2.5-pro'));
       for (final name in vertexAiKnownModelNames) {
         expect(names, contains('vertexai/$name'));
       }
@@ -81,7 +81,7 @@ void main() {
         publisherModelsResponse:
             '{"publisherModels": ['
             '{"name": "publishers/google/models/gemini-3.5-flash"}, '
-            '{"name": "publishers/google/models/gemini-1.5-pro"}]}',
+            '{"name": "publishers/google/models/gemini-2.5-pro"}]}',
       );
       final actions = await plugin(client: client).list();
       final names = actions.map((a) => a.name).toList();

--- a/packages/genkit_vertexai/test/test_http_client.dart
+++ b/packages/genkit_vertexai/test/test_http_client.dart
@@ -21,11 +21,15 @@ class MockHttpClient extends http.BaseClient {
     this.returnEmptyPredictions = false,
     this.returnInvalidTextPrediction = false,
     this.returnMissingMultimodalEmbedding = false,
+    this.publisherModelsResponse,
   });
 
   final bool returnEmptyPredictions;
   final bool returnInvalidTextPrediction;
   final bool returnMissingMultimodalEmbedding;
+
+  /// Overrides the JSON body returned for the publisher-models listing.
+  final String? publisherModelsResponse;
   final List<Uri> requestUrls = [];
   final List<String> requestBodies = [];
   Uri? lastUrl;
@@ -56,7 +60,8 @@ class MockHttpClient extends http.BaseClient {
       return http.StreamedResponse(
         Stream.value(
           utf8.encode(
-            '{"publisherModels": [{"name": "publishers/google/models/gemini-1.5-pro"}, {"name": "publishers/google/models/text-embedding-005"}, {"name": "publishers/google/models/multimodalembedding"}]}',
+            publisherModelsResponse ??
+                '{"publisherModels": [{"name": "publishers/google/models/gemini-1.5-pro"}, {"name": "publishers/google/models/text-embedding-005"}, {"name": "publishers/google/models/multimodalembedding"}]}',
           ),
         ),
         200,

--- a/packages/genkit_vertexai/test/test_http_client.dart
+++ b/packages/genkit_vertexai/test/test_http_client.dart
@@ -61,7 +61,7 @@ class MockHttpClient extends http.BaseClient {
         Stream.value(
           utf8.encode(
             publisherModelsResponse ??
-                '{"publisherModels": [{"name": "publishers/google/models/gemini-1.5-pro"}, {"name": "publishers/google/models/text-embedding-005"}, {"name": "publishers/google/models/multimodalembedding"}]}',
+                '{"publisherModels": [{"name": "publishers/google/models/gemini-2.5-pro"}, {"name": "publishers/google/models/text-embedding-005"}, {"name": "publishers/google/models/multimodalembedding"}]}',
           ),
         ),
         200,

--- a/packages/genkit_vertexai/test/vertex_test.dart
+++ b/packages/genkit_vertexai/test/vertex_test.dart
@@ -28,7 +28,7 @@ void main() {
         authClient: mockClient,
       );
 
-      final model = plugin.resolve('model', 'gemini-1.5-pro') as Action;
+      final model = plugin.resolve('model', 'gemini-2.5-pro') as Action;
       final req = ModelRequest(
         messages: [
           Message(
@@ -43,7 +43,7 @@ void main() {
       expect(mockClient.lastUrl, isNotNull);
       expect(
         mockClient.lastUrl.toString(),
-        'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent',
+        'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent',
       );
     });
 
@@ -55,7 +55,7 @@ void main() {
         authClient: mockClient,
       );
 
-      final model = plugin.resolve('model', 'gemini-1.5-pro') as Action;
+      final model = plugin.resolve('model', 'gemini-2.5-pro') as Action;
       final req = ModelRequest(
         messages: [
           Message(
@@ -70,7 +70,7 @@ void main() {
       expect(mockClient.lastUrl, isNotNull);
       expect(
         mockClient.lastUrl.toString(),
-        'https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-1.5-pro:generateContent',
+        'https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-2.5-pro:generateContent',
       );
     });
   });


### PR DESCRIPTION
## Summary

First slice of #303: introduces the curated known-model map decided in #302 (feature-parity half only, mirroring the Go plugin's `supportedGeminiModels` pattern) and seeds it with the four P0 Vertex AI models.

## Changes

- **`genkit_google_genai/src/known_models.dart` (new)**: `knownGeminiModels` map with per-model `label` / `supports` / `stage`, plus a `multimodalModelInfo` preset matching Go's `Multimodal` capability set.
- **`CommonGoogleGenPlugin`**: new `knownModels` getter (default empty) and `modelInfoFor(name)` fallback to `commonModelInfo`. `createModel` now stamps per-model metadata. Models still resolve from raw strings per the #302 decision - no public model symbols, no breaking surface.
- **`genkit_vertexai`**: exposes the four P0 entries (`gemini-3.5-flash`, `gemini-3.1-flash-lite`, `gemini-3.1-flash-image`, `gemini-3-pro-image`). `list()` applies curated metadata to discovered models and includes curated models even when publisher-model discovery omits them (deduped).

## Notes

- GoogleAI and Anthropic P0 entries from #303 follow as thin additive PRs on top of this map.
- Image-output models ride the existing `responseModalities` / `inlineData` handling; no new request machinery.

## Testing

- `dart analyze` clean on both packages.
- `dart test`: 26 passing in `genkit_vertexai` (7 new: curated resolution per model, common fallback, list union, list dedup), 29 passing in `genkit_google_genai`.


Dev UI connected: 21 models, 17 flows discovered from the Dart runtime. The gemini testapp running under genkit start with the PR-branch genkit_vertexai package resolved from the workspace:


<img width="1440" height="757" alt="image" src="https://github.com/user-attachments/assets/d61f1928-26ce-4f10-ad9f-e9cdaf3d9cee" />

Model picker filtered to "gemini-3": all four curated P0 models present. vertexai/gemini-3-pro-image, gemini-3.1-flash-image, gemini-3.1-flash-lite visible; gemini-3.5-flash already selected in the combobox above. Preview variants come from live Vertex discovery; the curated entries carry per-model metadata.
<img width="1440" height="757" alt="image" src="https://github.com/user-attachments/assets/4eababf4-8719-4353-a6d0-0a623b87a273" />

Real generate through vertexai/gemini-3.5-flash with ADC. Prompt sent to the live Vertex AI API using application-default credentials; the model responded. End-to-end proof the curated registration resolves and serves.
<img width="1440" height="757" alt="image" src="https://github.com/user-attachments/assets/a8fd2636-a26d-4a81-8c73-1847a87f3ded" />
