### PR TITLE
docs(testapps/agents): add reasoning display and file viewer to agents app

### DIFF
--- a/testapps/agents/web/lib/components/chat_ui.dart
+++ b/testapps/agents/web/lib/components/chat_ui.dart
@@ -18,17 +18,31 @@
 /// logic; each page owns its own session/streaming code and passes messages in.
 library;
 
+import 'dart:async';
+
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:markdown/markdown.dart' as md;
+import 'package:web/web.dart' as web;
 
 /// A single chat message to render.
 class ChatMessage {
-  ChatMessage({required this.role, required this.text});
+  ChatMessage({
+    required this.role,
+    required this.text,
+    this.reasoning,
+    this.detail,
+  });
 
   /// One of `user`, `model`, `system`, `tool`.
   final String role;
   final String text;
+
+  /// Optional reasoning/thinking content — rendered as a collapsible block.
+  final String? reasoning;
+
+  /// Optional detail content — rendered as a terminal-style box below the text.
+  final String? detail;
 }
 
 /// Renders a markdown string as an HTML block.
@@ -40,15 +54,34 @@ Component markdownBlock(String source) {
   return div(classes: 'markdown-body', [RawText(html)]);
 }
 
+/// A collapsible "🧠 Thinking…" reasoning block.
+Component _thinkingBlock(String reasoning, {bool streaming = false}) {
+  return details(
+    open: streaming,
+    classes: streaming ? 'thinking-block thinking-streaming' : 'thinking-block',
+    [
+      summary(classes: 'thinking-summary', [
+        span(
+          classes: streaming ? 'thinking-icon thinking-pulse' : 'thinking-icon',
+          [.text('🧠')],
+        ),
+        .text(' Thinking…'),
+      ]),
+      div(classes: 'thinking-content', [markdownBlock(reasoning)]),
+    ],
+  );
+}
+
 /// Shared chat panel. The page supplies [messages], optional [streamingText],
 /// suggestions, and an [onSend] callback.
-class ChatUI extends StatelessComponent {
+class ChatUI extends StatefulComponent {
   const ChatUI({
     required this.title,
     required this.onSend,
     this.description,
     this.messages = const [],
     this.streamingText,
+    this.streamingReasoning,
     this.loading = false,
     this.inputDisabled = false,
     this.renderMarkdown = false,
@@ -62,6 +95,10 @@ class ChatUI extends StatelessComponent {
   final String? description;
   final List<ChatMessage> messages;
   final String? streamingText;
+
+  /// Partial reasoning text being streamed (shown as animated "thinking…"
+  /// block).
+  final String? streamingReasoning;
   final bool loading;
   final bool inputDisabled;
   final bool renderMarkdown;
@@ -74,15 +111,34 @@ class ChatUI extends StatelessComponent {
   final Component? extra;
 
   @override
+  State<ChatUI> createState() => _ChatUIState();
+}
+
+class _ChatUIState extends State<ChatUI> {
+  /// Auto-scroll the message list to the bottom after the DOM updates.
+  ///
+  /// Mirrors the JS double-rAF trick: schedule after the current render so the
+  /// container has its final height before we set `scrollTop`.
+  void _scrollToBottom() {
+    Timer.run(() {
+      final el = web.document.querySelector('.chat-messages');
+      if (el != null) {
+        el.scrollTop = el.scrollHeight.toDouble();
+      }
+    });
+  }
+
+  @override
   Component build(BuildContext context) {
+    _scrollToBottom();
     return div(classes: 'chat-panel', [
       _header(),
       _messages(),
-      ?extra,
+      ?component.extra,
       _ChatInput(
-        title: title,
-        disabled: loading || inputDisabled,
-        onSend: onSend,
+        title: component.title,
+        disabled: component.loading || component.inputDisabled,
+        onSend: component.onSend,
       ),
     ]);
   }
@@ -90,43 +146,62 @@ class ChatUI extends StatelessComponent {
   Component _header() {
     return div(classes: 'chat-header', [
       div(classes: 'chat-header-top', [
-        h2([.text(title)]),
-        if (headerAction != null)
-          div(classes: 'chat-header-action', [headerAction!]),
+        h2([.text(component.title)]),
+        if (component.headerAction != null)
+          div(classes: 'chat-header-action', [component.headerAction!]),
       ]),
-      if (description != null)
-        span(classes: 'chat-desc', [Component.text(description!)]),
+      if (component.description != null)
+        span(classes: 'chat-desc', [Component.text(component.description!)]),
     ]);
   }
 
   Component _messages() {
     final items = <Component>[];
+    final messages = component.messages;
+    final streamingText = component.streamingText;
+    final streamingReasoning = component.streamingReasoning;
+    final loading = component.loading;
 
     if (messages.isEmpty &&
-        (streamingText == null || streamingText!.isEmpty) &&
+        (streamingText == null || streamingText.isEmpty) &&
+        (streamingReasoning == null || streamingReasoning.isEmpty) &&
         !loading) {
       items.add(_emptyState());
     }
 
     for (final m in messages) {
+      if (m.reasoning != null && m.reasoning!.isNotEmpty) {
+        items.add(_thinkingBlock(m.reasoning!));
+      }
       if (m.text.isEmpty) continue;
       items.add(_messageBubble(m));
     }
 
-    final streaming = streamingText;
-    if (streaming != null && streaming.isNotEmpty) {
+    // Live streaming reasoning indicator (before any text is produced).
+    if (streamingReasoning != null &&
+        streamingReasoning.isNotEmpty &&
+        (streamingText == null || streamingText.isEmpty)) {
+      items.add(_thinkingBlock(streamingReasoning, streaming: true));
+    }
+
+    if (streamingText != null && streamingText.isNotEmpty) {
       items.add(
         div(classes: 'message', [
           div(classes: 'message-role', [.text('model')]),
           div(classes: 'message-text streaming', [
-            if (renderMarkdown) markdownBlock(streaming) else .text(streaming),
+            if (component.renderMarkdown)
+              markdownBlock(streamingText)
+            else
+              .text(streamingText),
             .text('▊'),
           ]),
         ]),
       );
     }
 
-    if (loading && (streaming == null || streaming.isEmpty)) {
+    if (loading &&
+        (streamingText == null || streamingText.isEmpty) &&
+        (streamingReasoning == null || streamingReasoning.isEmpty)) {
       items.add(
         div(classes: 'message', [
           div(classes: 'message-role', [.text('model')]),
@@ -139,10 +214,12 @@ class ChatUI extends StatelessComponent {
   }
 
   Component _emptyState() {
+    final suggestions = component.suggestions;
+    final disabled = component.loading || component.inputDisabled;
     return div(classes: 'empty-state', [
       p([
         .text('Send a message to start a conversation with '),
-        strong([.text(title)]),
+        strong([.text(component.title)]),
       ]),
       if (suggestions.isNotEmpty)
         div(classes: 'suggestions', [
@@ -152,8 +229,8 @@ class ChatUI extends StatelessComponent {
               button(
                 [.text(s)],
                 classes: 'suggestion-chip',
-                disabled: loading || inputDisabled,
-                onClick: () => onSend(s),
+                disabled: disabled,
+                onClick: () => component.onSend(s),
               ),
           ]),
         ]),
@@ -174,11 +251,13 @@ class ChatUI extends StatelessComponent {
     return div(classes: cls, [
       div(classes: 'message-role', [.text(m.role)]),
       div(classes: textCls, [
-        if (renderMarkdown && m.role == 'model')
+        if (component.renderMarkdown && m.role == 'model')
           markdownBlock(m.text)
         else
           .text(m.text),
       ]),
+      if (m.detail != null && m.detail!.isNotEmpty)
+        pre(classes: 'message-detail', [.text(m.detail!)]),
     ]);
   }
 }
@@ -225,6 +304,15 @@ class _ChatInputState extends State<_ChatInput> {
         rows: 2,
         disabled: component.disabled,
         onInput: (value) => _draft = value,
+        events: {
+          'keydown': (event) {
+            final e = event as web.KeyboardEvent;
+            if (e.key == 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              _send();
+            }
+          },
+        },
       ),
       button(
         [.text('Send')],

--- a/testapps/agents/web/lib/components/info_sidebar.dart
+++ b/testapps/agents/web/lib/components/info_sidebar.dart
@@ -1,0 +1,309 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Reusable "How It Works" educational side panels.
+///
+/// Ported from the `info-sidebar` asides in the JS pages. Each page exposes a
+/// small builder that returns an `<aside class="info-sidebar">` component with a
+/// "How It Works" list, "Key APIs" code block, and any extra notes.
+library;
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+/// Renders inline text that may contain `<code>` spans. Each entry is either a
+/// plain [String] (rendered as text) or a [Component] (e.g. `code(...)` or
+/// `strong(...)`).
+List<Component> _inline(List<Object> parts) => [
+  for (final part in parts)
+    if (part is Component) part else Component.text(part.toString()),
+];
+
+/// A single `<li>` built from mixed text/code [parts].
+Component _li(List<Object> parts) => li(_inline(parts));
+
+/// A `<p>` built from mixed text/code [parts].
+Component _p(List<Object> parts) => p(_inline(parts));
+
+/// The canonical info sidebar shell: an `<aside class="info-sidebar">`.
+Component infoSidebar(List<Component> children) =>
+    aside(classes: 'info-sidebar', children);
+
+/// A monospace "Key APIs" code block.
+Component keyApisBlock(String code) => pre([Component.text(code)]);
+
+// ---------------------------------------------------------------------------
+// Weather
+// ---------------------------------------------------------------------------
+
+Component weatherSidebar() => infoSidebar([
+  h3([.text('📋 How It Works')]),
+  ol([
+    _li([
+      'Client sends user message via ',
+      code([.text('chat.sendStream()')]),
+      " — responses arrive as they're generated.",
+    ]),
+    _li([
+      'The model can invoke ',
+      strong([.text('tools')]),
+      ' (e.g. ',
+      code([.text('getWeather')]),
+      '). Tool calls and responses render inline in the chat.',
+    ]),
+    _li([
+      'The ',
+      code([.text('remoteAgent')]),
+      ' client tracks the session across turns automatically — no manual '
+          'state threading.',
+    ]),
+  ]),
+  h4([.text('Key APIs')]),
+  keyApisBlock('''
+// Streaming multi-turn
+final agent = remoteAgent(url: '/api/weatherAgent');
+final chat = agent.chat();
+
+final turn = chat.sendStream(text: 'Weather in Tokyo?');
+await for (final chunk in turn.stream) {
+  // chunk.text → streamed text
+  // chunk.raw.modelChunk.content → tool req/resp
+}
+final res = await turn.response;'''),
+]);
+
+// ---------------------------------------------------------------------------
+// Banking (interrupt)
+// ---------------------------------------------------------------------------
+
+Component bankingSidebar() => infoSidebar([
+  h3([.text('📋 How It Works')]),
+  ol([
+    _li([
+      'User sends a request like ',
+      em([.text('"Transfer \$500 to savings"')]),
+      ' via ',
+      code([.text('chat.sendStream()')]),
+      '.',
+    ]),
+    _li([
+      'The model decides to call the ',
+      code([.text('userApproval')]),
+      ' tool. Instead of a final answer, the response carries an entry in ',
+      code([.text('response.interrupts')]),
+      ' with the action details.',
+    ]),
+    _li([
+      'The client detects the interrupt and shows an inline approval dialog — '
+          'the flow is ',
+      strong([.text('paused')]),
+      '.',
+    ]),
+    _li([
+      'When the user approves or denies, the client calls ',
+      code([.text('chat.resumeStream(interrupt.respond(output))')]),
+      ' to ',
+      strong([.text('resume')]),
+      ' from the exact point where the flow paused.',
+    ]),
+    _li([
+      'The model processes the approval result and returns a final '
+          'confirmation or denial message.',
+    ]),
+  ]),
+  h4([.text('Interrupt Pattern')]),
+  _p([
+    'The interrupt pattern uses ',
+    strong([.text('tool calls as control flow')]),
+    '. The ',
+    code([.text('userApproval')]),
+    ' tool never executes server-side — it exists solely to pause the flow and '
+        "hand control back to the client. The client's ",
+    code([.text('resume')]),
+    ' payload resumes execution.',
+  ]),
+]);
+
+// ---------------------------------------------------------------------------
+// Sub-agent delegation
+// ---------------------------------------------------------------------------
+
+Component subAgentSidebar() => infoSidebar([
+  h3([.text('🤝 How It Works')]),
+  ol([
+    _li([
+      'The ',
+      strong([.text('orchestrator')]),
+      ' agent has two sub-agents wired via the ',
+      code([.text('agents')]),
+      ' middleware: ',
+      strong([.text('researcher')]),
+      ' and ',
+      strong([.text('coder')]),
+      '.',
+    ]),
+    _li([
+      'The middleware injects a ',
+      code([.text('call_agent')]),
+      ' tool that the orchestrator model can invoke to delegate tasks.',
+    ]),
+    _li([
+      'When the model calls ',
+      code([.text('call_agent')]),
+      ', the middleware intercepts it, runs the sub-agent via its ',
+      code([.text('.run()')]),
+      " method, and returns the sub-agent's response as the tool result.",
+    ]),
+    _li([
+      'The orchestrator synthesizes sub-agent responses into a final answer '
+          'for the user.',
+    ]),
+  ]),
+  h4([.text('Architecture')]),
+  _p([
+    'The ',
+    code([.text('agents')]),
+    ' middleware resolves sub-agents from the registry, calls their ',
+    code([.text('.run()')]),
+    ' method with the delegated task, and extracts the text response. '
+        'Interrupts from sub-agents propagate up automatically.',
+  ]),
+]);
+
+// ---------------------------------------------------------------------------
+// Trip planner (prompt file)
+// ---------------------------------------------------------------------------
+
+Component tripPlannerSidebar() => infoSidebar([
+  h3([.text('📋 How It Works')]),
+  _p([
+    'This agent demonstrates ',
+    code([.text('definePromptAgent')]),
+    ' — the prompt template lives in a ',
+    strong([.text('.prompt file')]),
+    ' (',
+    code([.text('prompts/tripPlanner.prompt')]),
+    ') rather than being defined inline in code.',
+  ]),
+  h4([.text('Prompt File')]),
+  keyApisBlock('''
+---
+model: googleai/gemini-flash-latest
+tools:
+  - getAttractions
+  - getFlightInfo
+---
+
+{{role "system"}}
+You are a friendly trip planning
+assistant...
+
+{{history}}'''),
+  h4([.text('Why use definePromptAgent?')]),
+  ul([
+    _li([
+      strong([.text('Separation of concerns')]),
+      ' — prompt authors can edit ',
+      code([.text('.prompt')]),
+      ' files without touching code',
+    ]),
+    _li([
+      strong([.text('Reuse')]),
+      ' — the same prompt can power multiple agents with different stores or '
+          'configurations',
+    ]),
+    _li([
+      strong([.text('Dotprompt features')]),
+      ' — use Handlebars templates, ',
+      code([.text('{{history}}')]),
+      ', roles, helpers, and partials',
+    ]),
+  ]),
+]);
+
+// ---------------------------------------------------------------------------
+// Background agent (detached execution)
+// ---------------------------------------------------------------------------
+
+Component backgroundSidebar() => infoSidebar([
+  h3([.text('📋 How It Works')]),
+  ol([
+    _li([
+      'Client sends ',
+      code([.text('detach: true')]),
+      ' with the input message.',
+    ]),
+    _li([
+      'Server saves a snapshot with status ',
+      code([.text('"pending"')]),
+      ' and returns the ',
+      code([.text('snapshotId')]),
+      ' immediately.',
+    ]),
+    _li(['The LLM request continues running in the background on the server.']),
+    _li([
+      'Client polls the ',
+      code([.text('/state')]),
+      ' endpoint with the snapshotId every couple of seconds.',
+    ]),
+    _li([
+      'When ',
+      code([.text('status')]),
+      ' becomes terminal, the report is extracted from the '
+          "snapshot's message history.",
+    ]),
+  ]),
+  h4([.text('Status Values')]),
+  ul(classes: 'background-status-list', [
+    _li([
+      code([.text('pending')]),
+      ' — still processing',
+    ]),
+    _li([
+      code([.text('completed')]),
+      ' — completed successfully',
+    ]),
+    _li([
+      code([.text('failed')]),
+      ' — error during processing',
+    ]),
+    _li([
+      code([.text('aborted')]),
+      ' — cancelled by the client',
+    ]),
+    _li([
+      code([.text('expired')]),
+      ' — the background worker stopped heartbeating',
+    ]),
+  ]),
+
+  h4([.text('Key APIs')]),
+  keyApisBlock('''
+// Submit a detached (background) turn
+final agent = remoteAgent(
+  url: '/api/backgroundAgent',
+);
+final task = await agent.chat().detach(text: topic);
+// task.snapshotId available now
+
+// Poll until a terminal status
+await for (final snap in task.poll(
+  interval: Duration(seconds: 2),
+)) {
+  // snap.status, snap.messages
+}
+
+// Abort
+await task.abort();'''),
+]);

--- a/testapps/agents/web/lib/pages/background_agent_page.dart
+++ b/testapps/agents/web/lib/pages/background_agent_page.dart
@@ -16,8 +16,8 @@
 ///
 /// Ported from the JS `BackgroundAgent.tsx`. Submits a turn with `detach: true`
 /// via `chat.detach(...)`, which returns immediately with a snapshotId. The
-/// page then polls the task status (pending → done/failed/aborted) and renders
-/// the final report. An "Abort" button cancels the running task.
+/// page then polls the task status (pending → completed/failed/aborted/expired)
+/// and renders the final report. An "Abort" button cancels the running task.
 library;
 
 import 'package:genkit/client.dart';
@@ -25,6 +25,7 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
 import '../components/chat_ui.dart' show markdownBlock;
+import '../components/info_sidebar.dart';
 import 'streaming_chat_page.dart';
 
 class BackgroundAgentPage extends StatefulComponent {
@@ -42,7 +43,9 @@ class _BackgroundAgentPageState extends State<BackgroundAgentPage> {
   String _status = '';
   String? _snapshotId;
   String _report = '';
+  String? _error;
   int _polls = 0;
+  int _formKey = 0;
   DetachedTask? _task;
 
   Future<void> _start() async {
@@ -52,6 +55,7 @@ class _BackgroundAgentPageState extends State<BackgroundAgentPage> {
       _running = true;
       _status = 'pending';
       _report = '';
+      _error = null;
       _polls = 0;
       _snapshotId = null;
     });
@@ -78,8 +82,22 @@ class _BackgroundAgentPageState extends State<BackgroundAgentPage> {
           }
         });
       }
+
+      // The poll stream completed without producing a report — the worker
+      // likely stopped heartbeating.
+      if (mounted && _report.isEmpty && _status == 'pending') {
+        setState(() {
+          _status = 'expired';
+          _error =
+              'The background worker stopped responding before producing a '
+              'report.';
+        });
+      }
     } catch (e) {
-      setState(() => _status = 'failed: $e');
+      setState(() {
+        _status = 'failed';
+        _error = '$e';
+      });
     } finally {
       setState(() => _running = false);
     }
@@ -92,8 +110,29 @@ class _BackgroundAgentPageState extends State<BackgroundAgentPage> {
     setState(() => _status = 'aborted');
   }
 
+  void _reset() {
+    setState(() {
+      _topic = '';
+      _running = false;
+      _status = '';
+      _snapshotId = null;
+      _report = '';
+      _error = null;
+      _polls = 0;
+      _task = null;
+      _formKey++;
+    });
+  }
+
+  bool get _isTerminal =>
+      _status == 'completed' ||
+      _status == 'failed' ||
+      _status == 'aborted' ||
+      _status == 'expired';
+
   @override
   Component build(BuildContext context) {
+    final showForm = !_running && _report.isEmpty && !_isTerminal;
     return div(classes: 'page-with-sidebar', [
       div(classes: 'chat-panel', [
         div(classes: 'chat-header', [
@@ -113,8 +152,9 @@ class _BackgroundAgentPageState extends State<BackgroundAgentPage> {
             ),
           ]),
         ]),
-        if (!_running && _report.isEmpty) _form() else _statusView(),
+        if (showForm) _form() else _statusView(),
       ]),
+      backgroundSidebar(),
     ]);
   }
 
@@ -123,7 +163,8 @@ class _BackgroundAgentPageState extends State<BackgroundAgentPage> {
       label(classes: 'background-label', [.text('Research topic')]),
       textarea(
         [],
-        classes: 'chat-input',
+        key: ValueKey('bg-form-$_formKey'),
+        classes: 'background-input',
         rows: 3,
         placeholder: 'e.g. renewable energy trends',
         onInput: (v) => _topic = v,
@@ -137,36 +178,55 @@ class _BackgroundAgentPageState extends State<BackgroundAgentPage> {
   }
 
   Component _statusView() {
-    final terminal =
-        _status == 'completed' ||
-        _status.startsWith('failed') ||
-        _status == 'aborted';
+    final badgeClass = switch (_status) {
+      'completed' => 'done',
+      'aborted' => 'aborted',
+      'failed' || 'expired' => 'failed',
+      _ => '',
+    };
     return div(classes: 'background-result', [
       div(classes: 'background-result-header', [
-        span(
-          classes:
-              'background-status-badge '
-              '${_status == 'completed'
-                  ? 'done'
-                  : _status == 'aborted'
-                  ? 'aborted'
-                  : _status.startsWith('failed')
-                  ? 'failed'
-                  : ''}',
-          [.text(_status)],
-        ),
-
+        span(classes: 'background-status-badge $badgeClass', [
+          .text(_statusLabel()),
+        ]),
         if (_snapshotId != null)
-          span(classes: 'chat-desc', [.text('snapshot: $_snapshotId')]),
-        if (!terminal) span(classes: 'chat-desc', [.text('polls: $_polls')]),
+          span(classes: 'background-snapshot-id', [
+            .text('snapshot: $_snapshotId'),
+          ]),
+        if (!_isTerminal)
+          span(classes: 'background-poll-count', [.text('polls: $_polls')]),
       ]),
-      if (!terminal)
+      if (!_isTerminal)
         div(classes: 'background-status', [
           span(classes: 'background-status-icon', [.text('⏳')]),
           h3([.text('Working…')]),
+          span(classes: 'background-status-detail', [
+            .text(
+              'The server is generating your report. This page polls for '
+              'status updates every couple of seconds.',
+            ),
+          ]),
         ]),
+      if (_error != null) p(classes: 'background-error', [.text(_error!)]),
       if (_report.isNotEmpty)
         div(classes: 'background-report', [markdownBlock(_report)]),
+      if (_isTerminal)
+        div(classes: 'background-form', [
+          button(
+            [.text(_status == 'completed' ? '📄 New Report' : '🔄 Try Again')],
+            classes: 'btn btn-send',
+            onClick: _reset,
+          ),
+        ]),
     ]);
   }
+
+  String _statusLabel() => switch (_status) {
+    'completed' => '✅ Completed',
+    'failed' => '❌ Failed',
+    'aborted' => '⏹ Aborted',
+    'expired' => '⌛ Expired',
+    'pending' => '⏳ Pending',
+    _ => _status,
+  };
 }

--- a/testapps/agents/web/lib/pages/banking_page.dart
+++ b/testapps/agents/web/lib/pages/banking_page.dart
@@ -29,6 +29,7 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
 import '../components/chat_ui.dart';
+import '../components/info_sidebar.dart';
 import 'streaming_chat_page.dart';
 
 class BankingPage extends StatefulComponent {
@@ -203,6 +204,7 @@ class _BankingPageState extends State<BankingPage> {
                 ]),
               ]),
       ),
+      bankingSidebar(),
     ]);
   }
 }

--- a/testapps/agents/web/lib/pages/branching_page.dart
+++ b/testapps/agents/web/lib/pages/branching_page.dart
@@ -357,6 +357,25 @@ class _BranchingPageState extends State<BranchingPage> {
           "original commit doesn't change when you create branches from it.",
         ),
       ]),
+      h4([.text('Key APIs')]),
+      pre([
+        .text('''
+// Branch: two chats from the same snapshot
+final agent = remoteAgent(
+  url: '/api/branchingAgent',
+);
+AgentChat makeChat() =>
+    agent.chat(snapshotId: snapshotId);
+
+final results = await Future.wait([
+  makeChat().send(text: text),
+  makeChat().send(text: text),
+]);
+
+// results[0].snapshotId != results[1].snapshotId
+// Both branch from the same point
+// Pick one to continue from'''),
+      ]),
     ]);
   }
 }

--- a/testapps/agents/web/lib/pages/client_state_page.dart
+++ b/testapps/agents/web/lib/pages/client_state_page.dart
@@ -133,7 +133,20 @@ class _ClientStatePageState extends State<ClientStatePage> {
         onSend: _handleSend,
       ),
       aside(classes: 'state-inspector', [
-        h3([.text('🧠 Client-held state')]),
+        h3([.text('📦 Session State (client-owned)')]),
+        p(classes: 'state-inspector-hint', [
+          .text('This is the raw '),
+          code([.text('state')]),
+          .text(
+            ' blob the client round-trips. It contains the full message '
+            'history, custom data, and artifacts. The ',
+          ),
+          code([.text('remoteAgent')]),
+          .text(
+            ' client stores it and sends it back on every subsequent turn '
+            'automatically.',
+          ),
+        ]),
         pre(classes: 'state-inspector-json', [.text(_stateJson)]),
       ]),
     ]);

--- a/testapps/agents/web/lib/pages/coding_agent_page.dart
+++ b/testapps/agents/web/lib/pages/coding_agent_page.dart
@@ -23,6 +23,10 @@
 ///     middleware reads); denying *responds* with a "not approved" result.
 ///   * `ask_user` pauses to ask a question — the dialog shows the options and
 ///     resumes by *responding* with the chosen answer.
+///
+/// A file-explorer sidebar mirrors the JS layout: it lists the sandboxed
+/// `workspace/` directory (via the `listWorkspaceFiles` flow), refreshing after
+/// each turn, and shows file contents on click (via `readWorkspaceFile`).
 library;
 
 import 'dart:async';
@@ -39,6 +43,32 @@ import 'streaming_chat_page.dart';
 /// Tools that pause for an approve/deny confirmation before running.
 const _approvalTools = {'write_file', 'search_and_replace', 'run_shell'};
 
+/// A file or directory node in the workspace tree.
+class _FileNode {
+  _FileNode({
+    required this.name,
+    required this.path,
+    required this.type,
+    this.children,
+  });
+
+  factory _FileNode.fromJson(Map<String, dynamic> json) => _FileNode(
+    name: json['name'] as String? ?? '',
+    path: json['path'] as String? ?? '',
+    type: json['type'] as String? ?? 'file',
+    children: (json['children'] as List?)
+        ?.map((c) => _FileNode.fromJson((c as Map).cast<String, dynamic>()))
+        .toList(),
+  );
+
+  final String name;
+  final String path;
+  final String type;
+  final List<_FileNode>? children;
+
+  bool get isDirectory => type == 'directory';
+}
+
 class CodingAgentPage extends StatefulComponent {
   const CodingAgentPage({super.key});
 
@@ -49,11 +79,37 @@ class CodingAgentPage extends StatefulComponent {
 class _CodingAgentPageState extends State<CodingAgentPage> {
   late final AgentApi _agent = remoteAgent(url: '$apiBase/api/codingAgent');
 
+  // Flows exposing the sandboxed workspace directory.
+  late final RemoteAction<void, List<_FileNode>, dynamic, dynamic> _listFiles =
+      defineRemoteAction(
+        url: '$apiBase/api/workspace/files',
+        fromResponse: (json) {
+          final files = (json as Map)['files'] as List? ?? const [];
+          return files
+              .map(
+                (f) => _FileNode.fromJson((f as Map).cast<String, dynamic>()),
+              )
+              .toList();
+        },
+      );
+  late final RemoteAction<String, String, dynamic, dynamic> _readFile =
+      defineRemoteAction(
+        url: '$apiBase/api/workspace/file',
+        fromResponse: (json) => (json as Map)['content'] as String? ?? '',
+      );
+
   AgentChat? _chat;
 
   final List<ChatMessage> _messages = [];
   String _streamingText = '';
   bool _loading = false;
+
+  // File explorer state.
+  List<_FileNode> _files = const [];
+  final Set<String> _expandedDirs = {};
+  String? _selectedPath;
+  String _fileContent = '';
+  bool _fileLoading = false;
 
   // Pending interrupts awaiting a user decision, resolved one at a time. Each
   // decision is accumulated into [_restarts] / [_responses]; once every pending
@@ -61,6 +117,40 @@ class _CodingAgentPageState extends State<CodingAgentPage> {
   final List<AgentInterrupt> _pending = [];
   final List<ToolRequestPart> _restarts = [];
   final List<ToolResponsePart> _responses = [];
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_refreshFiles());
+  }
+
+  Future<void> _refreshFiles() async {
+    try {
+      final files = await _listFiles.call(input: null);
+      if (!mounted) return;
+      setState(() => _files = files);
+    } catch (_) {
+      // Silently ignore — the workspace may not exist until the first write.
+    }
+  }
+
+  Future<void> _openFile(String path) async {
+    setState(() {
+      _selectedPath = path;
+      _fileLoading = true;
+      _fileContent = '';
+    });
+    try {
+      final content = await _readFile.call(input: path);
+      if (!mounted) return;
+      setState(() => _fileContent = content);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _fileContent = 'Failed to read file: $e');
+    } finally {
+      if (mounted) setState(() => _fileLoading = false);
+    }
+  }
 
   Future<void> _runTurn(AgentTurn turn) async {
     var accumulated = '';
@@ -115,6 +205,9 @@ class _CodingAgentPageState extends State<CodingAgentPage> {
         ..clear()
         ..addAll(res.interrupts);
     });
+
+    // The agent may have created/edited files this turn — refresh the tree.
+    unawaited(_refreshFiles());
   }
 
   Future<void> _handleSend(String text) async {
@@ -207,7 +300,7 @@ class _CodingAgentPageState extends State<CodingAgentPage> {
   @override
   Component build(BuildContext context) {
     final interrupt = _pending.isNotEmpty ? _pending.first : null;
-    return div(classes: 'page-with-sidebar', [
+    return div(classes: 'coding-agent-layout', [
       ChatUI(
         title: 'Coding Agent',
         description:
@@ -227,9 +320,91 @@ class _CodingAgentPageState extends State<CodingAgentPage> {
         onSend: _handleSend,
         extra: interrupt == null ? null : _interruptDialog(interrupt),
       ),
+      _fileExplorer(),
     ]);
   }
 
+  // ── File explorer sidebar ──────────────────────────────────────────────
+  Component _fileExplorer() {
+    return aside(classes: 'file-explorer', [
+      div(classes: 'file-explorer-header', [
+        h3([.text('📁 Workspace')]),
+        button(
+          [.text('⟳ Refresh')],
+          classes: 'btn-refresh-files',
+          onClick: () => unawaited(_refreshFiles()),
+        ),
+      ]),
+      if (_files.isEmpty)
+        div(classes: 'file-explorer-empty', [.text('Workspace is empty.')])
+      else
+        div(classes: 'file-tree', _fileTree(_files, 0)),
+      if (_selectedPath != null) _fileViewer(),
+    ]);
+  }
+
+  List<Component> _fileTree(List<_FileNode> nodes, int depth) {
+    final items = <Component>[];
+    for (final node in nodes) {
+      final indentPad = 12 + depth * 14;
+      if (node.isDirectory) {
+        final expanded = _expandedDirs.contains(node.path);
+        items.add(
+          button(
+            classes: 'file-tree-item file-tree-dir',
+            styles: Styles(raw: {'padding-left': '${indentPad}px'}),
+            onClick: () => setState(() {
+              if (!_expandedDirs.add(node.path)) {
+                _expandedDirs.remove(node.path);
+              }
+            }),
+            [
+              span(classes: 'file-icon', [.text(expanded ? '📂' : '📁')]),
+              span(classes: 'file-name', [.text(node.name)]),
+            ],
+          ),
+        );
+        if (expanded && node.children != null) {
+          items.addAll(_fileTree(node.children!, depth + 1));
+        }
+      } else {
+        final selected = node.path == _selectedPath;
+        items.add(
+          button(
+            classes: selected ? 'file-tree-item selected' : 'file-tree-item',
+            styles: Styles(raw: {'padding-left': '${indentPad}px'}),
+            onClick: () => unawaited(_openFile(node.path)),
+            [
+              span(classes: 'file-icon', [.text('📄')]),
+              span(classes: 'file-name', [.text(node.name)]),
+            ],
+          ),
+        );
+      }
+    }
+    return items;
+  }
+
+  Component _fileViewer() {
+    return div(classes: 'file-viewer', [
+      div(classes: 'file-viewer-header', [
+        span(classes: 'file-viewer-path', [.text(_selectedPath ?? '')]),
+        button(
+          [.text('✕')],
+          classes: 'file-viewer-close',
+          onClick: () => setState(() {
+            _selectedPath = null;
+            _fileContent = '';
+          }),
+        ),
+      ]),
+      pre(classes: 'file-viewer-content', [
+        .text(_fileLoading ? 'Loading…' : _fileContent),
+      ]),
+    ]);
+  }
+
+  // ── Interrupt dialogs ──────────────────────────────────────────────────
   Component _interruptDialog(AgentInterrupt interrupt) {
     if (interrupt.name == 'ask_user') return _askUserDialog(interrupt);
     return _approvalDialog(interrupt);
@@ -237,15 +412,15 @@ class _CodingAgentPageState extends State<CodingAgentPage> {
 
   Component _approvalDialog(AgentInterrupt interrupt) {
     final isApproval = _approvalTools.contains(interrupt.name);
-    return div(classes: 'interrupt-dialog', [
-      h3([.text('Approval required')]),
-      p([
+    return div(classes: 'approval-dialog', [
+      h3([.text('🔒 Approval required')]),
+      p(classes: 'approval-tool-name', [
         .text('The agent wants to run '),
-        strong([.text(interrupt.name)]),
+        code([.text(interrupt.name)]),
         .text(':'),
       ]),
-      pre([.text(jsonEncode(interrupt.input))]),
-      div(classes: 'interrupt-buttons', [
+      pre(classes: 'approval-code', [.text(jsonEncode(interrupt.input))]),
+      div(classes: 'approval-buttons', [
         button(
           [.text(isApproval ? 'Approve' : 'Allow')],
           classes: 'btn btn-approve',
@@ -266,16 +441,14 @@ class _CodingAgentPageState extends State<CodingAgentPage> {
     final options = input is Map && input['options'] is List
         ? (input['options'] as List).map((o) => o.toString()).toList()
         : <String>[];
-    return div(classes: 'interrupt-dialog', [
-      h3([.text('The agent has a question')]),
-      p([
-        strong([.text(question)]),
-      ]),
-      div(classes: 'interrupt-buttons', [
+    return div(classes: 'ask-user-dialog', [
+      h3([.text('💬 The agent has a question')]),
+      p(classes: 'ask-user-question', [.text(question)]),
+      div(classes: 'ask-user-options', [
         for (final option in options)
           button(
             [.text(option)],
-            classes: 'btn btn-approve',
+            classes: 'ask-user-option',
             onClick: () => _answer(interrupt, option),
           ),
       ]),

--- a/testapps/agents/web/lib/pages/research_page.dart
+++ b/testapps/agents/web/lib/pages/research_page.dart
@@ -102,7 +102,7 @@ class _ResearchPageState extends State<ResearchPage> {
 
   @override
   Component build(BuildContext context) {
-    return div(classes: 'page-with-sidebar', [
+    return div(classes: 'research-layout', [
       ChatUI(
         title: 'Research Agent',
         description:
@@ -119,18 +119,58 @@ class _ResearchPageState extends State<ResearchPage> {
         renderMarkdown: true,
         onSend: _handleSend,
       ),
-      aside(classes: 'state-inspector', [
-        h3([.text('🔬 Progress')]),
-        if (_status.isNotEmpty)
-          p(classes: 'chat-desc', [.text(_status)])
-        else
-          p(classes: 'artifacts-empty', [.text('Idle.')]),
-        if (_subQuestions.isNotEmpty) ...[
-          h3([.text('Sub-questions')]),
-          ul([
-            for (final q in _subQuestions) li([.text(q)]),
+      _sidebar(),
+    ]);
+  }
+
+  Component _sidebar() {
+    final hasProgress = _status.isNotEmpty || _subQuestions.isNotEmpty;
+    return aside(classes: 'research-sidebar', [
+      h3([.text('🔬 Research Process')]),
+      p(classes: 'research-sidebar-hint', [
+        .text('A custom agent that orchestrates '),
+        code([.text('decompose → research → synthesize')]),
+        .text(' and streams progress via '),
+        code([.text('customPatch')]),
+        .text(' chunks.'),
+      ]),
+      if (_loading && _status.isNotEmpty)
+        div(classes: 'research-status-bar', [
+          div(classes: 'research-status-dot', []),
+          .text(_status),
+        ]),
+      if (!hasProgress)
+        div(classes: 'research-empty', [
+          .text('Ask a question to watch the research process unfold.'),
+        ]),
+      if (_subQuestions.isNotEmpty)
+        div(classes: 'research-section', [
+          h4([.text('Sub-questions')]),
+          p(classes: 'research-section-hint', [
+            .text('The agent decomposed your question into these parts:'),
           ]),
-        ],
+          ol(classes: 'research-questions', [
+            for (final q in _subQuestions)
+              li(classes: 'research-question', [.text(q)]),
+          ]),
+        ]),
+      hr(classes: 'research-divider'),
+      h4([.text('📋 How It Works')]),
+      ol(classes: 'research-howto', [
+        li([
+          .text('Decompose: the agent breaks your question into '),
+          code([.text('subQuestions')]),
+          .text('.'),
+        ]),
+        li([.text('Research: each sub-question is answered in turn.')]),
+        li([.text('Synthesize: answers are combined into a final response.')]),
+        li([
+          .text('Each step streams a '),
+          code([.text('customPatch')]),
+          .text(' with the live '),
+          code([.text('status')]),
+          .text('.'),
+        ]),
       ]),
     ]);
   }

--- a/testapps/agents/web/lib/pages/streaming_chat_page.dart
+++ b/testapps/agents/web/lib/pages/streaming_chat_page.dart
@@ -19,6 +19,11 @@
 /// calls and responses inline, and stream the model text. Specialized pages
 /// (banking interrupts, custom state, artifacts) compose this same client
 /// surface directly rather than reusing this widget.
+///
+/// When [sessionPath] is provided the page also supports URL-based session
+/// persistence (matching the JS demos): it restores history from a
+/// `:snapshotId` route param via `agent.loadChat`, pushes `chat.snapshotId`
+/// into the URL after each turn, and shows a "✨ New Session" header action.
 library;
 
 import 'dart:convert';
@@ -26,6 +31,7 @@ import 'dart:convert';
 import 'package:genkit/client.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_router/jaspr_router.dart';
 
 import '../components/chat_ui.dart';
 
@@ -41,6 +47,9 @@ class StreamingChatPage extends StatefulComponent {
     this.description,
     this.suggestions = const [],
     this.renderMarkdown = true,
+    this.sidebar,
+    this.sessionPath,
+    this.snapshotId,
     super.key,
   });
 
@@ -50,6 +59,18 @@ class StreamingChatPage extends StatefulComponent {
   final String? description;
   final List<String> suggestions;
   final bool renderMarkdown;
+
+  /// Optional educational side panel rendered next to the chat (e.g. a
+  /// "How It Works" `info-sidebar`).
+  final Component? sidebar;
+
+  /// The base route for URL-based session persistence, e.g. `/weather`. When
+  /// set, the page restores from [snapshotId] on load and pushes the current
+  /// snapshot into the URL (`$sessionPath/:snapshotId`) after each turn.
+  final String? sessionPath;
+
+  /// Snapshot id read from the URL (`$sessionPath/:snapshotId`), if any.
+  final String? snapshotId;
 
   @override
   State<StreamingChatPage> createState() => _StreamingChatPageState();
@@ -65,6 +86,102 @@ class _StreamingChatPageState extends State<StreamingChatPage> {
   final List<ChatMessage> _messages = [];
   String _streamingText = '';
   bool _loading = false;
+
+  /// True while restoring history from a URL snapshotId on first load.
+  late bool _restoring = component.snapshotId != null;
+
+  @override
+  void initState() {
+    super.initState();
+    if (component.snapshotId != null) {
+      _restore(component.snapshotId!);
+    }
+  }
+
+  @override
+  void didUpdateComponent(StreamingChatPage oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    // The route's snapshotId can change without remounting (back/forward
+    // navigation, an edited URL, or our own post-turn `context.replace`), so
+    // re-sync here rather than keying the whole page (which would remount and
+    // drop the transient tool-call cards that are not re-rendered mid-session).
+    final next = component.snapshotId;
+    if (next == oldComponent.snapshotId) return;
+    // Our own post-turn URL push sets the route to the snapshot we just
+    // produced — the UI is already correct, so don't reload (which would drop
+    // the inline tool cards until the next reload).
+    if (next == _chat?.snapshotId) return;
+
+    if (next != null) {
+      setState(() => _restoring = true);
+      _restore(next);
+    } else {
+      // Navigated to "New Session": start fresh.
+      setState(() {
+        _chat = null;
+        _messages.clear();
+        _streamingText = '';
+        _restoring = false;
+      });
+    }
+  }
+
+  bool get _persists => component.sessionPath != null;
+
+  // ── Restore session history from a snapshotId ──────────────────────────
+  //
+  // Reconstructs the full transcript — including inline tool request/response
+  // cards — from the snapshot's message history so a reload looks the same as
+  // the live session.
+  Future<void> _restore(String snapshotId) async {
+    try {
+      final chat = await _agent.loadChat(snapshotId: snapshotId);
+      final restored = <ChatMessage>[];
+      for (final msg in chat.messages) {
+        final role = msg.role.value;
+        // Emit inline tool cards for any tool request/response parts, matching
+        // the live streaming loop in `_handleSend`.
+        for (final part in msg.content) {
+          if (part.isToolRequest) {
+            final tr = part.toolRequest!;
+            restored.add(
+              ChatMessage(
+                role: 'tool',
+                text: '🔧 Calling ${tr.name}(${jsonEncode(tr.input)})',
+              ),
+            );
+          } else if (part.isToolResponse) {
+            final tr = part.toolResponse!;
+            restored.add(
+              ChatMessage(
+                role: 'tool',
+                text: '✅ ${tr.name} → ${jsonEncode(tr.output)}',
+              ),
+            );
+          }
+        }
+        if (role != 'user' && role != 'model') continue;
+        final text = msg.content.map((part) => part.text ?? '').join();
+        if (text.isNotEmpty) restored.add(ChatMessage(role: role, text: text));
+      }
+      if (!mounted) return;
+      setState(() {
+        _chat = chat;
+        _messages
+          ..clear()
+          ..addAll(restored);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _messages.add(
+          ChatMessage(role: 'system', text: '⚠️ Failed to restore session: $e'),
+        );
+      });
+    } finally {
+      if (mounted) setState(() => _restoring = false);
+    }
+  }
 
   Future<void> _handleSend(String text) async {
     if (_loading) return;
@@ -131,6 +248,12 @@ class _StreamingChatPageState extends State<StreamingChatPage> {
           ),
         );
       });
+
+      // Push the snapshot id into the URL so the session is bookmarkable.
+      final id = chat.snapshotId;
+      if (_persists && id != null && mounted) {
+        context.replace('${component.sessionPath}/$id');
+      }
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -153,6 +276,29 @@ class _StreamingChatPageState extends State<StreamingChatPage> {
 
   @override
   Component build(BuildContext context) {
+    if (_restoring) {
+      return div(classes: 'page-with-sidebar', [
+        div(classes: 'chat-panel', [
+          div(classes: 'chat-header', [
+            h2([.text(component.title)]),
+            span(classes: 'chat-desc', [.text('Restoring session…')]),
+          ]),
+          div(classes: 'chat-messages', [
+            div(classes: 'message', [
+              div(classes: 'message-role', [.text('system')]),
+              div(classes: 'message-text loading', [
+                .text(
+                  'Restoring session from snapshot ${component.snapshotId}…',
+                ),
+              ]),
+            ]),
+          ]),
+        ]),
+        ?component.sidebar,
+      ]);
+    }
+
+    final showNewSession = _persists && _chat?.snapshotId != null;
     return div(classes: 'page-with-sidebar', [
       ChatUI(
         title: component.title,
@@ -163,7 +309,15 @@ class _StreamingChatPageState extends State<StreamingChatPage> {
         loading: _loading,
         renderMarkdown: component.renderMarkdown,
         onSend: _handleSend,
+        headerAction: showNewSession
+            ? Link(
+                to: component.sessionPath!,
+                classes: 'btn btn-new-session',
+                children: [.text('✨ New Session')],
+              )
+            : null,
       ),
+      ?component.sidebar,
     ]);
   }
 }

--- a/testapps/agents/web/lib/pages/sub_agent_page.dart
+++ b/testapps/agents/web/lib/pages/sub_agent_page.dart
@@ -20,6 +20,7 @@ library;
 
 import 'package:jaspr/jaspr.dart';
 
+import '../components/info_sidebar.dart';
 import 'streaming_chat_page.dart';
 
 class SubAgentPage extends StatelessComponent {
@@ -27,17 +28,18 @@ class SubAgentPage extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
-    return const StreamingChatPage(
+    return StreamingChatPage(
       endpoint: '/api/orchestratorAgent',
       title: 'Sub-Agent Delegation',
       description:
           'An orchestrator agent that delegates to a researcher and a coder '
           'sub-agent and synthesizes their answers.',
-      suggestions: [
+      suggestions: const [
         'Research the best sorting algorithms and write a Dart quicksort.',
         'Write a function that calculates the fibonacci sequence.',
         'Explain how HTTPS works.',
       ],
+      sidebar: subAgentSidebar(),
     );
   }
 }

--- a/testapps/agents/web/lib/pages/task_tracker_page.dart
+++ b/testapps/agents/web/lib/pages/task_tracker_page.dart
@@ -118,29 +118,48 @@ class _TaskTrackerPageState extends State<TaskTrackerPage> {
     }
   }
 
-  Component _taskList() {
+  List<Map> get _tasks {
     final custom = _custom;
-    if (custom is! Map) {
-      return p(classes: 'artifacts-empty', [.text('No tasks yet.')]);
-    }
-    final tasks = (custom['tasks'] as List?) ?? const [];
+    if (custom is! Map) return const [];
+    return ((custom['tasks'] as List?) ?? const []).cast<Map>();
+  }
+
+  Component _progress() {
+    final tasks = _tasks;
+    if (tasks.isEmpty) return const _Empty();
+    final done = tasks.where((t) => t['done'] == true).length;
+    final pct = tasks.isEmpty ? 0 : (done / tasks.length * 100).round();
+    return div(classes: 'task-progress', [
+      .text('$done of ${tasks.length} done'),
+      div(classes: 'task-progress-bar', [
+        div(
+          classes: 'task-progress-fill',
+          styles: Styles(raw: {'width': '$pct%'}),
+          [],
+        ),
+      ]),
+    ]);
+  }
+
+  Component _taskList() {
+    final tasks = _tasks;
     if (tasks.isEmpty) {
-      return p(classes: 'artifacts-empty', [.text('No tasks yet.')]);
+      return p(classes: 'task-empty', [.text('No tasks yet.')]);
     }
-    return ul([
-      for (final t in tasks.cast<Map>())
-        li([
-          .text(
-            '${(t['done'] == true) ? '✅' : '⬜'} '
-            '#${t['id']} ${t['title']}',
-          ),
+    return ul(classes: 'task-list', [
+      for (final t in tasks)
+        li(classes: t['done'] == true ? 'task-item task-done' : 'task-item', [
+          span(classes: 'task-checkbox', [
+            .text(t['done'] == true ? '✅' : '⬜'),
+          ]),
+          span(classes: 'task-title', [.text('#${t['id']} ${t['title']}')]),
         ]),
     ]);
   }
 
   @override
   Component build(BuildContext context) {
-    return div(classes: 'page-with-sidebar', [
+    return div(classes: 'task-tracker-layout', [
       ChatUI(
         title: 'Task Tracker',
         description:
@@ -158,10 +177,61 @@ class _TaskTrackerPageState extends State<TaskTrackerPage> {
         renderMarkdown: true,
         onSend: _handleSend,
       ),
-      aside(classes: 'state-inspector', [
-        h3([.text('✅ Tasks')]),
+      aside(classes: 'task-sidebar', [
+        h3([.text('✅ Task List')]),
+        p(classes: 'task-sidebar-hint', [
+          .text('Lives in the agent\'s custom '),
+          code([.text('state')]),
+          .text('. Updated live via '),
+          code([.text('customPatch')]),
+          .text(' stream chunks.'),
+        ]),
+        _progress(),
         _taskList(),
+        hr(classes: 'task-divider'),
+        h4([.text('📋 How It Works')]),
+        ol(classes: 'task-howto', [
+          li([
+            .text('Tools mutate '),
+            code([.text('ctx.state.custom')]),
+            .text(' on the server.'),
+          ]),
+          li([
+            .text('Each mutation streams a '),
+            code([.text('customPatch')]),
+            .text(' chunk to the client.'),
+          ]),
+          li([
+            code([.text('chunk.custom')]),
+            .text(' updates this panel mid-stream.'),
+          ]),
+        ]),
+        h4([.text('Key APIs')]),
+        pre(classes: 'task-code', [
+          .text('''
+// Seed initial custom state
+final chat = agent.chat(
+  state: SessionState(
+    custom: {'tasks': [], 'nextId': 1},
+  ),
+);
+
+// Live updates during a turn
+await for (final chunk in turn.stream) {
+  if (chunk.custom != null) {
+    setState(() => custom = chunk.custom);
+  }
+}'''),
+        ]),
       ]),
     ]);
   }
+}
+
+/// A blank placeholder used when there is no progress bar to show.
+class _Empty extends StatelessComponent {
+  const _Empty();
+
+  @override
+  Component build(BuildContext context) => span([]);
 }

--- a/testapps/agents/web/lib/pages/trip_planner_page.dart
+++ b/testapps/agents/web/lib/pages/trip_planner_page.dart
@@ -19,6 +19,7 @@ library;
 
 import 'package:jaspr/jaspr.dart';
 
+import '../components/info_sidebar.dart';
 import 'streaming_chat_page.dart';
 
 class TripPlannerPage extends StatelessComponent {
@@ -26,17 +27,18 @@ class TripPlannerPage extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
-    return const StreamingChatPage(
+    return StreamingChatPage(
       endpoint: '/api/tripPlannerAgent',
       title: 'Trip Planner',
       description:
           'A prompt-file (dotprompt) agent. Suggests attractions and looks up '
           'flights using tools.',
-      suggestions: [
+      suggestions: const [
         'I want to plan a trip to Paris. What should I see there?',
         'Find me flights from London to Tokyo.',
         'What are the top attractions in Tokyo?',
       ],
+      sidebar: tripPlannerSidebar(),
     );
   }
 }

--- a/testapps/agents/web/lib/pages/weather_page.dart
+++ b/testapps/agents/web/lib/pages/weather_page.dart
@@ -19,29 +19,33 @@ library;
 
 import 'package:jaspr/jaspr.dart';
 
+import '../components/info_sidebar.dart';
 import 'streaming_chat_page.dart';
 
 class WeatherPage extends StatelessComponent {
   const WeatherPage({this.snapshotId, super.key});
 
-  /// Optional snapshot id from the URL (`/weather/:snapshotId`). The Dart
-  /// sample starts a fresh chat per visit; the JS demo additionally restores
-  /// from this snapshot via `agent.loadChat()`.
+  /// Optional snapshot id from the URL (`/weather/:snapshotId`). When present,
+  /// the session is restored via `agent.loadChat()`.
   final String? snapshotId;
 
   @override
   Component build(BuildContext context) {
-    return const StreamingChatPage(
+    return StreamingChatPage(
       endpoint: '/api/weatherAgent',
       title: 'Weather Agent',
+
       description:
           'Multi-turn chat with tool-calling. Ask about the weather in any '
           'city.',
-      suggestions: [
+      suggestions: const [
         'What is the weather like in London?',
         'Is it sunny in Tokyo right now?',
         'Compare the weather in Paris and New York.',
       ],
+      sidebar: weatherSidebar(),
+      sessionPath: '/weather',
+      snapshotId: snapshotId,
     );
   }
 }

--- a/testapps/agents/web/web/styles.css
+++ b/testapps/agents/web/web/styles.css
@@ -2,9 +2,21 @@
  * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * Ported from the JS testapps/agents/web/src/App.css.
  */
 
+/* Reset & base */
 *,
 *::before,
 *::after {
@@ -16,9 +28,15 @@
 body {
   background: #0f0f10;
   color: #e4e4e7;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+    sans-serif;
   height: 100vh;
   overflow: hidden;
+}
+
+#root {
+  height: 100vh;
 }
 
 .app {
@@ -67,7 +85,10 @@ body {
   gap: 10px;
   padding: 12px 16px;
   text-decoration: none;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .nav-item:hover {
@@ -84,6 +105,10 @@ body {
 
 .nav-icon {
   font-size: 1.1rem;
+}
+
+.nav-label {
+  white-space: nowrap;
 }
 
 .sidebar-footer {
@@ -113,14 +138,7 @@ body {
   overflow: hidden;
 }
 
-.page-with-sidebar {
-  display: flex;
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-}
-
-/* ---- Chat panel ---- */
+/* ---- Chat panel (used by ChatUI) ---- */
 .chat-panel {
   display: flex;
   flex: 1;
@@ -155,6 +173,9 @@ body {
   font-size: 0.75rem;
   padding: 5px 12px;
   text-decoration: none;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
   white-space: nowrap;
 }
 
@@ -189,12 +210,16 @@ body {
 .empty-state {
   color: #52525b;
   font-size: 0.9rem;
-  margin-top: 15%;
+  margin-top: 20%;
   text-align: center;
 }
 
 .empty-state p {
   margin-bottom: 16px;
+}
+
+.suggestions {
+  margin-top: 12px;
 }
 
 .suggestions-label {
@@ -221,6 +246,10 @@ body {
   max-width: 420px;
   padding: 8px 16px;
   text-align: left;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
   width: 100%;
 }
 
@@ -268,8 +297,25 @@ body {
 }
 
 .message-text-mono {
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
   font-size: 0.8rem;
+}
+
+/* Terminal-style detail box inside tool messages (e.g. shell output, file content) */
+.message-detail {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  color: #d4d4d8;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  margin: 8px 0 0;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .message-role {
@@ -291,8 +337,49 @@ body {
   word-break: break-word;
 }
 
+/* When rendering markdown inside a message, reset pre-wrap so block
+   elements (p, ul, ol, pre) use normal flow instead of double-spacing. */
 .message-text .markdown-body {
   white-space: normal;
+}
+
+.message-text .markdown-body p {
+  line-height: 1.5;
+  margin: 0 0 8px;
+}
+
+.message-text .markdown-body p:last-child {
+  margin-bottom: 0;
+}
+
+.message-text .markdown-body ul,
+.message-text .markdown-body ol {
+  margin: 4px 0 8px;
+  padding-left: 20px;
+}
+
+.message-text .markdown-body li {
+  line-height: 1.45;
+  margin-bottom: 2px;
+}
+
+.message-text .markdown-body h1,
+.message-text .markdown-body h2,
+.message-text .markdown-body h3,
+.message-text .markdown-body h4 {
+  margin-bottom: 6px;
+  margin-top: 12px;
+}
+
+.message-text .markdown-body h1:first-child,
+.message-text .markdown-body h2:first-child,
+.message-text .markdown-body h3:first-child,
+.message-text .markdown-body h4:first-child {
+  margin-top: 0;
+}
+
+.message-text .markdown-body pre {
+  margin: 6px 0;
 }
 
 .message-text.streaming {
@@ -305,8 +392,13 @@ body {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 /* ---- Input area ---- */
@@ -330,6 +422,7 @@ body {
   outline: none;
   padding: 10px 12px;
   resize: none;
+  transition: border-color 0.15s;
 }
 
 .chat-input:focus {
@@ -348,6 +441,9 @@ body {
   font-size: 0.85rem;
   font-weight: 600;
   padding: 8px 18px;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
 }
 
 .btn:disabled {
@@ -369,9 +465,17 @@ body {
   color: white;
 }
 
+.btn-approve:hover:not(:disabled) {
+  background: #15803d;
+}
+
 .btn-deny {
   background: #dc2626;
   color: white;
+}
+
+.btn-deny:hover:not(:disabled) {
+  background: #b91c1c;
 }
 
 /* ---- Interrupt dialog ---- */
@@ -393,15 +497,263 @@ body {
   margin-bottom: 4px;
 }
 
+.interrupt-feedback {
+  background: #27272a;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  color: #f4f4f5;
+  font-family: inherit;
+  font-size: 0.8rem;
+  margin: 8px 0;
+  min-height: 40px;
+  padding: 8px;
+  resize: vertical;
+  width: 100%;
+}
+
 .interrupt-buttons {
   display: flex;
   gap: 8px;
   margin-top: 8px;
 }
 
-/* ---- Side panels (state inspector / artifacts) ---- */
-.info-sidebar,
-.state-inspector,
+/* ================================================================
+   Prompt Variables page
+   ================================================================ */
+.pv-page {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.pv-controls {
+  align-items: center;
+  background: #18181b;
+  border-bottom: 1px solid #27272a;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 12px 24px;
+}
+
+.pv-controls label {
+  align-items: center;
+  color: #a1a1aa;
+  display: flex;
+  font-size: 0.85rem;
+  gap: 8px;
+}
+
+.pv-control-label {
+  color: #71717a;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pv-controls select {
+  background: #27272a;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  color: #f4f4f5;
+  font-family: inherit;
+  font-size: 0.85rem;
+  outline: none;
+  padding: 6px 10px;
+}
+
+.pv-controls select:focus {
+  border-color: #fbbf24;
+}
+
+.pv-vars-changed {
+  color: #fb923c;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.pv-prompt-preview {
+  margin: 0 24px;
+  padding: 8px 0;
+}
+
+.pv-prompt-preview summary {
+  color: #a1a1aa;
+  cursor: pointer;
+  font-size: 0.8rem;
+  user-select: none;
+}
+
+.pv-prompt-code {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  color: #a1a1aa;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.75rem;
+  margin-top: 8px;
+  overflow-x: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.pv-panels {
+  background: #27272a;
+  display: flex;
+  flex: 1;
+  gap: 1px;
+  min-height: 200px;
+  overflow: hidden;
+}
+
+.pv-panel {
+  background: #0f0f10;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 16px 20px;
+}
+
+.pv-panel h3 {
+  color: #71717a;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+}
+
+.pv-textarea {
+  background: #18181b;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  color: #f4f4f5;
+  flex: 1;
+  font-family: inherit;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  outline: none;
+  padding: 12px;
+  resize: none;
+  transition: border-color 0.15s;
+}
+
+.pv-textarea:focus {
+  border-color: #fbbf24;
+}
+
+.pv-textarea:disabled {
+  opacity: 0.5;
+}
+
+.pv-output {
+  background: #18181b;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  color: #d4d4d8;
+  flex: 1;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  overflow-y: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.loading-text {
+  animation: pulse 1.5s ease-in-out infinite;
+  color: #71717a;
+}
+
+.error-text {
+  color: #f87171;
+}
+
+.pv-actions {
+  align-items: center;
+  background: #18181b;
+  border-top: 1px solid #27272a;
+  display: flex;
+  gap: 12px;
+  padding: 12px 24px;
+}
+
+.pv-hint {
+  color: #52525b;
+  font-size: 0.75rem;
+}
+
+/* ================================================================
+   Client State page — side-by-side chat + state inspector
+   ================================================================ */
+.client-state-layout {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.state-inspector {
+  background: #18181b;
+  border-left: 1px solid #27272a;
+  display: flex;
+  flex-direction: column;
+  min-width: 280px;
+  overflow-y: auto;
+  padding: 16px;
+  width: 320px;
+}
+
+.state-inspector h3 {
+  color: #fbbf24;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.state-inspector-hint {
+  color: #71717a;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin-bottom: 12px;
+}
+
+.state-inspector-hint code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #a1a1aa;
+  font-size: 0.7rem;
+  padding: 1px 4px;
+}
+
+.state-inspector-json {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  color: #a1a1aa;
+  flex: 1;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.75rem;
+  overflow-y: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ================================================================
+   Workspace Builder — side-by-side chat + artifacts
+   ================================================================ */
+.workspace-layout {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .artifacts-sidebar {
   background: #18181b;
   border-left: 1px solid #27272a;
@@ -410,31 +762,65 @@ body {
   min-width: 300px;
   overflow-y: auto;
   padding: 16px;
-  width: 340px;
+  width: 360px;
 }
 
-.state-inspector h3 { color: #fbbf24; font-size: 0.9rem; margin-bottom: 8px; }
-.artifacts-sidebar h3 { color: #a78bfa; font-size: 0.9rem; margin-bottom: 12px; }
+.artifacts-sidebar h3 {
+  color: #a78bfa;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
 
-.state-inspector-json,
+.artifacts-empty {
+  color: #52525b;
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
+.artifact {
+  margin-bottom: 12px;
+}
+
+.artifact-name {
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
 .artifact-content {
   background: #0f0f10;
   border: 1px solid #27272a;
-  border-radius: 8px;
+  border-radius: 6px;
   color: #a1a1aa;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
   font-size: 0.75rem;
-  overflow-y: auto;
-  padding: 12px;
+  max-height: 200px;
+  overflow-x: auto;
+  padding: 10px;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.artifact { margin-bottom: 12px; }
-.artifact-name { color: #c4b5fd; font-size: 0.75rem; font-weight: 600; margin-bottom: 4px; }
-.artifacts-empty { color: #52525b; font-size: 0.8rem; font-style: italic; }
+/* ================================================================
+   Background Agent — task submission + polling + result
+   ================================================================ */
+.background-layout {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
 
-/* ---- Background page ---- */
+.background-panel {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 0 0 24px;
+}
+
 .background-form {
   display: flex;
   flex-direction: column;
@@ -442,15 +828,94 @@ body {
   padding: 24px;
 }
 
-.background-status,
-.background-result {
+.background-label {
+  color: #a1a1aa;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.background-input {
+  background: #18181b;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  color: #f4f4f5;
+  font-family: inherit;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  outline: none;
+  padding: 12px;
+  resize: none;
+  transition: border-color 0.15s;
+}
+
+.background-input:focus {
+  border-color: #fbbf24;
+}
+
+.background-input:disabled {
+  opacity: 0.5;
+}
+
+.background-status {
+  align-items: center;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+}
+
+.background-status-icon {
+  animation: pulse 1.5s ease-in-out infinite;
+  font-size: 3rem;
+}
+
+.background-status h3 {
+  color: #f4f4f5;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.background-status-detail {
+  color: #71717a;
+  font-size: 0.85rem;
+  max-width: 400px;
+}
+
+.background-meta {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 8px 0;
+}
+
+.background-meta code {
+  background: #27272a;
+  border-radius: 4px;
+  color: #a1a1aa;
+  font-size: 0.7rem;
+  padding: 4px 8px;
+}
+
+.background-poll-count {
+  color: #52525b;
+  font-size: 0.75rem;
+}
+
+.background-result {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   padding: 24px;
 }
 
-.background-status-icon { animation: pulse 1.5s ease-in-out infinite; font-size: 3rem; }
+.background-result-header {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
 
 .background-status-badge {
   border-radius: 20px;
@@ -459,9 +924,28 @@ body {
   padding: 4px 10px;
 }
 
-.background-status-badge.done { background: #14532d; color: #4ade80; }
-.background-status-badge.failed { background: #450a0a; color: #f87171; }
-.background-status-badge.aborted { background: #451a03; color: #fb923c; }
+.background-status-badge.done {
+  background: #14532d;
+  color: #4ade80;
+}
+
+.background-status-badge.failed {
+  background: #450a0a;
+  color: #f87171;
+}
+
+.background-status-badge.aborted {
+  background: #451a03;
+  color: #fb923c;
+}
+
+.background-snapshot-id {
+  background: #27272a;
+  border-radius: 4px;
+  color: #71717a;
+  font-size: 0.65rem;
+  padding: 4px 8px;
+}
 
 .background-report {
   background: #18181b;
@@ -473,10 +957,144 @@ body {
   max-height: 60vh;
   overflow-y: auto;
   padding: 20px;
-  white-space: pre-wrap;
 }
 
-/* ---- Info sidebar text content ---- */
+/* Markdown rendering inside reports */
+.markdown-body h1 {
+  border-bottom: 1px solid #27272a;
+  color: #f4f4f5;
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0 0 16px;
+  padding-bottom: 8px;
+}
+
+.markdown-body h2 {
+  color: #fbbf24;
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 24px 0 12px;
+}
+
+.markdown-body h3 {
+  color: #e4e4e7;
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 20px 0 8px;
+}
+
+.markdown-body h4 {
+  color: #a1a1aa;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 16px 0 6px;
+}
+
+.markdown-body p {
+  line-height: 1.7;
+  margin: 0 0 12px;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin: 0 0 12px;
+  padding-left: 24px;
+}
+
+.markdown-body li {
+  line-height: 1.6;
+  margin-bottom: 4px;
+}
+
+.markdown-body strong {
+  color: #f4f4f5;
+  font-weight: 600;
+}
+
+.markdown-body em {
+  color: #a1a1aa;
+}
+
+.markdown-body code {
+  background: #27272a;
+  border-radius: 4px;
+  color: #d4d4d8;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.8rem;
+  padding: 2px 5px;
+}
+
+.markdown-body pre {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  margin: 0 0 12px;
+  overflow-x: auto;
+  padding: 12px;
+}
+
+.markdown-body pre code {
+  background: none;
+  padding: 0;
+}
+
+.markdown-body blockquote {
+  border-left: 3px solid #fbbf24;
+  color: #a1a1aa;
+  margin: 0 0 12px;
+  padding: 4px 16px;
+}
+
+.markdown-body hr {
+  border: none;
+  border-top: 1px solid #27272a;
+  margin: 20px 0;
+}
+
+.markdown-body table {
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  margin: 12px 0;
+  width: 100%;
+}
+
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid #3f3f46;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.markdown-body th {
+  background: #27272a;
+  color: #fbbf24;
+  font-weight: 600;
+}
+
+.markdown-body tr:nth-child(even) {
+  background: rgba(39, 39, 42, 0.4);
+}
+
+.background-error {
+  color: #f87171;
+  font-size: 0.85rem;
+}
+
+/* ================================================================
+   Shared info sidebar — reusable "How It Works" panel
+   ================================================================ */
+.info-sidebar {
+  background: #18181b;
+  border-left: 1px solid #27272a;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 280px;
+  overflow-y: auto;
+  padding: 20px;
+  width: 320px;
+}
+
 .info-sidebar h3 {
   color: #fbbf24;
   font-size: 0.9rem;
@@ -488,7 +1106,7 @@ body {
   color: #a1a1aa;
   font-size: 0.8rem;
   font-weight: 600;
-  margin: 12px 0 0;
+  margin: 0;
 }
 
 .info-sidebar ol,
@@ -502,8 +1120,7 @@ body {
   padding-left: 20px;
 }
 
-.info-sidebar li code,
-.info-sidebar p code {
+.info-sidebar li code {
   background: #27272a;
   border-radius: 3px;
   color: #d4d4d8;
@@ -517,13 +1134,92 @@ body {
   line-height: 1.5;
 }
 
-/* ---- Branching: empty state + variant picker ---- */
-.chat-empty {
-  color: #71717a;
-  font-size: 0.85rem;
-  line-height: 1.6;
-  padding: 16px 20px;
+.info-sidebar p code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #d4d4d8;
+  font-size: 0.7rem;
+  padding: 1px 4px;
 }
+
+.info-sidebar pre {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  color: #a1a1aa;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.7rem;
+  overflow-x: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Generic layout: content + info sidebar */
+.page-with-sidebar {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Backward compat aliases */
+.background-info {
+  /* same as info-sidebar */
+}
+
+.background-steps {
+  color: #a1a1aa;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.78rem;
+  gap: 6px;
+  line-height: 1.6;
+  padding-left: 20px;
+}
+
+.background-steps code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #d4d4d8;
+  font-size: 0.7rem;
+  padding: 1px 4px;
+}
+
+.background-status-list {
+  color: #a1a1aa;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.78rem;
+  gap: 4px;
+  list-style: none;
+  padding: 0;
+}
+
+.background-status-list code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #d4d4d8;
+  font-size: 0.7rem;
+  padding: 1px 4px;
+}
+
+.background-code {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  color: #a1a1aa;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.7rem;
+  overflow-x: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ================================================================
+   Branching Chat — Variant Picker
+   ================================================================ */
 
 .variant-loading {
   align-items: center;
@@ -621,3 +1317,898 @@ body {
   opacity: 1;
 }
 
+.chat-empty {
+  color: #71717a;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  padding: 40px 20px;
+  text-align: center;
+}
+
+/* ================================================================
+   Task Tracker — chat + custom state sidebar
+   ================================================================ */
+.task-tracker-layout {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.task-sidebar {
+  background: #18181b;
+  border-left: 1px solid #27272a;
+  display: flex;
+  flex-direction: column;
+  min-width: 280px;
+  overflow-y: auto;
+  padding: 16px;
+  width: 340px;
+}
+
+.task-sidebar h3 {
+  color: #34d399;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.task-sidebar h4 {
+  color: #a1a1aa;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin: 12px 0 6px;
+}
+
+.task-sidebar-hint {
+  color: #71717a;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin-bottom: 12px;
+}
+
+.task-sidebar-hint code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #a1a1aa;
+  font-size: 0.7rem;
+  padding: 1px 4px;
+}
+
+.task-empty {
+  color: #52525b;
+  font-size: 0.8rem;
+  font-style: italic;
+  padding: 16px 0;
+}
+
+/* ── Progress bar ── */
+.task-progress {
+  color: #a1a1aa;
+  font-size: 0.75rem;
+  margin-bottom: 10px;
+}
+
+.task-progress-bar {
+  background: #27272a;
+  border-radius: 3px;
+  height: 6px;
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.task-progress-fill {
+  background: #34d399;
+  border-radius: 3px;
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+/* ── Task list ── */
+.task-list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+}
+
+.task-item {
+  align-items: center;
+  border-radius: 6px;
+  color: #e4e4e7;
+  display: flex;
+  font-size: 0.8rem;
+  gap: 8px;
+  padding: 6px 8px;
+  transition: background 0.15s;
+}
+
+.task-item:hover {
+  background: #27272a;
+}
+
+.task-done .task-title {
+  color: #52525b;
+  text-decoration: line-through;
+}
+
+.task-checkbox {
+  flex-shrink: 0;
+  font-size: 0.9rem;
+}
+
+.task-title {
+  flex: 1;
+}
+
+/* ── Status bar ── */
+.task-status-bar {
+  align-items: center;
+  background: #1a1a2e;
+  border-top: 1px solid #27272a;
+  color: #818cf8;
+  display: flex;
+  font-size: 0.75rem;
+  gap: 8px;
+  padding: 8px 16px;
+}
+
+.task-status-dot {
+  animation: task-pulse 1s ease-in-out infinite;
+  background: #818cf8;
+  border-radius: 50%;
+  height: 8px;
+  width: 8px;
+}
+
+@keyframes task-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+/* ── Raw state JSON ── */
+.task-state-raw {
+  margin-top: 8px;
+}
+
+.task-state-raw summary {
+  color: #71717a;
+  cursor: pointer;
+  font-size: 0.75rem;
+  margin-bottom: 6px;
+}
+
+.task-state-json {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  color: #a1a1aa;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.7rem;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.task-divider {
+  border: none;
+  border-top: 1px solid #27272a;
+  margin: 16px 0 8px;
+}
+
+.task-howto {
+  color: #a1a1aa;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  padding-left: 16px;
+}
+
+.task-howto li {
+  margin-bottom: 6px;
+}
+
+.task-howto code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #c4b5fd;
+  font-size: 0.7rem;
+  padding: 1px 4px;
+}
+
+.task-code {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  color: #a1a1aa;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.7rem;
+  margin-top: 6px;
+  overflow-x: auto;
+  padding: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ================================================================
+   Research Agent — multi-step orchestration panel
+   ================================================================ */
+
+.research-layout {
+  display: flex;
+  flex: 1;
+  gap: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.research-layout > .chat-panel {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Status bar — shows orchestration progress ── */
+.research-status-bar {
+  align-items: center;
+  animation: research-pulse 2s ease-in-out infinite;
+  background: #1a1a2e;
+  border: 1px solid #2d2d5e;
+  border-radius: 8px;
+  color: #818cf8;
+  display: flex;
+  font-size: 0.8rem;
+  gap: 8px;
+  margin: 0 16px 8px;
+  padding: 8px 16px;
+}
+
+@keyframes research-pulse {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.research-status-dot {
+  animation: research-dot-blink 1s ease-in-out infinite;
+  background: #818cf8;
+  border-radius: 50%;
+  height: 8px;
+  width: 8px;
+}
+
+@keyframes research-dot-blink {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* ── Sidebar — research process panel ── */
+.research-sidebar {
+  background: #18181b;
+  border-left: 1px solid #27272a;
+  min-width: 320px;
+  overflow-y: auto;
+  padding: 20px;
+  width: 380px;
+}
+
+.research-sidebar h3 {
+  font-size: 1.1rem;
+  margin-bottom: 4px;
+}
+
+.research-sidebar h4 {
+  color: #e4e4e7;
+  font-size: 0.9rem;
+  margin-bottom: 6px;
+  margin-top: 12px;
+}
+
+.research-sidebar-hint {
+  color: #71717a;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin-bottom: 16px;
+}
+
+.research-sidebar-hint code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #c4b5fd;
+  font-size: 0.7rem;
+  padding: 1px 4px;
+}
+
+.research-empty {
+  border: 1px dashed #27272a;
+  border-radius: 8px;
+  color: #52525b;
+  font-size: 0.85rem;
+  padding: 24px;
+  text-align: center;
+}
+
+/* ── Research sections ── */
+.research-section {
+  margin-bottom: 16px;
+}
+
+.research-section-hint {
+  color: #52525b;
+  font-size: 0.7rem;
+  margin-bottom: 8px;
+}
+
+.research-section-hint code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #a78bfa;
+  font-size: 0.65rem;
+  padding: 1px 3px;
+}
+
+.research-questions {
+  color: #d4d4d8;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  padding-left: 20px;
+}
+
+.research-question {
+  margin-bottom: 4px;
+  padding: 4px 0;
+}
+
+/* ── Sub-answer details ── */
+.research-answer {
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+
+.research-answer-q {
+  background: #1c1c20;
+  color: #e4e4e7;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 8px 12px;
+}
+
+.research-answer-q:hover {
+  background: #27272a;
+}
+
+.research-answer-text {
+  color: #a1a1aa;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.research-divider {
+  border: none;
+  border-top: 1px solid #27272a;
+  margin: 16px 0 8px;
+}
+
+.research-howto {
+  color: #a1a1aa;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  padding-left: 16px;
+}
+
+.research-howto li {
+  margin-bottom: 6px;
+}
+
+.research-howto code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #c4b5fd;
+  font-size: 0.7rem;
+  padding: 1px 4px;
+}
+
+.research-code {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  color: #a1a1aa;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.7rem;
+  margin-top: 6px;
+  overflow-x: auto;
+  padding: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ================================================================
+   Coding Agent — chat + file explorer + approval dialog
+   ================================================================ */
+.coding-agent-layout {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ── File explorer sidebar ── */
+.file-explorer {
+  background: #18181b;
+  border-left: 1px solid #27272a;
+  display: flex;
+  flex-direction: column;
+  min-width: 280px;
+  overflow-y: auto;
+  width: 340px;
+}
+
+.file-explorer-header {
+  align-items: center;
+  border-bottom: 1px solid #27272a;
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 16px;
+}
+
+.file-explorer-header h3 {
+  color: #34d399;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.btn-refresh-files {
+  background: none;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  color: #a1a1aa;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 4px 8px;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.btn-refresh-files:hover {
+  background: #27272a;
+  border-color: #52525b;
+}
+
+.file-explorer-empty {
+  color: #52525b;
+  font-size: 0.8rem;
+  font-style: italic;
+  padding: 16px;
+}
+
+/* ── File tree ── */
+.file-tree {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.file-tree-item {
+  align-items: center;
+  background: none;
+  border: none;
+  color: #d4d4d8;
+  cursor: pointer;
+  display: flex;
+  font-family: inherit;
+  font-size: 0.8rem;
+  gap: 6px;
+  padding: 5px 12px;
+  text-align: left;
+  transition: background 0.1s;
+  width: 100%;
+}
+
+.file-tree-item:hover {
+  background: #27272a;
+}
+
+.file-tree-item.selected {
+  background: #1e3a5f;
+  color: #93c5fd;
+}
+
+.file-tree-dir {
+  color: #a1a1aa;
+  font-weight: 500;
+}
+
+.file-icon {
+  flex-shrink: 0;
+  font-size: 0.85rem;
+}
+
+.file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── File viewer ── */
+.file-viewer {
+  border-top: 1px solid #27272a;
+  display: flex;
+  flex-direction: column;
+  max-height: 50%;
+  min-height: 120px;
+}
+
+.file-viewer-header {
+  align-items: center;
+  background: #1c1c20;
+  border-bottom: 1px solid #27272a;
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+}
+
+.file-viewer-path {
+  color: #93c5fd;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-viewer-close {
+  background: none;
+  border: none;
+  color: #71717a;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 2px 6px;
+  transition: color 0.15s;
+}
+
+.file-viewer-close:hover {
+  color: #f4f4f5;
+}
+
+.file-viewer-content {
+  background: #0f0f10;
+  color: #a1a1aa;
+  flex: 1;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  margin: 0;
+  overflow: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Tool approval dialog ── */
+.approval-dialog {
+  background: #1a1a2e;
+  border: 1px solid #4338ca;
+  border-radius: 12px;
+  margin: 0 24px;
+  padding: 16px;
+}
+
+.approval-dialog h3 {
+  color: #818cf8;
+  font-size: 0.95rem;
+  margin-bottom: 12px;
+}
+
+.approval-tool-name {
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.approval-tool-name code {
+  background: #27272a;
+  border-radius: 4px;
+  color: #c4b5fd;
+  font-size: 0.8rem;
+  padding: 2px 6px;
+}
+
+.approval-label {
+  color: #a1a1aa;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.approval-details {
+  margin: 8px 0;
+}
+
+.approval-file-path {
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.approval-file-path code {
+  background: #27272a;
+  border-radius: 4px;
+  color: #93c5fd;
+  font-size: 0.8rem;
+  padding: 2px 6px;
+}
+
+.approval-content-preview {
+  margin-top: 8px;
+}
+
+.approval-code {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  color: #d4d4d8;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  margin-top: 6px;
+  max-height: 300px;
+  overflow: auto;
+  padding: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.approval-diff {
+  border-color: #4338ca;
+}
+
+.approval-command {
+  background: #1a1a2e;
+  border-radius: 4px;
+  color: #e879f9;
+  font-size: 0.85rem;
+  padding: 4px 8px;
+  word-break: break-all;
+}
+
+.approval-warning {
+  background: #451a03;
+  border: 1px solid #92400e;
+  border-radius: 6px;
+  color: #fbbf24;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  margin-top: 8px;
+  padding: 10px 12px;
+}
+
+.approval-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+/* ================================================================
+   Ask User dialog — question with options + custom answer
+   ================================================================ */
+.ask-user-dialog {
+  background: #0f2a2a;
+  border: 1px solid #0d9488;
+  border-radius: 12px;
+  margin: 0 24px;
+  padding: 16px;
+}
+
+.ask-user-dialog h3 {
+  color: #2dd4bf;
+  font-size: 0.95rem;
+  margin-bottom: 12px;
+}
+
+.ask-user-question {
+  color: #e4e4e7;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-bottom: 14px;
+}
+
+.ask-user-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.ask-user-option {
+  background: #18181b;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  color: #e4e4e7;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  padding: 10px 14px;
+  text-align: left;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s,
+    transform 0.1s;
+}
+
+.ask-user-option:hover {
+  background: #1a3a3a;
+  border-color: #2dd4bf;
+  color: #f4f4f5;
+  transform: translateX(4px);
+}
+
+.ask-user-option:active {
+  transform: translateX(2px);
+}
+
+.ask-user-custom-section {
+  border-top: 1px solid #134e4a;
+  padding-top: 12px;
+}
+
+.ask-user-custom-label {
+  color: #71717a;
+  display: block;
+  font-size: 0.78rem;
+  margin-bottom: 8px;
+}
+
+.ask-user-custom-row {
+  display: flex;
+  gap: 8px;
+}
+
+.ask-user-custom {
+  background: #18181b;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  color: #f4f4f5;
+  flex: 1;
+  font-family: inherit;
+  font-size: 0.85rem;
+  outline: none;
+  padding: 8px 12px;
+  transition: border-color 0.15s;
+}
+
+.ask-user-custom:focus {
+  border-color: #2dd4bf;
+}
+
+/* ================================================================
+   Thinking / Reasoning blocks — collapsible model reasoning
+   ================================================================ */
+.thinking-block {
+  align-self: flex-start;
+  background: #1a1a2e;
+  border: 1px solid #2d2d5e;
+  border-radius: 10px;
+  margin-bottom: 4px;
+  max-width: 80%;
+  overflow: clip;
+}
+
+.thinking-summary {
+  align-items: center;
+  color: #818cf8;
+  cursor: pointer;
+  display: flex;
+  font-size: 0.8rem;
+  font-weight: 500;
+  gap: 6px;
+  list-style: none;
+  padding: 8px 14px;
+  user-select: none;
+}
+
+.thinking-summary::-webkit-details-marker {
+  display: none;
+}
+
+.thinking-summary::after {
+  color: #52525b;
+  content: '▸';
+  font-size: 0.7rem;
+  margin-left: auto;
+  transition: transform 0.15s;
+}
+
+.thinking-block[open] .thinking-summary::after {
+  transform: rotate(90deg);
+}
+
+.thinking-icon {
+  font-size: 0.9rem;
+}
+
+.thinking-content {
+  border-top: 1px solid #2d2d5e;
+  color: #a1a1aa;
+  font-size: 0.78rem;
+  line-height: 1.6;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 10px 14px;
+}
+
+.thinking-content p {
+  margin: 0 0 8px;
+}
+
+.thinking-content p:last-child {
+  margin-bottom: 0;
+}
+
+.thinking-content code {
+  background: #27272a;
+  border-radius: 3px;
+  color: #d4d4d8;
+  font-size: 0.72rem;
+  padding: 1px 4px;
+}
+
+.thinking-content pre {
+  background: #0f0f10;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  margin: 6px 0;
+  overflow-x: auto;
+  padding: 8px;
+}
+
+.thinking-content pre code {
+  background: none;
+  padding: 0;
+}
+
+/* Streaming / live thinking indicator */
+.thinking-streaming {
+  border-color: #4338ca;
+}
+
+.thinking-streaming .thinking-summary {
+  color: #a78bfa;
+}
+
+.thinking-pulse {
+  animation: thinking-glow 1.2s ease-in-out infinite;
+}
+
+@keyframes thinking-glow {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}


### PR DESCRIPTION
Add support for rendering reasoning/thinking blocks and detail content in the chat UI, converting ChatUI to a StatefulComponent to enable auto-scrolling. Introduce collapsible "Thinking…" blocks with streaming animation and a terminal-style file tree viewer with associated styling.