### PR TITLE
feat(google_genai): wire curated Gemini catalog into googleai plugin

### DIFF
--- a/packages/genkit_google_genai/lib/genkit_google_genai.dart
+++ b/packages/genkit_google_genai/lib/genkit_google_genai.dart
@@ -41,11 +41,11 @@ class GoogleGenAiPluginHandle {
   }
 }
 
-/// Typed [ModelRef]s for the curated Gemini models.
+/// Typed [ModelRef]s for the Gemini models curated by the googleai plugin.
 ///
 /// Each entry is equivalent to `googleAI.gemini('<name>')`, which remains the
 /// escape hatch for models not listed here.
-abstract final class GeminiModels {
+abstract final class GoogleAiModels {
   static final ModelRef<GeminiOptions> gemini35Flash = googleAI.gemini(
     KnownGeminiModel.gemini35Flash.id,
   );

--- a/packages/genkit_google_genai/lib/genkit_google_genai.dart
+++ b/packages/genkit_google_genai/lib/genkit_google_genai.dart
@@ -15,6 +15,7 @@
 import 'package:genkit/plugin.dart';
 
 import 'src/google_api_client.dart';
+import 'src/known_models.dart';
 import 'src/model.dart';
 
 export 'src/model.dart';
@@ -38,4 +39,26 @@ class GoogleGenAiPluginHandle {
       customOptions: TextEmbedderOptions.$schema,
     );
   }
+}
+
+/// Typed [ModelRef]s for the curated Gemini models.
+///
+/// Each entry is equivalent to `googleAI.gemini('<name>')`, which remains the
+/// escape hatch for models not listed here.
+abstract final class GeminiModels {
+  static final ModelRef<GeminiOptions> gemini35Flash = googleAI.gemini(
+    KnownGeminiModel.gemini35Flash.id,
+  );
+
+  static final ModelRef<GeminiOptions> gemini31FlashLite = googleAI.gemini(
+    KnownGeminiModel.gemini31FlashLite.id,
+  );
+
+  static final ModelRef<GeminiOptions> gemini31FlashImage = googleAI.gemini(
+    KnownGeminiModel.gemini31FlashImage.id,
+  );
+
+  static final ModelRef<GeminiOptions> gemini3ProImage = googleAI.gemini(
+    KnownGeminiModel.gemini3ProImage.id,
+  );
 }

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -13,21 +13,32 @@
 // limitations under the License.
 
 import 'package:genkit/plugin.dart';
+import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 import 'api_client.dart';
 import 'common_plugin.dart';
 import 'generated/generativelanguage.dart' as gcl;
+import 'known_models.dart';
 import 'model.dart';
 
 @visibleForTesting
 class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
   String? apiKey;
 
-  GoogleGenAiPluginImpl({this.apiKey});
+  /// Test-only HTTP transport. When set it replaces the API-key client for
+  /// every request (any per-request `apiKey` option is ignored) and is never
+  /// closed by the plugin; the caller owns its lifecycle.
+  @visibleForTesting
+  final http.Client? httpClient;
+
+  GoogleGenAiPluginImpl({this.apiKey, this.httpClient});
 
   @override
   String get name => 'googleai';
+
+  @override
+  final Map<String, ModelInfo> knownModels = knownGeminiModels;
 
   @override
   Future<GenerativeLanguageBaseClient> getApiClient([
@@ -35,7 +46,7 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
   ]) async {
     return GenerativeLanguageBaseClient(
       baseUrl: 'https://generativelanguage.googleapis.com/',
-      client: httpClientFromApiKey(requestApiKey ?? apiKey),
+      client: httpClient ?? httpClientFromApiKey(requestApiKey ?? apiKey),
     );
   }
 
@@ -49,24 +60,33 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
         modelsResponse = await service.listModels(pageSize: 1000);
       } catch (e, stack) {
         logger.warning('Failed to list models: $e', e, stack);
-        throw handleException(e, stack);
+        return knownModels.entries.map(_curatedModelMetadata).toList();
       }
+      final discoveredNames = <String>{};
       final models = (modelsResponse.models ?? [])
           .where((model) {
             return model.name != null &&
                 model.name!.startsWith('models/gemini-');
           })
           .map((model) {
-            final isTts = model.name!.contains('-tts');
+            final bareName = model.name!.split('/').last;
+            discoveredNames.add(bareName);
+            final isTts = bareName.contains('-tts');
             return modelMetadata(
-              '$name/${model.name!.split('/').last}',
+              '$name/$bareName',
               customOptions: isTts
                   ? GeminiTtsOptions.$schema
                   : GeminiOptions.$schema,
-              modelInfo: commonModelInfo,
+              modelInfo: modelInfoFor(bareName),
             );
           })
           .toList();
+
+      // Curated models are listed even when model discovery omits them.
+      final curated = knownModels.entries
+          .where((entry) => !discoveredNames.contains(entry.key))
+          .map(_curatedModelMetadata);
+
       final embedders = (modelsResponse.models ?? [])
           .where(
             (model) =>
@@ -78,14 +98,28 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
             return embedderMetadata('$name/${model.name!.split('/').last}');
           })
           .toList();
-      return [...models, ...embedders];
+      return [...models, ...curated, ...embedders];
     } catch (e, stack) {
       if (e is GenkitException) rethrow;
       logger.warning('Failed to list models: $e', e, stack);
       throw handleException(e, stack);
     } finally {
-      service.client.close();
+      if (httpClient == null) {
+        service.client.close();
+      }
     }
+  }
+
+  ActionMetadata<dynamic, dynamic, dynamic, dynamic> _curatedModelMetadata(
+    MapEntry<String, ModelInfo> entry,
+  ) {
+    return modelMetadata(
+      '$name/${entry.key}',
+      customOptions: entry.key.contains('-tts')
+          ? GeminiTtsOptions.$schema
+          : GeminiOptions.$schema,
+      modelInfo: entry.value,
+    );
   }
 
   @override
@@ -145,7 +179,9 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
         } catch (e, stack) {
           throw handleException(e, stack);
         } finally {
-          service.client.close();
+          if (httpClient == null) {
+            service.client.close();
+          }
         }
       },
     );

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -46,7 +46,9 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
   ]) async {
     return GenerativeLanguageBaseClient(
       baseUrl: 'https://generativelanguage.googleapis.com/',
-      client: httpClient ?? httpClientFromApiKey(requestApiKey ?? apiKey),
+      client: httpClient != null
+          ? _NonClosingClient(httpClient!)
+          : httpClientFromApiKey(requestApiKey ?? apiKey),
     );
   }
 
@@ -104,9 +106,7 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
       logger.warning('Failed to list models: $e', e, stack);
       throw handleException(e, stack);
     } finally {
-      if (httpClient == null) {
-        service.client.close();
-      }
+      service.client.close();
     }
   }
 
@@ -179,11 +179,21 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
         } catch (e, stack) {
           throw handleException(e, stack);
         } finally {
-          if (httpClient == null) {
-            service.client.close();
-          }
+          service.client.close();
         }
       },
     );
   }
+}
+
+/// Delegates to a caller-owned client but ignores `close()`, so the plugin's
+/// per-call cleanup never tears down an injected transport.
+class _NonClosingClient extends http.BaseClient {
+  _NonClosingClient(this._inner);
+
+  final http.Client _inner;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) =>
+      _inner.send(request);
 }

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -60,6 +60,10 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
       try {
         modelsResponse = await service.listModels(pageSize: 1000);
       } catch (e, stack) {
+        // Any discovery failure (network, auth, quota) degrades to the curated
+        // catalog rather than rethrowing, matching the anthropic plugin. The
+        // Go and JS plugins swallow these errors too but return an empty list;
+        // a misconfigured key still fails loudly at generate time.
         logger.warning('Failed to list models: $e', e, stack);
         return knownModels.entries.map(_curatedModelMetadata).toList();
       }

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -29,7 +29,6 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
   /// Test-only HTTP transport. When set it replaces the API-key client for
   /// every request (any per-request `apiKey` option is ignored) and is never
   /// closed by the plugin; the caller owns its lifecycle.
-  @visibleForTesting
   final http.Client? httpClient;
 
   GoogleGenAiPluginImpl({this.apiKey, this.httpClient});

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -199,4 +199,10 @@ class _NonClosingClient extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) =>
       _inner.send(request);
+
+  @override
+  void close() {
+    // Intentional no-op: the inner client is caller-owned and must survive
+    // the per-call close() in the list/embed/generate paths.
+  }
 }

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -61,9 +61,8 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
         modelsResponse = await service.listModels(pageSize: 1000);
       } catch (e, stack) {
         // Any discovery failure (network, auth, quota) degrades to the curated
-        // catalog rather than rethrowing, matching the anthropic plugin. The
-        // Go and JS plugins swallow these errors too but return an empty list;
-        // a misconfigured key still fails loudly at generate time.
+        // catalog rather than rethrowing; a misconfigured key still fails
+        // loudly at generate time.
         logger.warning('Failed to list models: $e', e, stack);
         return knownModels.entries.map(_curatedModelMetadata).toList();
       }

--- a/packages/genkit_google_genai/test/known_models_wiring_test.dart
+++ b/packages/genkit_google_genai/test/known_models_wiring_test.dart
@@ -1,0 +1,188 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/common.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+class MockHttpClient extends http.BaseClient {
+  MockHttpClient({this.modelsResponse, this.listStatus = 200});
+
+  /// Overrides the JSON body returned for the models listing.
+  final String? modelsResponse;
+
+  /// HTTP status returned for the models listing.
+  final int listStatus;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (request.url.path != '/v1beta/models') {
+      throw StateError('Unexpected request: ${request.url}');
+    }
+    final body =
+        modelsResponse ??
+        '{"models": ['
+            '{"name": "models/gemini-2.0-flash"}, '
+            '{"name": "models/text-embedding-004"}]}';
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(body)),
+      listStatus,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+}
+
+void main() {
+  GoogleGenAiPluginImpl plugin({MockHttpClient? client}) =>
+      GoogleGenAiPluginImpl(
+        apiKey: 'test-key',
+        httpClient: client ?? MockHttpClient(),
+      );
+
+  Map<String, dynamic> modelInfoOf(Action action) =>
+      (action.metadata['model'] as Map).cast<String, dynamic>();
+
+  group('resolve', () {
+    for (final model in KnownGeminiModel.values) {
+      test('${model.id} resolves with curated metadata', () {
+        final action = plugin().resolve('model', model.id);
+
+        expect(action, isNotNull);
+        final info = modelInfoOf(action!);
+        expect(info['label'], model.label);
+        expect(info['stage'], 'stable');
+        expect(
+          (info['supports'] as Map).cast<String, dynamic>(),
+          model.info.supports,
+        );
+      });
+    }
+
+    test('unknown model falls back to common metadata', () {
+      final action = plugin().resolve('model', 'gemini-unknown-model');
+
+      expect(action, isNotNull);
+      final info = modelInfoOf(action!);
+      expect(info['supports'], commonModelInfo.supports);
+      expect(info.containsKey('stage'), isFalse);
+      expect(info['label'], 'googleai/gemini-unknown-model');
+    });
+  });
+
+  group('list', () {
+    test('enriches discovered curated models', () async {
+      final client = MockHttpClient(
+        modelsResponse:
+            '{"models": ['
+            '{"name": "models/gemini-3.5-flash"}, '
+            '{"name": "models/gemini-2.0-flash"}]}',
+      );
+      final actions = await plugin(client: client).list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(names, contains('googleai/gemini-3.5-flash'));
+
+      final discovered = actions.firstWhere(
+        (a) => a.name == 'googleai/gemini-3.5-flash',
+      );
+      final info = (discovered.metadata['model'] as Map)
+          .cast<String, dynamic>();
+      expect(info['label'], 'Gemini 3.5 Flash');
+      expect(info['stage'], 'stable');
+    });
+
+    test('appends curated models missing from discovery', () async {
+      final actions = await plugin().list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(names, contains('googleai/gemini-2.0-flash'));
+      expect(names, contains('googleai/text-embedding-004'));
+      for (final model in KnownGeminiModel.values) {
+        expect(names, contains('googleai/${model.id}'));
+      }
+
+      final curated = actions.firstWhere(
+        (a) => a.name == 'googleai/gemini-3.5-flash',
+      );
+      final info = (curated.metadata['model'] as Map).cast<String, dynamic>();
+      expect(info['label'], 'Gemini 3.5 Flash');
+      expect(info['stage'], 'stable');
+    });
+
+    test('does not duplicate curated models returned by discovery', () async {
+      final client = MockHttpClient(
+        modelsResponse:
+            '{"models": ['
+            '{"name": "models/gemini-3.5-flash"}, '
+            '{"name": "models/gemini-2.0-flash"}]}',
+      );
+      final actions = await plugin(client: client).list();
+      final names = actions.map((a) => a.name).toList();
+
+      expect(
+        names.where((n) => n == 'googleai/gemini-3.5-flash'),
+        hasLength(1),
+      );
+      for (final model in KnownGeminiModel.values) {
+        expect(names, contains('googleai/${model.id}'));
+      }
+    });
+
+    test('falls back to the curated catalog when discovery fails', () async {
+      final client = MockHttpClient(
+        listStatus: 500,
+        modelsResponse: '{"error": {"message": "boom", "status": "INTERNAL"}}',
+      );
+      final actions = await plugin(client: client).list();
+      final names = actions.map((a) => a.name).toList();
+
+      for (final model in KnownGeminiModel.values) {
+        expect(names, contains('googleai/${model.id}'));
+      }
+      expect(names.where((n) => n.contains('embedding')), isEmpty);
+      final curated = actions.firstWhere(
+        (a) => a.name == 'googleai/gemini-3.5-flash',
+      );
+      final info = (curated.metadata['model'] as Map).cast<String, dynamic>();
+      expect(info['label'], 'Gemini 3.5 Flash');
+      expect(info['stage'], 'stable');
+    });
+  });
+
+  group('GeminiModels', () {
+    test('refs point at the curated action names', () {
+      expect(
+        GeminiModels.gemini35Flash.name,
+        'googleai/${KnownGeminiModel.gemini35Flash.id}',
+      );
+      expect(
+        GeminiModels.gemini31FlashLite.name,
+        'googleai/${KnownGeminiModel.gemini31FlashLite.id}',
+      );
+      expect(
+        GeminiModels.gemini31FlashImage.name,
+        'googleai/${KnownGeminiModel.gemini31FlashImage.id}',
+      );
+      expect(
+        GeminiModels.gemini3ProImage.name,
+        'googleai/${KnownGeminiModel.gemini3ProImage.id}',
+      );
+    });
+  });
+}

--- a/packages/genkit_google_genai/test/known_models_wiring_test.dart
+++ b/packages/genkit_google_genai/test/known_models_wiring_test.dart
@@ -58,7 +58,7 @@ void main() {
   Map<String, dynamic> modelInfoOf(Action action) =>
       (action.metadata['model'] as Map).cast<String, dynamic>();
 
-  group('resolve', () {
+  group('known model resolution', () {
     for (final model in KnownGeminiModel.values) {
       test('${model.id} resolves with curated metadata', () {
         final action = plugin().resolve('model', model.id);
@@ -165,22 +165,22 @@ void main() {
     });
   });
 
-  group('GeminiModels', () {
+  group('GoogleAiModels', () {
     test('refs point at the curated action names', () {
       expect(
-        GeminiModels.gemini35Flash.name,
+        GoogleAiModels.gemini35Flash.name,
         'googleai/${KnownGeminiModel.gemini35Flash.id}',
       );
       expect(
-        GeminiModels.gemini31FlashLite.name,
+        GoogleAiModels.gemini31FlashLite.name,
         'googleai/${KnownGeminiModel.gemini31FlashLite.id}',
       );
       expect(
-        GeminiModels.gemini31FlashImage.name,
+        GoogleAiModels.gemini31FlashImage.name,
         'googleai/${KnownGeminiModel.gemini31FlashImage.id}',
       );
       expect(
-        GeminiModels.gemini3ProImage.name,
+        GoogleAiModels.gemini3ProImage.name,
         'googleai/${KnownGeminiModel.gemini3ProImage.id}',
       );
     });


### PR DESCRIPTION
Closes #326. Part of #303.

## What

Wires the curated `KnownGeminiModel` catalog (added in #320, refactored in #323) into the googleai plugin itself. Until now only the Vertex AI plugin consumed it: `GoogleGenAiPluginImpl` never overrode `knownModels`, and `list()` hardcoded `commonModelInfo` for every discovered model.

## Changes

- `knownModels` override in `google_api_client.dart`, so `resolve()` and `list()` pick up curated `ModelInfo` (label, stage, capability `supports`); unknown names still fall back to `commonModelInfo`. Curated entries missing from discovery are appended (deduped), and a discovery failure falls back to the curated catalog (warning-logged) instead of throwing; a missing API key still throws.
- `GoogleAiModels` typed refs, one per `KnownGeminiModel`, ids derived from the enum. Named plugin-scoped so vertexai can grow a symmetric surface. `googleAI.gemini('...')` remains the escape hatch.
- Optional `httpClient` constructor param (wrapped non-closing) so offline tests inject a mock transport, mirroring #322's seam.
- `test/known_models_wiring_test.dart`: offline coverage of curated resolve, fallback, list enrichment, dedupe, discovery-failure fallback (via a 500), typed-ref names.

## Testing

`dart analyze` clean; all 49 package tests pass (10 new). Live image-bytes round-trip for the image models: see PR comment.

Follow-ups (sibling-plugin seam convergence, TTS options duplication) tracked in #387.

