### PR TITLE
fix(prompt): carry resolved middleware refs on rendered options

### DIFF
--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -430,8 +430,14 @@ class ExecutablePrompt<Input> {
 /// Converts a config value to a Map. Follows the same pattern as generate.dart.
 Map<String, dynamic>? _configToMap(dynamic config) {
   if (config == null) return null;
-  if (config is Map) return config as Map<String, dynamic>;
-  return (config as dynamic).toJson() as Map<String, dynamic>;
+  if (config is Map) return config.cast<String, dynamic>();
+  if (config is String || config is num || config is bool) return null;
+
+  try {
+    return (config as dynamic).toJson() as Map<String, dynamic>?;
+  } catch (_) {
+    return null;
+  }
 }
 
 /// Defines an executable prompt and registers it in the registry.

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -217,6 +217,20 @@ class ExecutablePrompt<Input> {
           ...?opts?.tools?.map((t) => t.name),
         }.toList();
 
+        // Resolve middleware refs. These must be carried on the returned
+        // options so callers that run the rendered request directly (e.g. the
+        // agent runtime via `runGenerateAction`) still apply the middleware.
+        final resolvedUse = <MiddlewareRef>[
+          ...?_config.use?.map(
+            (mw) =>
+                MiddlewareRef(name: mw.name, config: _configToMap(mw.config)),
+          ),
+          ...?opts?.use?.map(
+            (mw) =>
+                MiddlewareRef(name: mw.name, config: _configToMap(mw.config)),
+          ),
+        ];
+
         return GenerateActionOptions(
           model: resolvedModel?.name,
           messages: messages,
@@ -227,6 +241,7 @@ class ExecutablePrompt<Input> {
               opts?.returnToolRequests ?? _config.returnToolRequests,
           maxTurns: opts?.maxTurns ?? _config.maxTurns,
           output: opts?.output ?? _config.output,
+          use: resolvedUse.isNotEmpty ? resolvedUse : null,
         );
       },
       input: input,

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -372,6 +372,100 @@ void main() {
       expect(options.maxTurns, equals(10));
     });
 
+    test('resolves middleware use from config', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          use: [middlewareRef(name: 'mw1')],
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.use, isNotNull);
+      expect(options.use!.length, equals(1));
+      expect(options.use![0].name, equals('mw1'));
+    });
+
+    test('resolves middleware use from opts', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', prompt: 'Hello'),
+      );
+
+      final options = await ep.render(
+        {},
+        PromptGenerateOptions(use: [middlewareRef(name: 'mw2')]),
+      );
+
+      expect(options.use, isNotNull);
+      expect(options.use!.length, equals(1));
+      expect(options.use![0].name, equals('mw2'));
+    });
+
+    test('merges middleware use from config and opts', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          use: [middlewareRef(name: 'configMw')],
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render(
+        {},
+        PromptGenerateOptions(use: [middlewareRef(name: 'optsMw')]),
+      );
+
+      // Config middleware should come first, then opts middleware.
+      expect(options.use, isNotNull);
+      expect(
+        options.use!.map((m) => m.name).toList(),
+        equals(['configMw', 'optsMw']),
+      );
+    });
+
+    test('carries middleware config through render', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          use: [
+            middlewareRef<Map<String, dynamic>>(
+              name: 'mw1',
+              config: {'foo': 'bar'},
+            ),
+          ],
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.use, isNotNull);
+      expect(options.use![0].name, equals('mw1'));
+      expect(options.use![0].config, equals({'foo': 'bar'}));
+    });
+
+    test('use is null when no middleware provided', () async {
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(name: 'test', prompt: 'Hello'),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.use, isNull);
+    });
+
     test('adds history from opts when no messages config', () async {
       final ep = definePromptAction(
         registry,

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -466,6 +466,31 @@ void main() {
       expect(options.use, isNull);
     });
 
+    test('middleware config with non-String map keys is handled', () async {
+      // A middleware config given as a Map<dynamic, dynamic> (not exactly
+      // Map<String, dynamic>) must not throw during render.
+      final ep = definePromptAction(
+        registry,
+        dpRegistry,
+        PromptConfig(
+          name: 'test',
+          use: [
+            middlewareRef<Map<dynamic, dynamic>>(
+              name: 'mw1',
+              config: <dynamic, dynamic>{'foo': 'bar'},
+            ),
+          ],
+          prompt: 'Hello',
+        ),
+      );
+
+      final options = await ep.render({});
+
+      expect(options.use, isNotNull);
+      expect(options.use![0].name, equals('mw1'));
+      expect(options.use![0].config, equals({'foo': 'bar'}));
+    });
+
     test('adds history from opts when no messages config', () async {
       final ep = definePromptAction(
         registry,


### PR DESCRIPTION
Resolve middleware refs from both prompt config and call options, attaching them to the returned GenerateActionOptions. This ensures callers that run the rendered request directly (e.g. the agent runtime via runGenerateAction) still apply the configured middleware.