### PR TITLE
refactor(google_genai,vertexai): model curated Gemini catalog as an enum

### DIFF
--- a/packages/genkit_google_genai/lib/src/known_models.dart
+++ b/packages/genkit_google_genai/lib/src/known_models.dart
@@ -14,35 +14,55 @@
 
 import 'package:genkit/plugin.dart';
 
-/// Builds the [ModelInfo] for a multimodal Gemini model.
+/// Gemini models the Google generative-AI plugins curate capability metadata
+/// for.
 ///
-/// Mirrors the `Multimodal` capability preset the Go plugin uses for its
-/// curated model list: multiturn chat, media input/output, tool calling and
-/// native constrained generation.
-ModelInfo multimodalModelInfo(String label) => ModelInfo(
-  label: label,
-  // Unmodifiable: curated entries are shared across every resolution of the
-  // model, so accidental mutation through action metadata must fail loudly.
-  supports: Map.unmodifiable({
-    'multiturn': true,
-    'media': true,
-    'tools': true,
-    'toolChoice': true,
-    'systemRole': true,
-    'constrained': true,
-  }),
-  stage: 'stable',
-);
+/// Each value pairs a bare model [id] (no plugin prefix) with a display
+/// [label]; [info] builds the shared multimodal capability preset. Other model
+/// names still resolve dynamically via the plugin's `commonModelInfo`
+/// fallback, so this enum only enriches the names listed here.
+enum KnownGeminiModel {
+  gemini35Flash('gemini-3.5-flash', 'Gemini 3.5 Flash'),
+  gemini31FlashLite('gemini-3.1-flash-lite', 'Gemini 3.1 Flash Lite'),
+  gemini31FlashImage('gemini-3.1-flash-image', 'Gemini 3.1 Flash Image'),
+  gemini3ProImage('gemini-3-pro-image', 'Gemini 3 Pro Image');
+
+  const KnownGeminiModel(this.id, this.label);
+
+  /// Bare model name (no plugin prefix).
+  final String id;
+
+  /// Human-readable label surfaced in listings.
+  final String label;
+
+  /// The multimodal capability profile for this model.
+  ///
+  /// Mirrors the `Multimodal` preset the Go plugin uses for its curated model
+  /// list: multiturn chat, media input/output, tool calling with tool choice,
+  /// a system role, and native constrained generation.
+  ModelInfo get info => ModelInfo(
+    label: label,
+    // Unmodifiable: curated entries are shared across every resolution of the
+    // model, so accidental mutation through action metadata must fail loudly.
+    supports: Map.unmodifiable({
+      'multiturn': true,
+      'media': true,
+      'tools': true,
+      'toolChoice': true,
+      'systemRole': true,
+      'constrained': true,
+    }),
+    stage: 'stable',
+  );
+}
 
 /// Curated capability metadata for known Gemini models, keyed by bare model
 /// name (no plugin prefix).
 ///
-/// Models are still resolved from raw strings; this map only enriches known
-/// names with per-model metadata instead of the shared `commonModelInfo`
-/// fallback. Plugins expose a subset via `CommonGoogleGenPlugin.knownModels`.
+/// Derived from [KnownGeminiModel]; models are still resolved from raw strings,
+/// this map only enriches known names with per-model metadata instead of the
+/// shared `commonModelInfo` fallback. Plugins expose a subset via
+/// `CommonGoogleGenPlugin.knownModels`.
 final knownGeminiModels = <String, ModelInfo>{
-  'gemini-3.5-flash': multimodalModelInfo('Gemini 3.5 Flash'),
-  'gemini-3.1-flash-lite': multimodalModelInfo('Gemini 3.1 Flash Lite'),
-  'gemini-3.1-flash-image': multimodalModelInfo('Gemini 3.1 Flash Image'),
-  'gemini-3-pro-image': multimodalModelInfo('Gemini 3 Pro Image'),
+  for (final model in KnownGeminiModel.values) model.id: model.info,
 };

--- a/packages/genkit_google_genai/test/known_models_test.dart
+++ b/packages/genkit_google_genai/test/known_models_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit_google_genai/src/known_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('KnownGeminiModel', () {
+    test('info carries the label, stable stage, and multimodal supports', () {
+      for (final model in KnownGeminiModel.values) {
+        final info = model.info;
+        expect(info.label, model.label);
+        expect(info.stage, 'stable');
+        expect(info.supports, {
+          'multiturn': true,
+          'media': true,
+          'tools': true,
+          'toolChoice': true,
+          'systemRole': true,
+          'constrained': true,
+        });
+      }
+    });
+
+    test('supports map is unmodifiable', () {
+      expect(
+        () =>
+            KnownGeminiModel.gemini35Flash.info.supports!['multiturn'] = false,
+        throwsUnsupportedError,
+      );
+    });
+  });
+
+  group('knownGeminiModels', () {
+    test('exposes the curated bare model names', () {
+      // Pin the literal ids so a typo in an enum value fails the suite (the
+      // derivation test below draws both sides from the enum, so it can't).
+      expect(
+        knownGeminiModels.keys,
+        containsAll([
+          'gemini-3.5-flash',
+          'gemini-3.1-flash-lite',
+          'gemini-3.1-flash-image',
+          'gemini-3-pro-image',
+        ]),
+      );
+    });
+
+    test('is derived from the enum, keyed by bare model id', () {
+      expect(
+        knownGeminiModels.keys,
+        unorderedEquals([for (final m in KnownGeminiModel.values) m.id]),
+      );
+      for (final model in KnownGeminiModel.values) {
+        expect(knownGeminiModels[model.id]!.label, model.label);
+      }
+    });
+  });
+}

--- a/packages/genkit_vertexai/lib/src/known_models.dart
+++ b/packages/genkit_vertexai/lib/src/known_models.dart
@@ -17,18 +17,19 @@ import 'package:genkit_google_genai/common.dart';
 
 /// Gemini models the Vertex AI plugin curates capability metadata for.
 ///
-/// Any other model name still resolves dynamically with the common fallback
-/// metadata; this list only controls which names get accurate per-model
-/// `supports` and appear in listings even when model discovery omits them.
-const vertexAiKnownModelNames = [
-  'gemini-3.5-flash',
-  'gemini-3.1-flash-lite',
-  'gemini-3.1-flash-image',
-  'gemini-3-pro-image',
+/// A subset of [KnownGeminiModel]. Any other model name still resolves
+/// dynamically with the common fallback metadata; these entries only give the
+/// listed models accurate per-model `supports` and keep them in listings even
+/// when model discovery omits them.
+const vertexAiKnownGeminiModels = <KnownGeminiModel>[
+  KnownGeminiModel.gemini35Flash,
+  KnownGeminiModel.gemini31FlashLite,
+  KnownGeminiModel.gemini31FlashImage,
+  KnownGeminiModel.gemini3ProImage,
 ];
 
 /// Curated capability metadata for the Vertex AI plugin, keyed by bare model
-/// name.
+/// name. Derived from [vertexAiKnownGeminiModels].
 final vertexAiKnownModels = <String, ModelInfo>{
-  for (final name in vertexAiKnownModelNames) name: knownGeminiModels[name]!,
+  for (final model in vertexAiKnownGeminiModels) model.id: model.info,
 };

--- a/packages/genkit_vertexai/test/known_models_test.dart
+++ b/packages/genkit_vertexai/test/known_models_test.dart
@@ -31,17 +31,17 @@ void main() {
       (action.metadata['model'] as Map).cast<String, dynamic>();
 
   group('known model resolution', () {
-    for (final name in vertexAiKnownModelNames) {
-      test('$name resolves with curated metadata', () {
-        final action = plugin().resolve('model', name);
+    for (final model in vertexAiKnownGeminiModels) {
+      test('${model.id} resolves with curated metadata', () {
+        final action = plugin().resolve('model', model.id);
 
         expect(action, isNotNull);
         final info = modelInfoOf(action!);
-        expect(info['label'], knownGeminiModels[name]!.label);
+        expect(info['label'], model.label);
         expect(info['stage'], 'stable');
         expect(
           (info['supports'] as Map).cast<String, dynamic>(),
-          knownGeminiModels[name]!.supports,
+          model.info.supports,
         );
       });
     }
@@ -64,8 +64,8 @@ void main() {
       final names = actions.map((a) => a.name).toList();
 
       expect(names, contains('vertexai/gemini-2.5-pro'));
-      for (final name in vertexAiKnownModelNames) {
-        expect(names, contains('vertexai/$name'));
+      for (final model in vertexAiKnownGeminiModels) {
+        expect(names, contains('vertexai/${model.id}'));
       }
 
       final curated = actions.firstWhere(


### PR DESCRIPTION
Applies review feedback from #322 (@Lyokone): model the curated Gemini catalog as an enum with the capability-preset builder attached to a type, rather than a top-level function + plain map.

## Change

**`google_genai/lib/src/known_models.dart`**
- Replaces the top-level `multimodalModelInfo(String label)` builder and the `<String, ModelInfo>` literal with a `KnownGeminiModel` enum. Each value pairs a bare model `id` with its `label` and exposes the multimodal capability preset via an `info` getter.
- `knownGeminiModels` is now **derived** from the enum (`{ for m in KnownGeminiModel.values: m.id: m.info }`). The public map is unchanged in shape and content, so `CommonGoogleGenPlugin.knownModels` needs no changes.

**`vertexai/lib/src/known_models.dart`**
- Selects its curated set from `KnownGeminiModel.values` (`vertexAiKnownGeminiModels`) instead of re-typing the four model-id strings, and derives `vertexAiKnownModels` from that. Removes the string duplication that could silently drift from the enum (a rename would previously throw at init via `knownGeminiModels[name]!`).

Result: the curated set is a single typed, iterable source of truth (`KnownGeminiModel.values`).

## On the `ModelInfo.fromLabel` suggestion

The review also suggested a builder *inside* `ModelInfo` (e.g. `ModelInfo.fromLabel`). `ModelInfo` is a **generated core type** (`genkit/lib/src/types.g.dart`), and Dart 3.10 extensions can't declare constructors or static members, so a literal `ModelInfo.fromLabel` would require a core-framework change. The builder therefore lives on the enum (`.info`) to keep this plugin-scoped. Happy to move it to core in a separate change if that's preferred.

## Follow-up

- The `genkit_anthropic` curated-catalog PR (#322) will adopt this same enum shape once this lands.

## Testing

Adds `google_genai/test/known_models_test.dart` (enum `info` shape, unmodifiable supports, enum->map derivation, and a literal-name assertion so an id typo can't slip past the derivation test). vertexai `known_models_test.dart` updated to iterate the enum. `dart analyze` clean; google_genai + vertexai suites pass.