### PR TITLE
feat(anthropic): curated known-model metadata for Claude models

### DIFF
--- a/packages/genkit_anthropic/lib/src/known_models.dart
+++ b/packages/genkit_anthropic/lib/src/known_models.dart
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+
+/// Claude models the Anthropic plugin curates capability metadata for.
+///
+/// Each value pairs a bare model [id] (no plugin prefix) with a display
+/// [label]; [info] builds the shared Claude capability preset. Other model
+/// names still resolve dynamically via the plugin's `commonModelInfo`
+/// fallback, so this enum only enriches the names listed here.
+enum KnownClaudeModel {
+  fable5('claude-fable-5', 'Claude Fable 5'),
+  opus48('claude-opus-4-8', 'Claude Opus 4.8'),
+  opus47('claude-opus-4-7', 'Claude Opus 4.7'),
+  sonnet5('claude-sonnet-5', 'Claude Sonnet 5'),
+  sonnet46('claude-sonnet-4-6', 'Claude Sonnet 4.6'),
+  sonnet45('claude-sonnet-4-5', 'Claude Sonnet 4.5'),
+  haiku45('claude-haiku-4-5', 'Claude Haiku 4.5');
+
+  const KnownClaudeModel(this.id, this.label);
+
+  /// Bare model name (no plugin prefix).
+  final String id;
+
+  /// Human-readable label surfaced in listings.
+  final String label;
+
+  /// The capability profile shared by every current Claude model: multiturn
+  /// chat, vision (media input), tool calling with tool choice, a system role,
+  /// and native constrained generation. Mirrors the single `defaultClaudeOpts`
+  /// profile the Go plugin applies to every Claude model.
+  ModelInfo get info => ModelInfo(
+    label: label,
+    // Unmodifiable: curated entries are shared across every resolution of the
+    // model, so accidental mutation through action metadata must fail loudly.
+    supports: Map.unmodifiable({
+      'multiturn': true,
+      'media': true,
+      'tools': true,
+      'toolChoice': true,
+      'systemRole': true,
+      'constrained': true,
+    }),
+    stage: 'stable',
+  );
+}
+
+/// Curated capability metadata for known Claude models, keyed by bare model
+/// name (no plugin prefix).
+///
+/// Derived from [KnownClaudeModel]; other model names still resolve dynamically
+/// with the shared `commonModelInfo` fallback. This map only enriches known
+/// names with a typed label and stable stage, and ensures they appear in
+/// listings even when the Anthropic models endpoint omits them.
+final knownClaudeModels = <String, ModelInfo>{
+  for (final model in KnownClaudeModel.values) model.id: model.info,
+};

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart' as sdk;
 import 'package:genkit/plugin.dart';
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:schemantic/schemantic.dart';
 
+import 'known_models.dart';
 import 'model.dart';
+
+final _logger = Logger('genkit_anthropic');
 
 /// Default model capabilities shared by all Anthropic Claude models.
 final commonModelInfo = ModelInfo(
@@ -37,6 +44,7 @@ final commonModelInfo = ModelInfo(
 ///
 /// Automatically discovers available models from the Anthropic API and
 /// registers them in the Genkit action registry.
+@visibleForTesting
 class AnthropicPluginImpl extends GenkitPlugin {
   /// The static API key used to authenticate requests.
   final String? apiKey;
@@ -47,13 +55,45 @@ class AnthropicPluginImpl extends GenkitPlugin {
   /// Custom base URL for the Anthropic API.
   final String? baseUrl;
 
+  /// Optional HTTP client used for every request. Useful for proxies,
+  /// instrumentation, or injecting a mock transport in tests.
+  final http.Client? httpClient;
+
   sdk.AnthropicClient? _client;
 
   /// Creates an [AnthropicPluginImpl].
-  AnthropicPluginImpl({this.apiKey, this.headers, this.baseUrl});
+  AnthropicPluginImpl({
+    this.apiKey,
+    this.headers,
+    this.baseUrl,
+    this.httpClient,
+  });
 
   @override
   String get name => 'anthropic';
+
+  /// Curated per-model capability metadata, keyed by bare model name.
+  ///
+  /// Names absent here still resolve; they fall back to [commonModelInfo].
+  final Map<String, ModelInfo> knownModels = UnmodifiableMapView(
+    knownClaudeModels,
+  );
+
+  static final _datedSuffixRegExp = RegExp(r'-\d{8}$');
+
+  /// Strips a trailing dated-snapshot suffix (e.g.
+  /// `claude-haiku-4-5-20251001` -> `claude-haiku-4-5`) so dated ids returned
+  /// by the models endpoint map onto the curated aliases.
+  static String _aliasOf(String modelName) =>
+      modelName.replaceFirst(_datedSuffixRegExp, '');
+
+  /// Returns the capability metadata for [modelName], matching by exact name
+  /// first and then by dated-snapshot alias, falling back to [commonModelInfo]
+  /// for names not in [knownModels].
+  ModelInfo modelInfoFor(String modelName) =>
+      knownModels[modelName] ??
+      knownModels[_aliasOf(modelName)] ??
+      commonModelInfo;
 
   sdk.AnthropicClient get client {
     if (_client != null) return _client!;
@@ -62,31 +102,51 @@ class AnthropicPluginImpl extends GenkitPlugin {
         apiKey!,
         defaultHeaders: headers,
         baseUrl: baseUrl,
+        httpClient: httpClient,
       );
     }
     final config = sdk.AnthropicConfig.fromEnvironment();
     return _client = sdk.AnthropicClient(
       config: config.copyWith(defaultHeaders: headers, baseUrl: baseUrl),
+      httpClient: httpClient,
     );
   }
 
+  ActionMetadata _curatedMetadata(String name, ModelInfo info) => modelMetadata(
+    'anthropic/$name',
+    customOptions: AnthropicOptions.$schema,
+    modelInfo: info,
+  );
+
   @override
   Future<List<ActionMetadata>> list() async {
-    // Attempt to list models from the API if available, otherwise return manual list.
+    // Attempt to enrich the curated catalog with dynamically discovered
+    // models; fall back to the curated catalog alone if listing fails.
     try {
       final response = await client.models.list();
-      return response.data
-          .map(
-            (m) => modelMetadata(
-              'anthropic/${m.id}',
-              customOptions: AnthropicOptions.$schema,
-            ),
-          )
+      final discovered = response.data
+          .map((m) => _curatedMetadata(m.id, modelInfoFor(m.id)))
           .toList();
+      // Curated aliases already covered by discovery. The endpoint may return
+      // dated snapshot ids (e.g. `claude-haiku-4-5-20251001`), so match on the
+      // alias to both enrich (above) and dedup against the curated catalog.
+      final coveredAliases = response.data.map((m) => _aliasOf(m.id)).toSet();
+
+      // Curated models are listed even when discovery omits them.
+      final curated = knownModels.entries
+          .where((entry) => !coveredAliases.contains(entry.key))
+          .map((entry) => _curatedMetadata(entry.key, entry.value));
+
+      return [...discovered, ...curated];
     } catch (e, s) {
-      // Fallback or empty if listing fails/not supported as expected
-      print('Failed to list Anthropic models: $e\n$s');
-      return [];
+      // The sibling plugins rethrow here; this plugin degrades gracefully
+      // instead, advertising the curated catalog so known models stay listable
+      // when discovery is unavailable (e.g. offline).
+      _logger.warning('Failed to list Anthropic models: $e', e, s);
+      return [
+        for (final entry in knownModels.entries)
+          _curatedMetadata(entry.key, entry.value),
+      ];
     }
   }
 
@@ -104,7 +164,7 @@ class AnthropicPluginImpl extends GenkitPlugin {
     return Model(
       name: 'anthropic/$modelName',
       customOptions: AnthropicOptions.$schema,
-      metadata: {'model': commonModelInfo.toJson()},
+      metadata: {'model': modelInfoFor(modelName).toJson()},
       fn: (req, ctx) async {
         final options = req!.config == null
             ? AnthropicOptions()
@@ -115,6 +175,7 @@ class AnthropicPluginImpl extends GenkitPlugin {
                 options.apiKey!,
                 defaultHeaders: headers,
                 baseUrl: baseUrl,
+                httpClient: httpClient,
               )
             : client;
 

--- a/packages/genkit_anthropic/pubspec.yaml
+++ b/packages/genkit_anthropic/pubspec.yaml
@@ -11,6 +11,8 @@ environment:
 dependencies:
   anthropic_sdk_dart: ^2.0.0
   genkit: ^0.15.1
+  http: ^1.6.0
+  logging: ^1.3.0
   meta: ^1.17.0
   schemantic: ^0.2.2
 

--- a/packages/genkit_anthropic/test/known_models_test.dart
+++ b/packages/genkit_anthropic/test/known_models_test.dart
@@ -1,0 +1,225 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_anthropic/src/known_models.dart';
+import 'package:genkit_anthropic/src/plugin_impl.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  /// Builds a plugin whose Anthropic client answers `GET /v1/models` with the
+  /// given model ids (and nothing else hits the network).
+  AnthropicPluginImpl pluginListing(List<String> modelIds) {
+    final mock = MockClient((request) async {
+      if (request.url.path == '/v1/models') {
+        return http.Response(
+          jsonEncode({
+            'data': [
+              for (final id in modelIds)
+                {
+                  'id': id,
+                  'display_name': id,
+                  'created_at': '2025-01-01T00:00:00Z',
+                  'type': 'model',
+                },
+            ],
+            'has_more': false,
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      return http.Response('not found', 404);
+    });
+    return AnthropicPluginImpl(apiKey: 'test-key', httpClient: mock);
+  }
+
+  /// Offline plugin — no request is issued when only [resolve] is exercised.
+  AnthropicPluginImpl plugin() => AnthropicPluginImpl(apiKey: 'test-key');
+
+  Map<String, dynamic> modelInfoOf(Action action) =>
+      (action.metadata['model'] as Map).cast<String, dynamic>();
+
+  group('known model resolution', () {
+    for (final model in KnownClaudeModel.values) {
+      test('${model.id} resolves with curated metadata', () {
+        final action = plugin().resolve('model', model.id);
+
+        expect(action, isNotNull);
+        final info = modelInfoOf(action!);
+        expect(info['label'], model.label);
+        expect(info['stage'], 'stable');
+        expect(
+          (info['supports'] as Map).cast<String, dynamic>(),
+          model.info.supports,
+        );
+      });
+    }
+
+    test('unknown model falls back to common metadata', () {
+      final action = plugin().resolve('model', 'claude-unknown-model');
+
+      expect(action, isNotNull);
+      final info = modelInfoOf(action!);
+      expect(info['supports'], commonModelInfo.supports);
+      expect(info.containsKey('stage'), isFalse);
+    });
+
+    test('non-model action types do not resolve', () {
+      expect(plugin().resolve('embedder', 'claude-opus-4-8'), isNull);
+    });
+  });
+
+  group('list', () {
+    test('includes curated models missing from discovery', () async {
+      final actions = await pluginListing(['claude-3-5-sonnet-latest']).list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(names, contains('anthropic/claude-3-5-sonnet-latest'));
+      for (final model in KnownClaudeModel.values) {
+        expect(names, contains('anthropic/${model.id}'));
+      }
+
+      final curated = actions.firstWhere(
+        (a) => a.name == 'anthropic/claude-opus-4-8',
+      );
+      final info = (curated.metadata['model'] as Map).cast<String, dynamic>();
+      expect(info['label'], 'Claude Opus 4.8');
+      expect(info['stage'], 'stable');
+    });
+
+    test('does not duplicate curated models returned by discovery', () async {
+      final actions = await pluginListing([
+        'claude-opus-4-8',
+        'claude-3-haiku',
+      ]).list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(
+        names.where((n) => n == 'anthropic/claude-opus-4-8'),
+        hasLength(1),
+      );
+
+      // Discovered entry still carries the curated metadata.
+      final discovered = actions.firstWhere(
+        (a) => a.name == 'anthropic/claude-opus-4-8',
+      );
+      final info = (discovered.metadata['model'] as Map)
+          .cast<String, dynamic>();
+      expect(info['label'], 'Claude Opus 4.8');
+      expect(info['stage'], 'stable');
+
+      // A discovered, non-curated model falls back to common metadata.
+      final generic = actions.firstWhere(
+        (a) => a.name == 'anthropic/claude-3-haiku',
+      );
+      final genericInfo = (generic.metadata['model'] as Map)
+          .cast<String, dynamic>();
+      expect(genericInfo['supports'], commonModelInfo.supports);
+      expect(genericInfo.containsKey('stage'), isFalse);
+    });
+
+    test(
+      'enriches dated snapshot ids and does not duplicate their alias',
+      () async {
+        // The models endpoint returns dated ids; the curated alias must not be
+        // appended again, and the dated entry must carry curated metadata.
+        final actions = await pluginListing([
+          'claude-haiku-4-5-20251001',
+        ]).list();
+        final names = actions.map((a) => a.name).toList();
+
+        expect(names, contains('anthropic/claude-haiku-4-5-20251001'));
+        expect(names, isNot(contains('anthropic/claude-haiku-4-5')));
+
+        final dated = actions.firstWhere(
+          (a) => a.name == 'anthropic/claude-haiku-4-5-20251001',
+        );
+        final info = (dated.metadata['model'] as Map).cast<String, dynamic>();
+        expect(info['label'], 'Claude Haiku 4.5');
+        expect(info['stage'], 'stable');
+      },
+    );
+
+    test('falls back to the curated catalog when discovery fails', () async {
+      // A 401 is a non-retryable client error, so the SDK surfaces it
+      // immediately (no retry backoff) and list() takes the fallback path.
+      final plugin = AnthropicPluginImpl(
+        apiKey: 'test-key',
+        httpClient: MockClient((_) async => http.Response('unauthorized', 401)),
+      );
+
+      final names = (await plugin.list()).map((a) => a.name).toSet();
+      for (final model in KnownClaudeModel.values) {
+        expect(names, contains('anthropic/${model.id}'));
+      }
+    });
+  });
+
+  group('KnownClaudeModel', () {
+    test('info carries the label, stable stage, and shared supports', () {
+      for (final model in KnownClaudeModel.values) {
+        final info = model.info;
+        expect(info.label, model.label);
+        expect(info.stage, 'stable');
+        expect(info.supports, {
+          'multiturn': true,
+          'media': true,
+          'tools': true,
+          'toolChoice': true,
+          'systemRole': true,
+          'constrained': true,
+        });
+      }
+    });
+
+    test('supports map is unmodifiable', () {
+      expect(
+        () => KnownClaudeModel.opus48.info.supports!['multiturn'] = false,
+        throwsUnsupportedError,
+      );
+    });
+  });
+
+  group('knownClaudeModels', () {
+    test('exposes the curated bare model names', () {
+      expect(
+        knownClaudeModels.keys,
+        containsAll([
+          'claude-fable-5',
+          'claude-opus-4-8',
+          'claude-opus-4-7',
+          'claude-sonnet-5',
+          'claude-sonnet-4-6',
+          'claude-sonnet-4-5',
+          'claude-haiku-4-5',
+        ]),
+      );
+    });
+
+    test('is derived from the enum, keyed by bare model id', () {
+      expect(
+        knownClaudeModels.keys,
+        unorderedEquals([for (final m in KnownClaudeModel.values) m.id]),
+      );
+      for (final model in KnownClaudeModel.values) {
+        expect(knownClaudeModels[model.id]!.label, model.label);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a curated known-model catalog to the `genkit_anthropic` plugin, mirroring the treatment merged for `googleAI`/`vertexAI` (#320) and refactored to the enum shape in #323. Known Claude model names resolve with a typed `ModelInfo` (label + `stage: 'stable'` + capability `supports`); unknown names still resolve dynamically via the shared `commonModelInfo` fallback.

Curated models (verified against the Anthropic models docs):
- `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`

## Changes

- **`lib/src/known_models.dart`** (new) — `KnownClaudeModel` enum: each value pairs a bare model `id` with its `label` and exposes the shared Claude capability preset via an `info` getter. `knownClaudeModels` is derived from the enum (`{ for m in KnownClaudeModel.values: m.id: m.info }`). Same shape as `KnownGeminiModel` in #323.
- **`lib/src/plugin_impl.dart`**
  - `knownModels` (`UnmodifiableMapView`) + `modelInfoFor()` fallback, wired into `resolve()` and model creation.
  - `list()` enriches discovered models with per-model `modelInfo`, appends curated entries missing from discovery (dedup), and falls back to the curated catalog when discovery fails.
  - Dated-snapshot ids (e.g. `claude-haiku-4-5-20251001`) are normalized to their alias for enrichment and dedup.
  - `print` replaced with `Logger('genkit_anthropic')`, matching the sibling plugins.
  - Optional `httpClient` (custom HTTP transport) seam, `@visibleForTesting`, used to inject a mock transport in the offline unit tests.
- **`test/known_models_test.dart`** (new) — resolve (curated + fallback), `list()` merge / no-dup / dated-id / discovery-failure, plus enum `info` shape, unmodifiable supports, and enum->map derivation with a literal-name assertion. Offline via a mocked HTTP client.
- **`pubspec.yaml`** — adds `logging` and `http` dependencies.

## Notes

- Go's Anthropic plugin has no per-Claude catalog (a single `defaultClaudeOpts`), so this deliberately goes a step beyond Go to bring Claude to the same autocompletable-catalog bar as the Gemini/Vertex work.
- `claude-mythos-5` / `claude-mythos-preview` are intentionally excluded (invitation-only, Project Glasswing).
- Depends conceptually on the enum pattern in #323; generate/stream paths are unchanged.

## Testing

`dart analyze` clean; tests pass (`dart test`). Verified end-to-end in the Genkit Dev UI: with no valid API key the discovery call fails and the plugin falls back to the curated catalog, registering all curated models with their labels + `stage: stable`.