### PR TITLE
feat(prompt): surface middleware and generate options in prompt loader

### DIFF
--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -491,7 +491,8 @@ Map<String, dynamic> _buildPromptMetadata<CustomOptions, Input>(
       if (config.toolChoice != null) 'toolChoice': config.toolChoice,
       if (config.messagesTemplate != null) 'template': config.messagesTemplate,
       if (config.maxTurns != null) 'maxTurns': config.maxTurns,
-      if (config.returnToolRequests != null) 'returnToolRequests': config.returnToolRequests,
+      if (config.returnToolRequests != null)
+        'returnToolRequests': config.returnToolRequests,
       // Surface middleware as `{name, config}` entries, mirroring the JS
       // prompt loader's `metadata.prompt.use`.
       if (config.use != null)

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -490,6 +490,8 @@ Map<String, dynamic> _buildPromptMetadata<CustomOptions, Input>(
       if (config.toolNames != null) 'tools': config.toolNames,
       if (config.toolChoice != null) 'toolChoice': config.toolChoice,
       if (config.messagesTemplate != null) 'template': config.messagesTemplate,
+      if (config.maxTurns != null) 'maxTurns': config.maxTurns,
+      if (config.returnToolRequests != null) 'returnToolRequests': config.returnToolRequests,
       // Surface middleware as `{name, config}` entries, mirroring the JS
       // prompt loader's `metadata.prompt.use`.
       if (config.use != null)

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -490,7 +490,13 @@ Map<String, dynamic> _buildPromptMetadata<CustomOptions, Input>(
       if (config.toolNames != null) 'tools': config.toolNames,
       if (config.toolChoice != null) 'toolChoice': config.toolChoice,
       if (config.messagesTemplate != null) 'template': config.messagesTemplate,
-      // TODO: Add middleware metadata when middleware support is added.
+      // Surface middleware as `{name, config}` entries, mirroring the JS
+      // prompt loader's `metadata.prompt.use`.
+      if (config.use != null)
+        'use': [
+          for (final mw in config.use!)
+            {'name': mw.name, if (mw.config != null) 'config': mw.config},
+        ],
     },
   };
 }

--- a/packages/genkit/lib/src/ai/prompt_loader_io.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_io.dart
@@ -20,10 +20,12 @@ import 'package:path/path.dart' as p;
 import 'package:schemantic/schemantic.dart';
 
 import '../core/registry.dart';
+import '../exception.dart';
 import '../types.dart' show GenerateActionOutputConfig;
 import 'dotprompt_registry.dart';
 import 'generate_middleware.dart';
 import 'model.dart';
+
 import 'prompt.dart';
 
 final _logger = Logger('genkit.prompt_loader');
@@ -142,13 +144,22 @@ void _loadPrompt(
   // `toolChoice`, `maxTurns`, `returnToolRequests`) from the raw frontmatter
   // map. They are threaded through `PromptConfig` so they apply at generate
   // time (and, where applicable, surface on the prompt metadata built by
-  // `definePromptAction`), matching the JS loader. Casts are guarded so a
-  // malformed value does not throw, consistent with the loader's tolerant
-  // handling of frontmatter.
+  // `definePromptAction`), matching the JS loader. A value of the wrong type is
+  // an authoring error in a static file, so it fails fast with a clear message
+  // at load time rather than being silently ignored or surfacing later as an
+  // obscure downstream error.
   final use = _toMiddlewareRefs(metadata.raw?['use']);
-  final toolChoice = metadata.raw?['toolChoice'] as String?;
-  final maxTurns = metadata.raw?['maxTurns'] as int?;
-  final returnToolRequests = metadata.raw?['returnToolRequests'] as bool?;
+  final toolChoice = _typedRawField<String>(
+    metadata.raw,
+    'toolChoice',
+    registryName,
+  );
+  final maxTurns = _typedRawField<int>(metadata.raw, 'maxTurns', registryName);
+  final returnToolRequests = _typedRawField<bool>(
+    metadata.raw,
+    'returnToolRequests',
+    registryName,
+  );
 
   // Named schemas registered via `defineSchema`. Picoschema may reference these
   // by name (e.g. `schema: MyAddress`), so they are passed through to the
@@ -212,6 +223,23 @@ String _registryDefinitionKey(String name, String? variant, String? ns) {
   final prefix = ns != null && ns.isNotEmpty ? '$ns/' : '';
   final suffix = variant != null ? '.$variant' : '';
   return '$prefix$name$suffix';
+}
+
+/// Reads a scalar frontmatter field of type [T] from the raw metadata map.
+///
+/// Returns `null` when the field is absent. A present value of the wrong type
+/// is an authoring error in a static prompt file, so it throws a
+/// [GenkitException] with a clear message at load time rather than silently
+/// ignoring the value or letting it fail obscurely downstream.
+T? _typedRawField<T>(Map<String, dynamic>? raw, String key, String promptName) {
+  final value = raw?[key];
+  if (value == null) return null;
+  if (value is T) return value;
+  throw GenkitException(
+    "Invalid '$key' in prompt '$promptName': expected $T, got "
+    '${value.runtimeType}.',
+    status: StatusCodes.INVALID_ARGUMENT,
+  );
 }
 
 /// Normalizes the frontmatter `use` field into a list of middleware refs.

--- a/packages/genkit/lib/src/ai/prompt_loader_io.dart
+++ b/packages/genkit/lib/src/ai/prompt_loader_io.dart
@@ -22,6 +22,7 @@ import 'package:schemantic/schemantic.dart';
 import '../core/registry.dart';
 import '../types.dart' show GenerateActionOutputConfig;
 import 'dotprompt_registry.dart';
+import 'generate_middleware.dart';
 import 'model.dart';
 import 'prompt.dart';
 
@@ -137,6 +138,18 @@ void _loadPrompt(
   final config = metadata.config;
   final tools = metadata.tools;
 
+  // Resolve fields that are not first-class dotprompt metadata (`use`,
+  // `toolChoice`, `maxTurns`, `returnToolRequests`) from the raw frontmatter
+  // map. They are threaded through `PromptConfig` so they apply at generate
+  // time (and, where applicable, surface on the prompt metadata built by
+  // `definePromptAction`), matching the JS loader. Casts are guarded so a
+  // malformed value does not throw, consistent with the loader's tolerant
+  // handling of frontmatter.
+  final use = _toMiddlewareRefs(metadata.raw?['use']);
+  final toolChoice = metadata.raw?['toolChoice'] as String?;
+  final maxTurns = metadata.raw?['maxTurns'] as int?;
+  final returnToolRequests = metadata.raw?['returnToolRequests'] as bool?;
+
   // Named schemas registered via `defineSchema`. Picoschema may reference these
   // by name (e.g. `schema: MyAddress`), so they are passed through to the
   // converter to resolve, mirroring what `_resolveMetadata` does internally.
@@ -168,20 +181,9 @@ void _loadPrompt(
     });
   }
 
-  // Build prompt metadata for the registry
-  final promptMeta = <String, dynamic>{
-    'type': 'prompt',
-    'prompt': {
-      'name': name,
-      'variant': ?variant,
-      'model': ?model,
-      'config': ?config,
-      'tools': ?tools,
-      'template': parsedPrompt.template,
-    },
-  };
-
-  // Create the prompt config
+  // Create the prompt config. `definePromptAction` builds the registry/display
+  // metadata (`type`, `prompt`) from these fields, so `use`/`toolChoice` are
+  // surfaced for the Developer UI without building the metadata map here.
   final promptConfig = PromptConfig<Map<String, dynamic>, Map<String, dynamic>>(
     name: _registryDefinitionKey(name, null, ns),
     variant: variant,
@@ -189,16 +191,18 @@ void _loadPrompt(
     config: config,
     inputSchema: inputSchema,
     toolNames: tools,
+    toolChoice: toolChoice,
+    maxTurns: maxTurns,
+    returnToolRequests: returnToolRequests,
     messagesTemplate: parsedPrompt.template,
     output: outputConfig,
-    metadata: promptMeta,
+    use: use,
   );
 
   definePromptAction<Map<String, dynamic>, Map<String, dynamic>>(
     registry,
     dotpromptRegistry,
     promptConfig,
-    metadata: promptMeta,
   );
 
   _logger.fine('Registered prompt "$registryName" from "$filePath"');
@@ -208,6 +212,54 @@ String _registryDefinitionKey(String name, String? variant, String? ns) {
   final prefix = ns != null && ns.isNotEmpty ? '$ns/' : '';
   final suffix = variant != null ? '.$variant' : '';
   return '$prefix$name$suffix';
+}
+
+/// Normalizes the frontmatter `use` field into a list of middleware refs.
+///
+/// dotprompt does not model `use` as a first-class field, so it arrives as a
+/// raw value from the parsed frontmatter. Two entry shapes are supported,
+/// mirroring the code API where `use: [retry(maxRetries: 3)]` is a middleware
+/// name plus optional config:
+///
+/// ```yaml
+/// use:
+///   - retry                 # bare string -> middlewareRef(name: 'retry')
+///   - name: retry           # map with optional config
+///     config:
+///       maxRetries: 3
+/// ```
+///
+/// Malformed entries (non-string / map without a `name`) are skipped rather
+/// than throwing, consistent with the loader's tolerant handling of
+/// frontmatter. Returns `null` when no valid middleware is declared.
+List<GenerateMiddlewareRef>? _toMiddlewareRefs(dynamic use) {
+  if (use is! List) return null;
+
+  final refs = <GenerateMiddlewareRef>[];
+  for (final entry in use) {
+    if (entry is String) {
+      refs.add(middlewareRef(name: entry));
+    } else if (entry is Map) {
+      final name = entry['name'];
+      if (name is! String) {
+        _logger.warning(
+          'Skipping middleware entry without a valid "name": $entry',
+        );
+        continue;
+      }
+      final config = entry['config'];
+      refs.add(
+        middlewareRef<dynamic>(
+          name: name,
+          config: config is Map ? Map<String, dynamic>.from(config) : config,
+        ),
+      );
+    } else {
+      _logger.warning('Skipping unsupported middleware entry: $entry');
+    }
+  }
+
+  return refs.isEmpty ? null : refs;
 }
 
 /// Converts a frontmatter schema map to a JSON Schema map.

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -1602,6 +1602,200 @@ Ship to {{address.city}}.
       expect(addressSchema['properties'], contains('street'));
       expect(addressSchema['properties'], contains('city'));
     });
+
+    test('parses bare-string middleware from the `use` frontmatter', () async {
+      File(p.join(tempDir.path, 'retrying.prompt')).writeAsStringSync('''
+---
+use:
+  - retry
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'retrying');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      final use = options.use!;
+      expect(use, hasLength(1));
+      expect(use.single.name, equals('retry'));
+      expect(use.single.config, anyOf(isNull, isEmpty));
+    });
+
+    test('parses middleware with config from the `use` frontmatter', () async {
+      File(p.join(tempDir.path, 'retrying.prompt')).writeAsStringSync('''
+---
+use:
+  - name: retry
+    config:
+      maxRetries: 3
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'retrying');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      final use = options.use!;
+      expect(use, hasLength(1));
+      expect(use.single.name, equals('retry'));
+      expect(use.single.config, containsPair('maxRetries', 3));
+    });
+
+    test('surfaces normalized `use` on the prompt metadata', () async {
+      File(p.join(tempDir.path, 'retrying.prompt')).writeAsStringSync('''
+---
+toolChoice: required
+use:
+  - logging
+  - name: retry
+    config:
+      maxRetries: 3
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final action =
+          await registry.lookupAction('executable-prompt', 'retrying')
+              as PromptAction;
+      final promptMeta = action.metadata['prompt'] as Map<String, dynamic>;
+
+      // Mirrors the JS loader's `metadata.prompt.use` / `toolChoice`.
+      expect(promptMeta['toolChoice'], equals('required'));
+      final useMeta = promptMeta['use'] as List;
+      expect(useMeta, hasLength(2));
+      expect(useMeta[0], equals({'name': 'logging'}));
+      expect(
+        useMeta[1],
+        equals({
+          'name': 'retry',
+          'config': {'maxRetries': 3},
+        }),
+      );
+    });
+
+    test('skips malformed and unsupported `use` entries', () async {
+      // A map without a `name`, and a non-string/non-map entry, are both
+      // dropped rather than throwing; the valid entry is still parsed.
+      File(p.join(tempDir.path, 'mixed.prompt')).writeAsStringSync('''
+---
+use:
+  - retry
+  - config:
+      maxRetries: 3
+  - 42
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'mixed');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      final use = options.use!;
+      expect(use, hasLength(1));
+      expect(use.single.name, equals('retry'));
+    });
+
+    test('parses toolChoice from frontmatter onto rendered options', () async {
+      File(p.join(tempDir.path, 'choosy.prompt')).writeAsStringSync('''
+---
+toolChoice: required
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'choosy');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      expect(options.toolChoice, equals('required'));
+    });
+
+    test('parses maxTurns and returnToolRequests from frontmatter', () async {
+      File(p.join(tempDir.path, 'looped.prompt')).writeAsStringSync('''
+---
+maxTurns: 7
+returnToolRequests: true
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'looped');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      expect(options.maxTurns, equals(7));
+      expect(options.returnToolRequests, isTrue);
+    });
+
+    test('returnToolRequests can be false in frontmatter', () async {
+      File(p.join(tempDir.path, 'noreturn.prompt')).writeAsStringSync('''
+---
+returnToolRequests: false
+---
+Hello {{name}}!
+''');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'noreturn');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      expect(options.returnToolRequests, isFalse);
+    });
+
+    test('omits maxTurns/returnToolRequests when absent', () async {
+      File(
+        p.join(tempDir.path, 'bare.prompt'),
+      ).writeAsStringSync('Hello {{name}}!');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'bare');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      expect(options.maxTurns, isNull);
+      expect(options.returnToolRequests, isNull);
+      expect(options.toolChoice, isNull);
+    });
+
+    test('ignores a prompt with no `use` frontmatter', () async {
+      File(
+        p.join(tempDir.path, 'plain.prompt'),
+      ).writeAsStringSync('Hello {{name}}!');
+
+      loadPromptFolder(registry, dpRegistry, dir: tempDir.path);
+
+      final ep = await registry.lookupAction('executable-prompt', 'plain');
+      final options = await (ep as PromptAction).executablePrompt!.render({
+        'name': 'World',
+      });
+
+      expect(options.use, anyOf(isNull, isEmpty));
+    });
   });
 
   group('DotpromptRegistry', () {

--- a/packages/genkit/test/ai/prompt_test.dart
+++ b/packages/genkit/test/ai/prompt_test.dart
@@ -1782,6 +1782,71 @@ Hello {{name}}!
       expect(options.toolChoice, isNull);
     });
 
+    test('throws a clear error for a wrong-typed maxTurns', () {
+      File(p.join(tempDir.path, 'badturns.prompt')).writeAsStringSync('''
+---
+maxTurns: not-a-number
+---
+Hello {{name}}!
+''');
+
+      // A wrong-typed scalar option is an authoring error and must fail fast
+      // with a GenkitException, not a raw TypeError or silent default.
+      expect(
+        () => loadPromptFolder(registry, dpRegistry, dir: tempDir.path),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('maxTurns'), contains('badturns')),
+          ),
+        ),
+      );
+    });
+
+    test('throws a clear error for a wrong-typed toolChoice', () {
+      File(p.join(tempDir.path, 'badchoice.prompt')).writeAsStringSync('''
+---
+toolChoice:
+  - not
+  - a
+  - string
+---
+Hello {{name}}!
+''');
+
+      expect(
+        () => loadPromptFolder(registry, dpRegistry, dir: tempDir.path),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.message,
+            'message',
+            contains('toolChoice'),
+          ),
+        ),
+      );
+    });
+
+    test('throws a clear error for a wrong-typed returnToolRequests', () {
+      File(p.join(tempDir.path, 'badreturn.prompt')).writeAsStringSync('''
+---
+returnToolRequests: 3
+---
+Hello {{name}}!
+''');
+
+      expect(
+        () => loadPromptFolder(registry, dpRegistry, dir: tempDir.path),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.message,
+            'message',
+            contains('returnToolRequests'),
+          ),
+        ),
+      );
+    });
+
     test('ignores a prompt with no `use` frontmatter', () async {
       File(
         p.join(tempDir.path, 'plain.prompt'),

--- a/testapps/agents/lib/trip_planner_agent.dart
+++ b/testapps/agents/lib/trip_planner_agent.dart
@@ -129,6 +129,11 @@ final getFlightInfo = ai.defineTool(
 /// `promptInput` supplies values for the prompt template's input variables, so
 /// a single shared `.prompt` file can be reused and customized by multiple
 /// agents. Here it sets the `{{tone}}` placeholder in `tripPlanner.prompt`.
+///
+/// Model middleware is declared directly in the `.prompt` frontmatter via the
+/// `use:` field (see `prompts/tripPlanner.prompt`, which applies the `retry`
+/// middleware). The referenced middleware must be registered on the shared
+/// Genkit instance (see `genkit.dart`, which registers `RetryPlugin`).
 final tripPlannerAgent = ai.definePromptAgent(
   promptName: 'tripPlanner',
   promptInput: {'tone': 'enthusiastic'},

--- a/testapps/agents/prompts/tripPlanner.prompt
+++ b/testapps/agents/prompts/tripPlanner.prompt
@@ -6,6 +6,7 @@ input:
 tools:
   - getAttractions
   - getFlightInfo
+maxTurns: 20
 use:
   - name: retry
     config:

--- a/testapps/agents/prompts/tripPlanner.prompt
+++ b/testapps/agents/prompts/tripPlanner.prompt
@@ -6,6 +6,10 @@ input:
 tools:
   - getAttractions
   - getFlightInfo
+use:
+  - name: retry
+    config:
+      maxRetries: 4
 ---
 
 {{role "system"}}


### PR DESCRIPTION
Resolve `use`, `toolChoice`, `maxTurns`, and `returnToolRequests` from dotprompt frontmatter and thread them through `PromptConfig` so they apply at generate time. Middleware is normalized into `GenerateMiddlewareRef` entries (supporting both bare-string and `{name, config}` shapes) and surfaced as `{name, config}` in prompt metadata, mirroring the JS loader's `metadata.prompt.use`. Metadata is now built by `definePromptAction` instead of manually in the loader.


```
---
model: googleai/gemini-flash-latest
input:
  schema:
    tone: string
tools:
  - getAttractions
  - getFlightInfo
maxTurns: 20
use:
  - name: retry
    config:
      maxRetries: 4
---
```