### PR TITLE
fix: preserve thought signature metadata in streaming aggregation (#301)

### DIFF
--- a/packages/genkit_firebase_ai/lib/src/aggregation.dart
+++ b/packages/genkit_firebase_ai/lib/src/aggregation.dart
@@ -14,7 +14,6 @@
 
 import 'package:firebase_ai/firebase_ai.dart' as m;
 
-/// Aggregates a list of streaming responses from Firebase AI into a single response.
 m.GenerateContentResponse aggregateResponses(
   List<m.GenerateContentResponse> responses,
 ) {
@@ -33,7 +32,6 @@ m.GenerateContentResponse aggregateResponses(
     }
 
     if (response.candidates.isNotEmpty) {
-      // Firebase AI Candidates don't expose index, assume single candidate.
       final index = 0;
       final state = candidateStates.putIfAbsent(index, _CandidateState.new);
       state.merge(response.candidates.first);
@@ -78,27 +76,50 @@ class _CandidateState {
   }
 
   void _mergeParts(List<m.Part> newParts) {
-    for (final part in newParts) {
-      if (parts.isNotEmpty) {
-        final lastPart = parts.last;
-        if (lastPart is m.TextPart && part is m.TextPart) {
-          // Merge text
-          final newText = lastPart.text + part.text;
-          parts.removeLast();
-          parts.add(m.TextPart(newText)); // Ignore thought stuff for now
-          continue;
-        } else if (lastPart is m.FunctionCall && part is m.FunctionCall) {
-          // Firebase AI currently returns completed tool calls, no need to merge partials manually.
-          // Will replace the last if it's identical ID or name as an edge case,
-          // but generally streaming function calls don't chunk in Firebase AI natively
-          if (part.id == lastPart.id || part.name == lastPart.name) {
-            parts.removeLast();
+  for (final part in newParts) {
+    if (parts.isNotEmpty) {
+      final lastPart = parts.last;
+      if (lastPart is m.TextPart && part is m.TextPart) {
+        final newText = lastPart.text + part.text;
+        parts.removeLast();
+        
+        Map<String, dynamic>? mergedMetadata;
+        if (lastPart.metadata != null || part.metadata != null) {
+          mergedMetadata = {};
+          if (lastPart.metadata != null) {
+            mergedMetadata!.addAll(lastPart.metadata!);
+          }
+          if (part.metadata != null) {
+            mergedMetadata!.addAll(part.metadata!);
           }
         }
+        
+        Map<String, dynamic>? mergedCustom;
+        if (lastPart.custom != null || part.custom != null) {
+          mergedCustom = {};
+          if (lastPart.custom != null) {
+            mergedCustom!.addAll(lastPart.custom!);
+          }
+          if (part.custom != null) {
+            mergedCustom!.addAll(part.custom!);
+          }
+        }
+        
+        parts.add(m.TextPart(
+          newText,
+          metadata: mergedMetadata,
+          custom: mergedCustom,
+        ));
+        continue;
+      } else if (lastPart is m.FunctionCall && part is m.FunctionCall) {
+        if (part.id == lastPart.id || part.name == lastPart.name) {
+          parts.removeLast();
+        }
       }
-      parts.add(part);
     }
+    parts.add(part);
   }
+}
 
   m.Candidate toCandidate() {
     return m.Candidate(

--- a/packages/genkit_firebase_ai/lib/src/aggregation.dart
+++ b/packages/genkit_firebase_ai/lib/src/aggregation.dart
@@ -14,6 +14,7 @@
 
 import 'package:firebase_ai/firebase_ai.dart' as m;
 
+/// Aggregates a list of streaming responses from Firebase AI into a single response.
 m.GenerateContentResponse aggregateResponses(
   List<m.GenerateContentResponse> responses,
 ) {
@@ -32,6 +33,7 @@ m.GenerateContentResponse aggregateResponses(
     }
 
     if (response.candidates.isNotEmpty) {
+      // Firebase AI Candidates don't expose index, assume single candidate.
       final index = 0;
       final state = candidateStates.putIfAbsent(index, _CandidateState.new);
       state.merge(response.candidates.first);
@@ -76,50 +78,44 @@ class _CandidateState {
   }
 
   void _mergeParts(List<m.Part> newParts) {
-  for (final part in newParts) {
-    if (parts.isNotEmpty) {
-      final lastPart = parts.last;
-      if (lastPart is m.TextPart && part is m.TextPart) {
-        final newText = lastPart.text + part.text;
-        parts.removeLast();
-        
-        Map<String, dynamic>? mergedMetadata;
-        if (lastPart.metadata != null || part.metadata != null) {
-          mergedMetadata = {};
-          if (lastPart.metadata != null) {
-            mergedMetadata!.addAll(lastPart.metadata!);
-          }
-          if (part.metadata != null) {
-            mergedMetadata!.addAll(part.metadata!);
-          }
-        }
-        
-        Map<String, dynamic>? mergedCustom;
-        if (lastPart.custom != null || part.custom != null) {
-          mergedCustom = {};
-          if (lastPart.custom != null) {
-            mergedCustom!.addAll(lastPart.custom!);
-          }
-          if (part.custom != null) {
-            mergedCustom!.addAll(part.custom!);
-          }
-        }
-        
-        parts.add(m.TextPart(
-          newText,
-          metadata: mergedMetadata,
-          custom: mergedCustom,
-        ));
-        continue;
-      } else if (lastPart is m.FunctionCall && part is m.FunctionCall) {
-        if (part.id == lastPart.id || part.name == lastPart.name) {
+    for (final part in newParts) {
+      if (parts.isNotEmpty) {
+        final lastPart = parts.last;
+        if (lastPart is m.TextPart && part is m.TextPart) {
+          final newText = lastPart.text + part.text;
           parts.removeLast();
+
+          // Merge metadata using null-aware spread operator
+          final mergedMetadata = lastPart.metadata == null && part.metadata == null
+              ? null
+              : {
+                  ...?lastPart.metadata,
+                  ...?part.metadata,
+                };
+
+          // Merge custom data using null-aware spread operator
+          final mergedCustom = lastPart.custom == null && part.custom == null
+              ? null
+              : {
+                  ...?lastPart.custom,
+                  ...?part.custom,
+                };
+
+          parts.add(m.TextPart(
+            newText,
+            metadata: mergedMetadata,
+            custom: mergedCustom,
+          ));
+          continue;
+        } else if (lastPart is m.FunctionCall && part is m.FunctionCall) {
+          if (part.id == lastPart.id || part.name == lastPart.name) {
+            parts.removeLast();
+          }
         }
       }
+      parts.add(part);
     }
-    parts.add(part);
   }
-}
 
   m.Candidate toCandidate() {
     return m.Candidate(


### PR DESCRIPTION
## Problem

I found a bug when using streaming with `genkit_firebase_ai`. The streaming aggregation drops `thoughtSignature` and `isThought` metadata from `TextParts`, which causes the Gemini API to fail in multi-turn tool calling with:

`400 INVALID_ARGUMENT: Function call is missing a thought_signature`

## What's Happening

In `aggregation.dart`, the `_mergeParts` method merges consecutive text chunks into one. But when it does that, it creates a new `TextPart` with just the merged text and discards all metadata. The `thoughtSignature` is stored in the metadata, so it gets lost.

When the conversation history is sent back to Gemini in the next turn, the missing signature causes the API to reject the request.

## My Fix

I updated `_mergeParts` to preserve `metadata` and `custom` fields when merging text parts. Now the thought signature survives aggregation and gets sent back correctly in the conversation history.

## Testing Done

- ✅ Basic metadata preservation works
- ✅ Streaming aggregation keeps thought data intact  
- ✅ Tool calling flow works with signatures preserved
- ✅ Conversation history maintains the signature

## Related Issue

Fixes #301

This is the Dart version of the same fix that was already merged for the JS SDK (#4217).

## Checklist

- [x] Fix implemented
- [x] Tests pass
- [x] No breaking changes
- [x] Code follows project style