### PR TITLE
feat(schemantic): add serialize to convert typed values to JSON

### DIFF
--- a/packages/schemantic/CHANGELOG.md
+++ b/packages/schemantic/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Features
+
+ - add `SchemanticType.serialize` to convert a typed value back into plain JSON
+   (the inverse of `parse`), with an optional `serialize` callback on
+   `SchemanticType.from` for bring-your-own serialization
+
 ## 0.2.0
 
 ### Fixes

--- a/packages/schemantic/CHANGELOG.md
+++ b/packages/schemantic/CHANGELOG.md
@@ -1,11 +1,3 @@
-## Unreleased
-
-### Features
-
- - add `SchemanticType.serialize` to convert a typed value back into plain JSON
-   (the inverse of `parse`), with an optional `serialize` callback on
-   `SchemanticType.from` for bring-your-own serialization
-
 ## 0.2.0
 
 ### Fixes

--- a/packages/schemantic/README.md
+++ b/packages/schemantic/README.md
@@ -166,6 +166,7 @@ class Person {
   static final schema = SchemanticType.from<Person>(
     jsonSchema: Person.jsonSchema,
     parse: (json) => Person.fromJson(json as Map<String, dynamic>),
+    serialize: (person) => person.toJson(),
   );
 }
 ```
@@ -177,6 +178,37 @@ final personSchema = Person.schema;
 print(personSchema.jsonSchema());
 // Output: {type: object, properties: {firstName: {type: string}, ...}, required: [firstName, lastName]}
 ```
+
+### Serialization
+
+Every `SchemanticType<T>` can convert a typed value back into plain JSON via
+`serialize`, which is the inverse of `parse`:
+
+```dart
+final scores = SchemanticType.map(.string(), .integer());
+final parsed = scores.parse({'Alice': 100}); // Map<String, int>
+print(scores.serialize(parsed)); // {Alice: 100}
+```
+
+For basic types, lists, maps, and generated schema types (which all expose a
+`toJson()` method) the default implementation works out of the box. When
+bridging your own types with `SchemanticType.from`, pass a `serialize` callback
+so writes round-trip correctly. This is the type-safe way to plug in
+`json_serializable`, `freezed`, `built_value`, or hand-rolled encodings:
+
+```dart
+final schema = SchemanticType.from<Person>(
+  jsonSchema: Person.jsonSchema,
+  parse: (json) => Person.fromJson(json as Map<String, dynamic>),
+  serialize: (person) => person.toJson(),
+);
+```
+
+If `serialize` is omitted, the default falls back to calling `toJson()` on the
+value, so a plain `json_serializable` class still works; provide the callback
+explicitly for anything that needs custom encoding (e.g. enums or generic
+types).
+
 
 ## Advanced
 

--- a/packages/schemantic/README.md
+++ b/packages/schemantic/README.md
@@ -209,7 +209,6 @@ value, so a plain `json_serializable` class still works; provide the callback
 explicitly for anything that needs custom encoding (e.g. enums or generic
 types).
 
-
 ## Advanced
 
 ### Recursive Schemas

--- a/packages/schemantic/lib/schemantic.dart
+++ b/packages/schemantic/lib/schemantic.dart
@@ -149,15 +149,41 @@ abstract class SchemanticType<T> {
   const SchemanticType();
 
   /// Creates a schema from a JSON schema and a parse function.
+  ///
+  /// Optionally provide [serialize] to convert a [T] back into plain JSON; when
+  /// omitted, the default [SchemanticType.serialize] is used (which handles
+  /// scalars, lists, maps, and any object exposing a `toJson()` method).
   static SchemanticType<T> from<T>({
     required Map<String, Object?> jsonSchema,
     required T Function(dynamic json) parse,
-  }) => _AdHocSchema(jsonSchema, parse);
+    Object? Function(T value)? serialize,
+  }) => _AdHocSchema(jsonSchema, parse, serialize);
 
   /// Parses the given [json] object into type [T].
   ///
   /// Throws if the JSON data does not match the expected structure.
   T parse(Object? json);
+
+  /// Serializes a [value] of type [T] back into plain JSON (a `Map`, `List`,
+  /// `String`, `num`, `bool`, or `null`) - the inverse of [parse].
+  ///
+  /// The default implementation handles scalars, lists, and maps recursively,
+  /// and delegates to `toJson()` for any other object (all generated schemantic
+  /// types expose one). Override this for custom encodings.
+  Object? serialize(T value) => serializeToJson(value);
+
+  /// Recursively converts a JSON-shaped [value] (scalar, `List`, `Map`, or an
+  /// object with a `toJson()` method) into plain JSON.
+  static Object? serializeToJson(Object? value) {
+    if (value == null || value is String || value is num || value is bool) {
+      return value;
+    }
+    if (value is List) return value.map(serializeToJson).toList();
+    if (value is Map) {
+      return value.map((k, v) => MapEntry(k.toString(), serializeToJson(v)));
+    }
+    return (value as dynamic).toJson();
+  }
 
   /// Validates the given [data] against this schema.
   ///
@@ -572,11 +598,16 @@ extension on jsb.ValidationErrorType {
 class _AdHocSchema<T> extends SchemanticType<T> {
   final Map<String, Object?> _jsonSchema;
   final T Function(dynamic json) _parse;
+  final Object? Function(T value)? _serialize;
 
-  const _AdHocSchema(this._jsonSchema, this._parse);
+  const _AdHocSchema(this._jsonSchema, this._parse, this._serialize);
 
   @override
   T parse(Object? json) => _parse(json);
+
+  @override
+  Object? serialize(T value) =>
+      _serialize != null ? _serialize(value) : super.serialize(value);
 
   @override
   Map<String, Object?> jsonSchema({bool useRefs = false}) =>

--- a/packages/schemantic/lib/schemantic.dart
+++ b/packages/schemantic/lib/schemantic.dart
@@ -182,7 +182,16 @@ abstract class SchemanticType<T> {
     if (value is Map) {
       return value.map((k, v) => MapEntry(k.toString(), serializeToJson(v)));
     }
-    return (value as dynamic).toJson();
+    try {
+      return (value as dynamic).toJson();
+      // Detecting a dynamic `toJson()` at runtime requires catching this error.
+      // ignore: avoid_catching_errors
+    } on NoSuchMethodError {
+      throw ArgumentError(
+        'Type ${value.runtimeType} cannot be serialized to JSON. '
+        'Provide a custom serialize function or implement toJson().',
+      );
+    }
   }
 
   /// Validates the given [data] against this schema.

--- a/packages/schemantic/lib/schemantic.dart
+++ b/packages/schemantic/lib/schemantic.dart
@@ -182,8 +182,9 @@ abstract class SchemanticType<T> {
     if (value is Map) {
       return value.map((k, v) => MapEntry(k.toString(), _serializeToJson(v)));
     }
+    final Object? json;
     try {
-      return (value as dynamic).toJson();
+      json = (value as dynamic).toJson();
       // Detecting a dynamic `toJson()` at runtime requires catching this error.
       // ignore: avoid_catching_errors
     } on NoSuchMethodError {
@@ -192,6 +193,9 @@ abstract class SchemanticType<T> {
         'Provide a custom serialize function or implement toJson().',
       );
     }
+    // Recurse into the result so a hand-rolled `toJson()` that returns nested
+    // non-JSON values (e.g. domain objects) is still normalized to plain JSON.
+    return _serializeToJson(json);
   }
 
   /// Validates the given [data] against this schema.

--- a/packages/schemantic/lib/schemantic.dart
+++ b/packages/schemantic/lib/schemantic.dart
@@ -170,17 +170,17 @@ abstract class SchemanticType<T> {
   /// The default implementation handles scalars, lists, and maps recursively,
   /// and delegates to `toJson()` for any other object (all generated schemantic
   /// types expose one). Override this for custom encodings.
-  Object? serialize(T value) => serializeToJson(value);
+  Object? serialize(T value) => _serializeToJson(value);
 
   /// Recursively converts a JSON-shaped [value] (scalar, `List`, `Map`, or an
   /// object with a `toJson()` method) into plain JSON.
-  static Object? serializeToJson(Object? value) {
+  static Object? _serializeToJson(Object? value) {
     if (value == null || value is String || value is num || value is bool) {
       return value;
     }
-    if (value is List) return value.map(serializeToJson).toList();
+    if (value is List) return value.map(_serializeToJson).toList();
     if (value is Map) {
-      return value.map((k, v) => MapEntry(k.toString(), serializeToJson(v)));
+      return value.map((k, v) => MapEntry(k.toString(), _serializeToJson(v)));
     }
     try {
       return (value as dynamic).toJson();

--- a/packages/schemantic/lib/src/basic_types.dart
+++ b/packages/schemantic/lib/src/basic_types.dart
@@ -40,6 +40,12 @@ final class _NullableSchemaFactory<T> extends SchemanticType<T?> {
   }
 
   @override
+  Object? serialize(T? value) {
+    if (value == null) return null;
+    return _type.serialize(value);
+  }
+
+  @override
   Map<String, Object?> jsonSchema({bool useRefs = false}) {
     return {
       'oneOf': [
@@ -354,6 +360,9 @@ final class _ListSchemaFactory<T> extends SchemanticType<List<T>> {
   List<T> parse(Object? json) => (json as List).map(itemType.parse).toList();
 
   @override
+  Object? serialize(List<T> value) => value.map(itemType.serialize).toList();
+
+  @override
   Map<String, Object?> jsonSchema({bool useRefs = false}) {
     final itemSchema = itemType.jsonSchema(useRefs: useRefs);
     var schema = jsb.Schema.list(
@@ -428,6 +437,14 @@ final class _MapSchemaFactory<K, V> extends SchemanticType<Map<K, V>> {
     return (json as Map).map((k, v) {
       return MapEntry(keyType.parse(k), valueType.parse(v));
     });
+  }
+
+  @override
+  Object? serialize(Map<K, V> value) {
+    return value.map(
+      (k, v) =>
+          MapEntry(keyType.serialize(k).toString(), valueType.serialize(v)),
+    );
   }
 
   @override

--- a/packages/schemantic/test/serialize_test.dart
+++ b/packages/schemantic/test/serialize_test.dart
@@ -137,6 +137,30 @@ void main() {
         final serialized = schema.serialize(_Widget('w1'));
         expect(serialized, {'id': 'w1'});
       });
+
+      test('default serialize recurses into nested toJson() results', () {
+        // _Container.toJson() returns a map holding a raw _Widget (a non-JSON
+        // domain object). The default serializer should normalize it to plain
+        // JSON rather than leaking the object.
+        final schema = SchemanticType.from<_Container>(
+          jsonSchema: {'type': 'object'},
+          parse: (json) => _Container(_Widget('w1')),
+        );
+
+        final serialized = schema.serialize(_Container(_Widget('w2')));
+        expect(serialized, {
+          'widget': {'id': 'w2'},
+        });
+      });
+
+      test('default serialize throws for nested non-serializable values', () {
+        final schema = SchemanticType.from<_OpaqueContainer>(
+          jsonSchema: {'type': 'object'},
+          parse: (json) => _OpaqueContainer(),
+        );
+
+        expect(() => schema.serialize(_OpaqueContainer()), throwsArgumentError);
+      });
     });
 
     group('generated schema types', () {
@@ -235,6 +259,20 @@ class _Widget {
   _Widget(this.id);
 
   Map<String, Object?> toJson() => {'id': id};
+}
+
+/// A hand-rolled type whose `toJson()` returns a nested non-JSON value.
+class _Container {
+  final _Widget widget;
+
+  _Container(this.widget);
+
+  Map<String, Object?> toJson() => {'widget': widget};
+}
+
+/// A hand-rolled type whose `toJson()` returns a nested non-serializable value.
+class _OpaqueContainer {
+  Map<String, Object?> toJson() => {'value': _Opaque()};
 }
 
 class _Opaque {}

--- a/packages/schemantic/test/serialize_test.dart
+++ b/packages/schemantic/test/serialize_test.dart
@@ -138,7 +138,88 @@ void main() {
         expect(serialized, {'id': 'w1'});
       });
     });
+
+    group('generated schema types', () {
+      // Mirrors the shape of code emitted by schemantic_builder: a
+      // SchemanticType factory whose parse() wraps the JSON map and whose
+      // values expose a toJson(). This exercises the default serialize path
+      // (the headline use case) end to end.
+      test('default serialize round trips a generated-style type', () {
+        final person = _GeneratedPerson.$schema.parse({
+          'name': 'Alice',
+          'age': 30,
+        });
+
+        final serialized = _GeneratedPerson.$schema.serialize(person);
+
+        expect(serialized, {'name': 'Alice', 'age': 30});
+        // Round trips back into an equal object.
+        final reparsed = _GeneratedPerson.$schema.parse(serialized);
+        expect(reparsed.name, 'Alice');
+        expect(reparsed.age, 30);
+      });
+
+      test('generated-style types serialize inside list and map', () {
+        final listSchema = SchemanticType.list(_GeneratedPerson.$schema);
+        final list = listSchema.parse([
+          {'name': 'Alice', 'age': 30},
+          {'name': 'Bob', 'age': 25},
+        ]);
+        expect(listSchema.serialize(list), [
+          {'name': 'Alice', 'age': 30},
+          {'name': 'Bob', 'age': 25},
+        ]);
+
+        final mapSchema = SchemanticType.map(
+          SchemanticType.string(),
+          _GeneratedPerson.$schema,
+        );
+        final map = mapSchema.parse({
+          'a': {'name': 'Alice', 'age': 30},
+        });
+        expect(mapSchema.serialize(map), {
+          'a': {'name': 'Alice', 'age': 30},
+        });
+      });
+    });
   });
+}
+
+/// A stand-in for a `@Schema`-generated data class (see the shape produced by
+/// schemantic_builder): backed by a JSON map with a `toJson()` method.
+class _GeneratedPerson {
+  _GeneratedPerson._(this._json);
+
+  static const SchemanticType<_GeneratedPerson> $schema =
+      _GeneratedPersonFactory();
+
+  final Map<String, dynamic> _json;
+
+  String get name => _json['name'] as String;
+  int get age => _json['age'] as int;
+
+  Map<String, dynamic> toJson() => _json;
+}
+
+final class _GeneratedPersonFactory extends SchemanticType<_GeneratedPerson> {
+  const _GeneratedPersonFactory();
+
+  @override
+  _GeneratedPerson parse(Object? json) =>
+      _GeneratedPerson._(json as Map<String, dynamic>);
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => const JsonSchemaMetadata(
+    name: 'GeneratedPerson',
+    definition: {
+      'type': 'object',
+      'properties': {
+        'name': {'type': 'string'},
+        'age': {'type': 'integer'},
+      },
+      'required': ['name', 'age'],
+    },
+  );
 }
 
 class _Person {

--- a/packages/schemantic/test/serialize_test.dart
+++ b/packages/schemantic/test/serialize_test.dart
@@ -66,6 +66,33 @@ void main() {
       expect(schema.serialize(schema.parse(7)), 7);
     });
 
+    test('nested custom serialized types inside list, map, and nullable', () {
+      final customInt = SchemanticType.from<int>(
+        jsonSchema: {'type': 'integer'},
+        parse: (json) => (json as int) + 1,
+        serialize: (val) => val - 1,
+      );
+
+      final listSchema = SchemanticType.list(customInt);
+      expect(listSchema.serialize([3, 4]), [2, 3]);
+
+      final mapSchema = SchemanticType.map(SchemanticType.string(), customInt);
+      expect(mapSchema.serialize({'a': 3}), {'a': 2});
+
+      final nullableSchema = SchemanticType.nullable(customInt);
+      expect(nullableSchema.serialize(3), 2);
+      expect(nullableSchema.serialize(null), null);
+    });
+
+    test('throws ArgumentError when value cannot be serialized', () {
+      final schema = SchemanticType.from<_Opaque>(
+        jsonSchema: {'type': 'object'},
+        parse: (json) => _Opaque(),
+      );
+
+      expect(() => schema.serialize(_Opaque()), throwsArgumentError);
+    });
+
     group('SchemanticType.from', () {
       final personSchema = {
         'type': 'object',
@@ -128,3 +155,5 @@ class _Widget {
 
   Map<String, Object?> toJson() => {'id': id};
 }
+
+class _Opaque {}

--- a/packages/schemantic/test/serialize_test.dart
+++ b/packages/schemantic/test/serialize_test.dart
@@ -1,0 +1,130 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:schemantic/schemantic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('serialize', () {
+    test('scalars round trip', () {
+      final s = SchemanticType.string();
+      expect(s.serialize(s.parse('hello')), 'hello');
+
+      final i = SchemanticType.integer();
+      expect(i.serialize(i.parse(42)), 42);
+
+      final d = SchemanticType.doubleSchema();
+      expect(d.serialize(d.parse(12.34)), 12.34);
+
+      final b = SchemanticType.boolean();
+      expect(b.serialize(b.parse(true)), true);
+    });
+
+    test('list round trips to plain JSON', () {
+      final schema = SchemanticType.list(.string());
+      final value = schema.parse(['a', 'b', 'c']);
+      final serialized = schema.serialize(value);
+
+      expect(serialized, ['a', 'b', 'c']);
+      expect(serialized, isA<List<Object?>>());
+    });
+
+    test('map round trips to plain JSON', () {
+      final schema = SchemanticType.map(.string(), .integer());
+      final value = schema.parse({'a': 1, 'b': 2});
+      final serialized = schema.serialize(value);
+
+      expect(serialized, {'a': 1, 'b': 2});
+      expect(serialized, isA<Map<String, Object?>>());
+    });
+
+    test('nested list of maps round trips', () {
+      final schema = SchemanticType.list(.map(.string(), .integer()));
+      final input = [
+        {'a': 1},
+        {'b': 2},
+      ];
+      final serialized = schema.serialize(schema.parse(input));
+
+      expect(serialized, input);
+    });
+
+    test('nullable serializes null and value', () {
+      final schema = SchemanticType.nullable(.integer());
+      expect(schema.serialize(schema.parse(null)), null);
+      expect(schema.serialize(schema.parse(7)), 7);
+    });
+
+    group('SchemanticType.from', () {
+      final personSchema = {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+          'age': {'type': 'integer'},
+        },
+      };
+
+      test('uses the provided serialize callback (BYO serialization)', () {
+        final schema = SchemanticType.from<_Person>(
+          jsonSchema: personSchema,
+          parse: (json) {
+            final map = json as Map<String, Object?>;
+            return _Person(name: map['name'] as String, age: map['age'] as int);
+          },
+          serialize: (p) => {'name': p.name, 'age': p.age},
+        );
+
+        final person = schema.parse({'name': 'Bob', 'age': 25});
+        final serialized = schema.serialize(person);
+
+        expect(serialized, {'name': 'Bob', 'age': 25});
+        // Round trips back into an equal object.
+        final reparsed = schema.parse(serialized);
+        expect(reparsed.name, 'Bob');
+        expect(reparsed.age, 25);
+      });
+
+      test('default serialize falls back to toJson()', () {
+        final schema = SchemanticType.from<_Widget>(
+          jsonSchema: {
+            'type': 'object',
+            'properties': {
+              'id': {'type': 'string'},
+            },
+          },
+          parse: (json) =>
+              _Widget((json as Map<String, Object?>)['id'] as String),
+        );
+
+        final serialized = schema.serialize(_Widget('w1'));
+        expect(serialized, {'id': 'w1'});
+      });
+    });
+  });
+}
+
+class _Person {
+  final String name;
+  final int age;
+
+  _Person({required this.name, required this.age});
+}
+
+class _Widget {
+  final String id;
+
+  _Widget(this.id);
+
+  Map<String, Object?> toJson() => {'id': id};
+}

--- a/packages/schemantic_builder/test/schema_generator_test.dart
+++ b/packages/schemantic_builder/test/schema_generator_test.dart
@@ -288,6 +288,13 @@ Future<void> _testBuilderWithNoFail(
     outputs: outputs,
     onLog: (log) {
       if (log.level >= Level.WARNING) {
+        // Ignore the environmental warning emitted when the running SDK's
+        // language version is newer than the analyzer package's. It's
+        // unrelated to the builder's output.
+        if (log.message.contains('is newer than') &&
+            log.message.contains('analyzer')) {
+          return;
+        }
         addTearDown(() {
           fail('Unexpected log: $log');
         });


### PR DESCRIPTION
Add `SchemanticType.serialize` as the inverse of `parse`, converting a typed value back into plain JSON. The default implementation handles scalars, lists, maps, and any object exposing a `toJson()` method recursively. Add an optional `serialize` callback to `SchemanticType.from` for custom encodings when bridging your own types.