### PR TITLE
fix: normalize nested models to JSON in generated setters

### DIFF
--- a/packages/genkit/lib/src/ai/resource.g.dart
+++ b/packages/genkit/lib/src/ai/resource.g.dart
@@ -99,7 +99,7 @@ base class ResourceOutput {
   }
 
   set content(List<Part> value) {
-    _json['content'] = value.toList();
+    _json['content'] = value.map((e) => e.toJson()).toList();
   }
 
   @override

--- a/packages/genkit/lib/src/types.g.dart
+++ b/packages/genkit/lib/src/types.g.dart
@@ -63,7 +63,7 @@ base class Candidate {
   }
 
   set message(Message value) {
-    _json['message'] = value;
+    _json['message'] = value.toJson();
   }
 
   GenerationUsage? get usage {
@@ -76,7 +76,7 @@ base class Candidate {
     if (value == null) {
       _json.remove('usage');
     } else {
-      _json['usage'] = value;
+      _json['usage'] = value.toJson();
     }
   }
 
@@ -191,7 +191,7 @@ base class Message {
   }
 
   set content(List<Part> value) {
-    _json['content'] = value.toList();
+    _json['content'] = value.map((e) => e.toJson()).toList();
   }
 
   Map<String, dynamic>? get metadata {
@@ -559,7 +559,7 @@ base class MediaPart implements Part {
   }
 
   set media(Media value) {
-    _json['media'] = value;
+    _json['media'] = value.toJson();
   }
 
   Map<String, dynamic>? get data {
@@ -669,7 +669,7 @@ base class ToolRequestPart implements Part {
   }
 
   set toolRequest(ToolRequest value) {
-    _json['toolRequest'] = value;
+    _json['toolRequest'] = value.toJson();
   }
 
   Map<String, dynamic>? get data {
@@ -779,7 +779,7 @@ base class ToolResponsePart implements Part {
   }
 
   set toolResponse(ToolResponse value) {
-    _json['toolResponse'] = value;
+    _json['toolResponse'] = value.toJson();
   }
 
   Map<String, dynamic>? get data {
@@ -1432,7 +1432,7 @@ base class EvalRequest {
   }
 
   set dataset(List<BaseDataPoint> value) {
-    _json['dataset'] = value.toList();
+    _json['dataset'] = value.map((e) => e.toJson()).toList();
   }
 
   String get evalRunId {
@@ -2194,7 +2194,7 @@ base class ModelRequest {
   }
 
   set messages(List<Message> value) {
-    _json['messages'] = value.toList();
+    _json['messages'] = value.map((e) => e.toJson()).toList();
   }
 
   Map<String, dynamic>? get config {
@@ -2219,7 +2219,7 @@ base class ModelRequest {
     if (value == null) {
       _json.remove('tools');
     } else {
-      _json['tools'] = value.toList();
+      _json['tools'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -2245,7 +2245,7 @@ base class ModelRequest {
     if (value == null) {
       _json.remove('output');
     } else {
-      _json['output'] = value;
+      _json['output'] = value.toJson();
     }
   }
 
@@ -2259,7 +2259,7 @@ base class ModelRequest {
     if (value == null) {
       _json.remove('docs');
     } else {
-      _json['docs'] = value.toList();
+      _json['docs'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -2360,7 +2360,7 @@ base class ModelResponse {
     if (value == null) {
       _json.remove('message');
     } else {
-      _json['message'] = value;
+      _json['message'] = value.toJson();
     }
   }
 
@@ -2407,7 +2407,7 @@ base class ModelResponse {
     if (value == null) {
       _json.remove('usage');
     } else {
-      _json['usage'] = value;
+      _json['usage'] = value.toJson();
     }
   }
 
@@ -2445,7 +2445,7 @@ base class ModelResponse {
     if (value == null) {
       _json.remove('request');
     } else {
-      _json['request'] = value;
+      _json['request'] = value.toJson();
     }
   }
 
@@ -2459,7 +2459,7 @@ base class ModelResponse {
     if (value == null) {
       _json.remove('operation');
     } else {
-      _json['operation'] = value;
+      _json['operation'] = value.toJson();
     }
   }
 
@@ -2570,7 +2570,7 @@ base class ModelResponseChunk {
   }
 
   set content(List<Part> value) {
-    _json['content'] = value.toList();
+    _json['content'] = value.map((e) => e.toJson()).toList();
   }
 
   Map<String, dynamic>? get custom {
@@ -2759,7 +2759,7 @@ base class GenerateResponse {
     if (value == null) {
       _json.remove('message');
     } else {
-      _json['message'] = value;
+      _json['message'] = value.toJson();
     }
   }
 
@@ -2809,7 +2809,7 @@ base class GenerateResponse {
     if (value == null) {
       _json.remove('usage');
     } else {
-      _json['usage'] = value;
+      _json['usage'] = value.toJson();
     }
   }
 
@@ -2847,7 +2847,7 @@ base class GenerateResponse {
     if (value == null) {
       _json.remove('request');
     } else {
-      _json['request'] = value;
+      _json['request'] = value.toJson();
     }
   }
 
@@ -2861,7 +2861,7 @@ base class GenerateResponse {
     if (value == null) {
       _json.remove('operation');
     } else {
-      _json['operation'] = value;
+      _json['operation'] = value.toJson();
     }
   }
 
@@ -2875,7 +2875,7 @@ base class GenerateResponse {
     if (value == null) {
       _json.remove('candidates');
     } else {
-      _json['candidates'] = value.toList();
+      _json['candidates'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -2970,7 +2970,7 @@ base class GenerateRequest {
   }
 
   set messages(List<Message> value) {
-    _json['messages'] = value.toList();
+    _json['messages'] = value.map((e) => e.toJson()).toList();
   }
 
   Map<String, dynamic>? get config {
@@ -2995,7 +2995,7 @@ base class GenerateRequest {
     if (value == null) {
       _json.remove('tools');
     } else {
-      _json['tools'] = value.toList();
+      _json['tools'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -3021,7 +3021,7 @@ base class GenerateRequest {
     if (value == null) {
       _json.remove('output');
     } else {
-      _json['output'] = value;
+      _json['output'] = value.toJson();
     }
   }
 
@@ -3035,7 +3035,7 @@ base class GenerateRequest {
     if (value == null) {
       _json.remove('docs');
     } else {
-      _json['docs'] = value.toList();
+      _json['docs'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -3637,7 +3637,7 @@ base class DocumentData {
   }
 
   set content(List<Part> value) {
-    _json['content'] = value.toList();
+    _json['content'] = value.map((e) => e.toJson()).toList();
   }
 
   Map<String, dynamic>? get metadata {
@@ -3756,7 +3756,7 @@ base class GenerateActionOptions {
     if (value == null) {
       _json.remove('docs');
     } else {
-      _json['docs'] = value.toList();
+      _json['docs'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -3767,7 +3767,7 @@ base class GenerateActionOptions {
   }
 
   set messages(List<Message> value) {
-    _json['messages'] = value.toList();
+    _json['messages'] = value.map((e) => e.toJson()).toList();
   }
 
   List<String>? get tools {
@@ -3830,7 +3830,7 @@ base class GenerateActionOptions {
     if (value == null) {
       _json.remove('output');
     } else {
-      _json['output'] = value;
+      _json['output'] = value.toJson();
     }
   }
 
@@ -3846,7 +3846,7 @@ base class GenerateActionOptions {
     if (value == null) {
       _json.remove('resume');
     } else {
-      _json['resume'] = value;
+      _json['resume'] = value.toJson();
     }
   }
 
@@ -3896,7 +3896,7 @@ base class GenerateActionOptions {
     if (value == null) {
       _json.remove('use');
     } else {
-      _json['use'] = value.toList();
+      _json['use'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -3998,7 +3998,7 @@ base class GenerateResumeOptions {
     if (value == null) {
       _json.remove('respond');
     } else {
-      _json['respond'] = value.toList();
+      _json['respond'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -4012,7 +4012,7 @@ base class GenerateResumeOptions {
     if (value == null) {
       _json.remove('restart');
     } else {
-      _json['restart'] = value.toList();
+      _json['restart'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -4247,7 +4247,7 @@ base class EmbedRequest {
   }
 
   set input(List<DocumentData> value) {
-    _json['input'] = value.toList();
+    _json['input'] = value.map((e) => e.toJson()).toList();
   }
 
   Map<String, dynamic>? get options {
@@ -4323,7 +4323,7 @@ base class EmbedResponse {
   }
 
   set embeddings(List<Embedding> value) {
-    _json['embeddings'] = value.toList();
+    _json['embeddings'] = value.map((e) => e.toJson()).toList();
   }
 
   @override
@@ -5406,7 +5406,7 @@ base class AgentInit {
     if (value == null) {
       _json.remove('state');
     } else {
-      _json['state'] = value;
+      _json['state'] = value.toJson();
     }
   }
 
@@ -5486,7 +5486,7 @@ base class AgentInput {
     if (value == null) {
       _json.remove('message');
     } else {
-      _json['message'] = value;
+      _json['message'] = value.toJson();
     }
   }
 
@@ -5500,7 +5500,7 @@ base class AgentInput {
     if (value == null) {
       _json.remove('resume');
     } else {
-      _json['resume'] = value;
+      _json['resume'] = value.toJson();
     }
   }
 
@@ -5571,7 +5571,7 @@ base class AgentResume {
     if (value == null) {
       _json.remove('respond');
     } else {
-      _json['respond'] = value.toList();
+      _json['respond'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -5585,7 +5585,7 @@ base class AgentResume {
     if (value == null) {
       _json.remove('restart');
     } else {
-      _json['restart'] = value.toList();
+      _json['restart'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -5693,7 +5693,7 @@ base class AgentOutput {
     if (value == null) {
       _json.remove('state');
     } else {
-      _json['state'] = value;
+      _json['state'] = value.toJson();
     }
   }
 
@@ -5707,7 +5707,7 @@ base class AgentOutput {
     if (value == null) {
       _json.remove('message');
     } else {
-      _json['message'] = value;
+      _json['message'] = value.toJson();
     }
   }
 
@@ -5721,7 +5721,7 @@ base class AgentOutput {
     if (value == null) {
       _json.remove('artifacts');
     } else {
-      _json['artifacts'] = value.toList();
+      _json['artifacts'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -5747,7 +5747,7 @@ base class AgentOutput {
     if (value == null) {
       _json.remove('error');
     } else {
-      _json['error'] = value;
+      _json['error'] = value.toJson();
     }
   }
 
@@ -5916,7 +5916,7 @@ base class AgentResult {
     if (value == null) {
       _json.remove('message');
     } else {
-      _json['message'] = value;
+      _json['message'] = value.toJson();
     }
   }
 
@@ -5930,7 +5930,7 @@ base class AgentResult {
     if (value == null) {
       _json.remove('artifacts');
     } else {
-      _json['artifacts'] = value.toList();
+      _json['artifacts'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -6022,7 +6022,7 @@ base class AgentStreamChunk {
     if (value == null) {
       _json.remove('modelChunk');
     } else {
-      _json['modelChunk'] = value;
+      _json['modelChunk'] = value.toJson();
     }
   }
 
@@ -6036,7 +6036,7 @@ base class AgentStreamChunk {
     if (value == null) {
       _json.remove('customPatch');
     } else {
-      _json['customPatch'] = value.toList();
+      _json['customPatch'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -6050,7 +6050,7 @@ base class AgentStreamChunk {
     if (value == null) {
       _json.remove('artifact');
     } else {
-      _json['artifact'] = value;
+      _json['artifact'] = value.toJson();
     }
   }
 
@@ -6064,7 +6064,7 @@ base class AgentStreamChunk {
     if (value == null) {
       _json.remove('turnEnd');
     } else {
-      _json['turnEnd'] = value;
+      _json['turnEnd'] = value.toJson();
     }
   }
 
@@ -6447,7 +6447,7 @@ base class Artifact {
   }
 
   set parts(List<Part> value) {
-    _json['parts'] = value.toList();
+    _json['parts'] = value.map((e) => e.toJson()).toList();
   }
 
   Map<String, dynamic>? get metadata {
@@ -6814,7 +6814,7 @@ base class SessionSnapshot {
     if (value == null) {
       _json.remove('error');
     } else {
-      _json['error'] = value;
+      _json['error'] = value.toJson();
     }
   }
 
@@ -6828,7 +6828,7 @@ base class SessionSnapshot {
     if (value == null) {
       _json.remove('state');
     } else {
-      _json['state'] = value;
+      _json['state'] = value.toJson();
     }
   }
 
@@ -6924,7 +6924,7 @@ base class SessionState {
     if (value == null) {
       _json.remove('messages');
     } else {
-      _json['messages'] = value.toList();
+      _json['messages'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -6950,7 +6950,7 @@ base class SessionState {
     if (value == null) {
       _json.remove('artifacts');
     } else {
-      _json['artifacts'] = value.toList();
+      _json['artifacts'] = value.map((e) => e.toJson()).toList();
     }
   }
 

--- a/packages/genkit/test/extension_type_test.g.dart
+++ b/packages/genkit/test/extension_type_test.g.dart
@@ -122,7 +122,7 @@ base class Recipe {
   }
 
   set ingredients(List<Ingredient> value) {
-    _json['ingredients'] = value.toList();
+    _json['ingredients'] = value.map((e) => e.toJson()).toList();
   }
 
   int get servings {
@@ -211,7 +211,7 @@ base class AnnotatedRecipe {
   }
 
   set ingredients(List<Ingredient> value) {
-    _json['ingredients'] = value.toList();
+    _json['ingredients'] = value.map((e) => e.toJson()).toList();
   }
 
   int get servings {
@@ -405,7 +405,7 @@ base class NullableFields {
     if (value == null) {
       _json.remove('optionalIngredient');
     } else {
-      _json['optionalIngredient'] = value;
+      _json['optionalIngredient'] = value.toJson();
     }
   }
 
@@ -530,7 +530,7 @@ base class ComplexObject {
     if (value == null) {
       _json.remove('nestedNullable');
     } else {
-      _json['nestedNullable'] = value;
+      _json['nestedNullable'] = value.toJson();
     }
   }
 
@@ -602,7 +602,7 @@ base class Menu {
   }
 
   set recipes(List<Recipe> value) {
-    _json['recipes'] = value.toList();
+    _json['recipes'] = value.map((e) => e.toJson()).toList();
   }
 
   List<Ingredient>? get optionalIngredients {
@@ -615,7 +615,7 @@ base class Menu {
     if (value == null) {
       _json.remove('optionalIngredients');
     } else {
-      _json['optionalIngredients'] = value.toList();
+      _json['optionalIngredients'] = value.map((e) => e.toJson()).toList();
     }
   }
 

--- a/packages/genkit_anthropic/lib/src/model.g.dart
+++ b/packages/genkit_anthropic/lib/src/model.g.dart
@@ -142,7 +142,7 @@ base class AnthropicOptions {
     if (value == null) {
       _json.remove('thinking');
     } else {
-      _json['thinking'] = value;
+      _json['thinking'] = value.toJson();
     }
   }
 

--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.g.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.g.dart
@@ -218,7 +218,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('thinkingConfig');
     } else {
-      _json['thinkingConfig'] = value;
+      _json['thinkingConfig'] = value.toJson();
     }
   }
 
@@ -258,7 +258,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('functionCallingConfig');
     } else {
-      _json['functionCallingConfig'] = value;
+      _json['functionCallingConfig'] = value.toJson();
     }
   }
 
@@ -586,7 +586,7 @@ base class VoiceConfig {
     if (value == null) {
       _json.remove('prebuiltVoiceConfig');
     } else {
-      _json['prebuiltVoiceConfig'] = value;
+      _json['prebuiltVoiceConfig'] = value.toJson();
     }
   }
 
@@ -652,7 +652,7 @@ base class SpeechConfig {
     if (value == null) {
       _json.remove('voiceConfig');
     } else {
-      _json['voiceConfig'] = value;
+      _json['voiceConfig'] = value.toJson();
     }
   }
 
@@ -748,7 +748,7 @@ base class LiveGenerationConfig {
     if (value == null) {
       _json.remove('speechConfig');
     } else {
-      _json['speechConfig'] = value;
+      _json['speechConfig'] = value.toJson();
     }
   }
 

--- a/packages/genkit_google_genai/example/src/model.g.dart
+++ b/packages/genkit_google_genai/example/src/model.g.dart
@@ -264,7 +264,7 @@ base class Category {
     if (value == null) {
       _json.remove('subcategories');
     } else {
-      _json['subcategories'] = value.toList();
+      _json['subcategories'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -345,7 +345,7 @@ base class Weapon {
   }
 
   set category(Category value) {
-    _json['category'] = value;
+    _json['category'] = value.toJson();
   }
 
   @override
@@ -436,7 +436,7 @@ base class RpgCharacter {
   }
 
   set weapons(List<Weapon> value) {
-    _json['weapons'] = value.toList();
+    _json['weapons'] = value.map((e) => e.toJson()).toList();
   }
 
   String get classType {

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -104,7 +104,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('safetySettings');
     } else {
-      _json['safetySettings'] = value.toList();
+      _json['safetySettings'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -132,7 +132,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('functionCallingConfig');
     } else {
-      _json['functionCallingConfig'] = value;
+      _json['functionCallingConfig'] = value.toJson();
     }
   }
 
@@ -148,7 +148,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('thinkingConfig');
     } else {
-      _json['thinkingConfig'] = value;
+      _json['thinkingConfig'] = value.toJson();
     }
   }
 
@@ -174,7 +174,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('googleSearch');
     } else {
-      _json['googleSearch'] = value;
+      _json['googleSearch'] = value.toJson();
     }
   }
 
@@ -188,7 +188,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('fileSearch');
     } else {
-      _json['fileSearch'] = value;
+      _json['fileSearch'] = value.toJson();
     }
   }
 
@@ -346,7 +346,7 @@ base class GeminiOptions {
     if (value == null) {
       _json.remove('speechConfig');
     } else {
-      _json['speechConfig'] = value;
+      _json['speechConfig'] = value.toJson();
     }
   }
 
@@ -836,7 +836,7 @@ base class GeminiTtsOptions {
     if (value == null) {
       _json.remove('safetySettings');
     } else {
-      _json['safetySettings'] = value.toList();
+      _json['safetySettings'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -864,7 +864,7 @@ base class GeminiTtsOptions {
     if (value == null) {
       _json.remove('functionCallingConfig');
     } else {
-      _json['functionCallingConfig'] = value;
+      _json['functionCallingConfig'] = value.toJson();
     }
   }
 
@@ -880,7 +880,7 @@ base class GeminiTtsOptions {
     if (value == null) {
       _json.remove('thinkingConfig');
     } else {
-      _json['thinkingConfig'] = value;
+      _json['thinkingConfig'] = value.toJson();
     }
   }
 
@@ -906,7 +906,7 @@ base class GeminiTtsOptions {
     if (value == null) {
       _json.remove('googleSearch');
     } else {
-      _json['googleSearch'] = value;
+      _json['googleSearch'] = value.toJson();
     }
   }
 
@@ -920,7 +920,7 @@ base class GeminiTtsOptions {
     if (value == null) {
       _json.remove('fileSearch');
     } else {
-      _json['fileSearch'] = value;
+      _json['fileSearch'] = value.toJson();
     }
   }
 
@@ -1078,7 +1078,7 @@ base class GeminiTtsOptions {
     if (value == null) {
       _json.remove('speechConfig');
     } else {
-      _json['speechConfig'] = value;
+      _json['speechConfig'] = value.toJson();
     }
   }
 
@@ -1182,7 +1182,7 @@ base class SpeechConfig {
     if (value == null) {
       _json.remove('voiceConfig');
     } else {
-      _json['voiceConfig'] = value;
+      _json['voiceConfig'] = value.toJson();
     }
   }
 
@@ -1198,7 +1198,7 @@ base class SpeechConfig {
     if (value == null) {
       _json.remove('multiSpeakerVoiceConfig');
     } else {
-      _json['multiSpeakerVoiceConfig'] = value;
+      _json['multiSpeakerVoiceConfig'] = value.toJson();
     }
   }
 
@@ -1269,7 +1269,7 @@ base class MultiSpeakerVoiceConfig {
   }
 
   set speakerVoiceConfigs(List<SpeakerVoiceConfig> value) {
-    _json['speakerVoiceConfigs'] = value.toList();
+    _json['speakerVoiceConfigs'] = value.map((e) => e.toJson()).toList();
   }
 
   @override
@@ -1344,7 +1344,7 @@ base class SpeakerVoiceConfig {
   }
 
   set voiceConfig(VoiceConfig value) {
-    _json['voiceConfig'] = value;
+    _json['voiceConfig'] = value.toJson();
   }
 
   @override
@@ -1415,7 +1415,7 @@ base class VoiceConfig {
     if (value == null) {
       _json.remove('prebuiltVoiceConfig');
     } else {
-      _json['prebuiltVoiceConfig'] = value;
+      _json['prebuiltVoiceConfig'] = value.toJson();
     }
   }
 

--- a/packages/schemantic/README.md
+++ b/packages/schemantic/README.md
@@ -23,6 +23,11 @@ dart pub add dev:schemantic_builder
 dart pub add dev:build_runner
 ```
 
+> **Troubleshooting:** if `dart run build_runner build` reports
+> `wrote 0 outputs` and no `.g.dart` files are generated, the most common cause
+> is a missing `schemantic_builder` dev dependency—the code generator lives in
+> that separate package, so without it the build silently does nothing.
+
 ## Usage
 
 ### 1. Basic & Dynamic Types

--- a/packages/schemantic/example/schemantic_example.g.dart
+++ b/packages/schemantic/example/schemantic_example.g.dart
@@ -176,7 +176,7 @@ base class User {
     if (value == null) {
       _json.remove('address');
     } else {
-      _json['address'] = value;
+      _json['address'] = value.toJson();
     }
   }
 

--- a/packages/schemantic_builder/lib/src/schema_generator.dart
+++ b/packages/schemantic_builder/lib/src/schema_generator.dart
@@ -701,14 +701,26 @@ final class SchemaGenerator extends GeneratorForAnnotation<Schema> {
     if (paramType.isNullable) {
       var valueExpression = 'value';
       if (nonNullableTypeName.isSchema) {
-        valueExpression = 'value';
+        // Normalize the nested model to plain JSON, mirroring the constructor.
+        valueExpression = 'value.toJson()';
       } else if (nonNullableTypeName == 'DateTime') {
         valueExpression = 'value.toIso8601String()';
       } else if (paramType.isDartCoreList) {
         final itemType = (paramType as InterfaceType).typeArguments.first;
         final itemTypeName = itemType.getDisplayString().replaceAll('?', '');
         if (itemTypeName.isSchema) {
-          valueExpression = 'value.toList()';
+          // Normalize each nested model in the list to plain JSON so that
+          // toJson() (and any later re-parse) sees Maps, not model instances.
+          final itemAccess = itemType.isNullable ? 'e?.toJson()' : 'e.toJson()';
+          valueExpression = 'value.map((e) => $itemAccess).toList()';
+        }
+      } else if (paramType.isDartCoreMap) {
+        final valueType = (paramType as InterfaceType).typeArguments[1];
+        final valueTypeName = valueType.getDisplayString().replaceAll('?', '');
+        if (valueTypeName.isSchema) {
+          // Normalize each nested model value in the map to plain JSON.
+          final valAccess = valueType.isNullable ? 'v?.toJson()' : 'v.toJson()';
+          valueExpression = 'value.map((k, v) => MapEntry(k, $valAccess))';
         }
       } else if (paramType.element is EnumElement) {
         valueExpression = 'value.name';
@@ -726,12 +738,26 @@ final class SchemaGenerator extends GeneratorForAnnotation<Schema> {
       final itemType = (paramType as InterfaceType).typeArguments.first;
       final itemTypeName = itemType.getDisplayString().replaceAll('?', '');
       if (itemTypeName.isSchema) {
-        setterBody = "_json['$jsonFieldName'] = value.toList();";
+        // Normalize each nested model in the list to plain JSON so that
+        // toJson() (and any later re-parse) sees Maps, not model instances.
+        final itemAccess = itemType.isNullable ? 'e?.toJson()' : 'e.toJson()';
+        setterBody =
+            "_json['$jsonFieldName'] = value.map((e) => $itemAccess).toList();";
+      }
+    } else if (paramType.isDartCoreMap) {
+      final valueType = (paramType as InterfaceType).typeArguments[1];
+      final valueTypeName = valueType.getDisplayString().replaceAll('?', '');
+      if (valueTypeName.isSchema) {
+        // Normalize each nested model value in the map to plain JSON.
+        final valAccess = valueType.isNullable ? 'v?.toJson()' : 'v.toJson()';
+        setterBody =
+            "_json['$jsonFieldName'] = "
+            'value.map((k, v) => MapEntry(k, $valAccess));';
       }
     } else if (nonNullableTypeName == 'DateTime') {
       setterBody = "_json['$jsonFieldName'] = value.toIso8601String();";
     } else if (nonNullableTypeName.isSchema) {
-      setterBody = "_json['$jsonFieldName'] = value;";
+      setterBody = "_json['$jsonFieldName'] = value.toJson();";
     }
 
     return Method(

--- a/packages/schemantic_builder/test/integration_test.dart
+++ b/packages/schemantic_builder/test/integration_test.dart
@@ -166,6 +166,21 @@ abstract class $House {
   $Location get location;
 }
 
+@Schema()
+abstract class $ItineraryDay {
+  int get day;
+  String get summary;
+}
+
+@Schema()
+abstract class $TripPlan {
+  String get destination;
+  List<$ItineraryDay> get itinerary;
+  List<$ItineraryDay>? get optionalItinerary;
+  $Location? get base;
+  Map<String, $ItineraryDay>? get keyedDays;
+}
+
 void main() {
   group('Integration Tests', () {
     test('User serialization and deserialization', () {
@@ -664,6 +679,74 @@ void main() {
         'color': 'red',
       });
       expect(parsedNull.nullableColor, isNull);
+    });
+  });
+
+  group('Nested-model setter normalization', () {
+    // Regression: generated setters must normalize nested models to plain JSON
+    // (matching the constructor), otherwise toJson() holds model instances
+    // instead of Maps and a later re-parse throws
+    // "type 'X' is not a subtype of Map".
+
+    test('List<Schema> setter stores plain JSON, round-trips', () {
+      final plan = TripPlan(destination: 'Rome', itinerary: []);
+
+      plan.itinerary = [
+        ItineraryDay(day: 1, summary: 'Colosseum'),
+        ItineraryDay(day: 2, summary: 'Vatican'),
+      ];
+
+      // The backing JSON must contain Maps, not ItineraryDay instances.
+      final rawList = plan.toJson()['itinerary'] as List;
+      expect(rawList, everyElement(isA<Map>()));
+      expect((rawList.first as Map)['summary'], 'Colosseum');
+
+      // Re-parsing the serialized JSON must not throw and must be intact.
+      final reparsed = TripPlan.$schema.parse(plan.toJson());
+      expect(reparsed.itinerary.length, 2);
+      expect(reparsed.itinerary[0].day, 1);
+      expect(reparsed.itinerary[1].summary, 'Vatican');
+    });
+
+    test('nullable List<Schema> setter stores plain JSON, round-trips', () {
+      final plan = TripPlan(destination: 'Paris', itinerary: []);
+
+      plan.optionalItinerary = [ItineraryDay(day: 1, summary: 'Louvre')];
+
+      final rawList = plan.toJson()['optionalItinerary'] as List;
+      expect(rawList, everyElement(isA<Map>()));
+
+      final reparsed = TripPlan.$schema.parse(plan.toJson());
+      expect(reparsed.optionalItinerary!.single.summary, 'Louvre');
+
+      // Setting null removes the key.
+      plan.optionalItinerary = null;
+      expect(plan.toJson().containsKey('optionalItinerary'), isFalse);
+    });
+
+    test('single nullable Schema setter stores plain JSON, round-trips', () {
+      final plan = TripPlan(destination: 'Tokyo', itinerary: []);
+
+      plan.base = Location(address: 'Shibuya');
+      expect(plan.toJson()['base'], isA<Map>());
+
+      final reparsed = TripPlan.$schema.parse(plan.toJson());
+      expect(reparsed.base!.address, 'Shibuya');
+
+      plan.base = null;
+      expect(plan.toJson().containsKey('base'), isFalse);
+    });
+
+    test('Map<String, Schema> setter stores plain JSON, round-trips', () {
+      final plan = TripPlan(destination: 'Oslo', itinerary: []);
+
+      plan.keyedDays = {'first': ItineraryDay(day: 1, summary: 'Fjord')};
+
+      final rawMap = plan.toJson()['keyedDays'] as Map;
+      expect(rawMap['first'], isA<Map>());
+
+      final reparsed = TripPlan.$schema.parse(plan.toJson());
+      expect(reparsed.keyedDays!['first']!.summary, 'Fjord');
     });
   });
 }

--- a/packages/schemantic_builder/test/integration_test.g.dart
+++ b/packages/schemantic_builder/test/integration_test.g.dart
@@ -138,7 +138,7 @@ base class Group {
   }
 
   set members(List<User> value) {
-    _json['members'] = value.toList();
+    _json['members'] = value.map((e) => e.toJson()).toList();
   }
 
   User? get leader {
@@ -151,7 +151,7 @@ base class Group {
     if (value == null) {
       _json.remove('leader');
     } else {
-      _json['leader'] = value;
+      _json['leader'] = value.toJson();
     }
   }
 
@@ -226,7 +226,7 @@ base class Node {
     if (value == null) {
       _json.remove('children');
     } else {
-      _json['children'] = value.toList();
+      _json['children'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -538,7 +538,7 @@ base class CrossFileParent {
   }
 
   set child(SharedChild value) {
-    _json['child'] = value;
+    _json['child'] = value.toJson();
   }
 
   @override
@@ -776,7 +776,7 @@ base class MapSchema {
     if (value == null) {
       _json.remove('stringToUser');
     } else {
-      _json['stringToUser'] = value;
+      _json['stringToUser'] = value.map((k, v) => MapEntry(k, v.toJson()));
     }
   }
 
@@ -1134,7 +1134,7 @@ base class House {
   }
 
   set location(Location value) {
-    _json['location'] = value;
+    _json['location'] = value.toJson();
   }
 
   @override
@@ -1173,5 +1173,206 @@ base class _HouseTypeFactory extends SchemanticType<House> {
         )
         .value,
     dependencies: [Location.$schema],
+  );
+}
+
+base class ItineraryDay {
+  /// Creates a [ItineraryDay] from a JSON map.
+  factory ItineraryDay.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  ItineraryDay._(this._json);
+
+  ItineraryDay({required int day, required String summary}) {
+    _json = {'day': day, 'summary': summary};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [ItineraryDay].
+  static const SchemanticType<ItineraryDay> $schema =
+      _ItineraryDayTypeFactory();
+
+  int get day {
+    return _json['day'] as int;
+  }
+
+  set day(int value) {
+    _json['day'] = value;
+  }
+
+  String get summary {
+    return _json['summary'] as String;
+  }
+
+  set summary(String value) {
+    _json['summary'] = value;
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [ItineraryDay] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _ItineraryDayTypeFactory extends SchemanticType<ItineraryDay> {
+  const _ItineraryDayTypeFactory();
+
+  @override
+  ItineraryDay parse(Object? json) {
+    return ItineraryDay._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'ItineraryDay',
+    definition: $Schema
+        .object(
+          properties: {'day': $Schema.integer(), 'summary': $Schema.string()},
+          required: ['day', 'summary'],
+        )
+        .value,
+    dependencies: [],
+  );
+}
+
+base class TripPlan {
+  /// Creates a [TripPlan] from a JSON map.
+  factory TripPlan.fromJson(Map<String, dynamic> json) => $schema.parse(json);
+
+  TripPlan._(this._json);
+
+  TripPlan({
+    required String destination,
+    required List<ItineraryDay> itinerary,
+    List<ItineraryDay>? optionalItinerary,
+    Location? base,
+    Map<String, ItineraryDay>? keyedDays,
+  }) {
+    _json = {
+      'destination': destination,
+      'itinerary': itinerary.map((e) => e.toJson()).toList(),
+      'optionalItinerary': ?optionalItinerary?.map((e) => e.toJson()).toList(),
+      'base': ?base?.toJson(),
+      'keyedDays': ?keyedDays?.map((k, v) => MapEntry(k, v.toJson())),
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [TripPlan].
+  static const SchemanticType<TripPlan> $schema = _TripPlanTypeFactory();
+
+  String get destination {
+    return _json['destination'] as String;
+  }
+
+  set destination(String value) {
+    _json['destination'] = value;
+  }
+
+  List<ItineraryDay> get itinerary {
+    return (_json['itinerary'] as List)
+        .map((e) => ItineraryDay.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  set itinerary(List<ItineraryDay> value) {
+    _json['itinerary'] = value.map((e) => e.toJson()).toList();
+  }
+
+  List<ItineraryDay>? get optionalItinerary {
+    return (_json['optionalItinerary'] as List?)
+        ?.map((e) => ItineraryDay.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  set optionalItinerary(List<ItineraryDay>? value) {
+    if (value == null) {
+      _json.remove('optionalItinerary');
+    } else {
+      _json['optionalItinerary'] = value.map((e) => e.toJson()).toList();
+    }
+  }
+
+  Location? get base {
+    return _json['base'] == null
+        ? null
+        : Location.fromJson(_json['base'] as Map<String, dynamic>);
+  }
+
+  set base(Location? value) {
+    if (value == null) {
+      _json.remove('base');
+    } else {
+      _json['base'] = value.toJson();
+    }
+  }
+
+  Map<String, ItineraryDay>? get keyedDays {
+    return (_json['keyedDays'] as Map?)?.map<String, ItineraryDay>(
+      (k, v) => MapEntry(
+        k as String,
+        ItineraryDay.fromJson(v as Map<String, dynamic>),
+      ),
+    );
+  }
+
+  set keyedDays(Map<String, ItineraryDay>? value) {
+    if (value == null) {
+      _json.remove('keyedDays');
+    } else {
+      _json['keyedDays'] = value.map((k, v) => MapEntry(k, v.toJson()));
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [TripPlan] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _TripPlanTypeFactory extends SchemanticType<TripPlan> {
+  const _TripPlanTypeFactory();
+
+  @override
+  TripPlan parse(Object? json) {
+    return TripPlan._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'TripPlan',
+    definition: $Schema
+        .object(
+          properties: {
+            'destination': $Schema.string(),
+            'itinerary': $Schema.list(
+              items: $Schema.fromMap({'\$ref': r'#/$defs/ItineraryDay'}),
+            ),
+            'optionalItinerary': $Schema.list(
+              items: $Schema.fromMap({'\$ref': r'#/$defs/ItineraryDay'}),
+            ),
+            'base': $Schema.fromMap({'\$ref': r'#/$defs/Location'}),
+            'keyedDays': $Schema.object(
+              additionalProperties: $Schema.fromMap({
+                '\$ref': r'#/$defs/ItineraryDay',
+              }),
+            ),
+          },
+          required: ['destination', 'itinerary'],
+        )
+        .value,
+    dependencies: [ItineraryDay.$schema, Location.$schema],
   );
 }

--- a/testapps/basic/lib/simple_flow_types.g.dart
+++ b/testapps/basic/lib/simple_flow_types.g.dart
@@ -122,7 +122,7 @@ base class Recipe {
   }
 
   set ingredients(List<Ingredient> value) {
-    _json['ingredients'] = value.toList();
+    _json['ingredients'] = value.map((e) => e.toJson()).toList();
   }
 
   int get servings {

--- a/testapps/gemini/bin/src/model.g.dart
+++ b/testapps/gemini/bin/src/model.g.dart
@@ -119,7 +119,7 @@ base class Category {
     if (value == null) {
       _json.remove('subcategories');
     } else {
-      _json['subcategories'] = value.toList();
+      _json['subcategories'] = value.map((e) => e.toJson()).toList();
     }
   }
 
@@ -200,7 +200,7 @@ base class Weapon {
   }
 
   set category(Category value) {
-    _json['category'] = value;
+    _json['category'] = value.toJson();
   }
 
   @override
@@ -291,7 +291,7 @@ base class RpgCharacter {
   }
 
   set weapons(List<Weapon> value) {
-    _json['weapons'] = value.toList();
+    _json['weapons'] = value.map((e) => e.toJson()).toList();
   }
 
   String get classType {


### PR DESCRIPTION
schemantic setters didn't serialize nested models. Generated __constructors__ normalize nested `@Schema` fields to their `.toJson()` form, but generated __setters__ stored the raw model instances instead:

```dart
// before (generated setter)
set itinerary(List<ItineraryDay> value) {
  _json['itinerary'] = value.toList();   // stores ItineraryDay instances, not Maps
}
```

After `plan.itinerary = [...]`, `plan.toJson()` returned a map whose `itinerary` held `ItineraryDay` objects rather than `Map`s. The next time that state was re-parsed (e.g. a later agent turn, or reloading from a store), the generated getter ran `ItineraryDay.fromJson(e as Map)` and threw:

```javascript
type 'ItineraryDay' is not a subtype of type 'Map<String, dynamic>'
```

The only workaround was a manual deep round-trip like `TripPlan.fromJson(jsonDecode(jsonEncode(plan.toJson()))).

__Setters now normalize nested models, mirroring the constructor.__ `_generateSetter` handles all three nested-schema shapes, with nullable field/item awareness:

```dart
// after
set itinerary(List<ItineraryDay> value) {
  _json['itinerary'] = value.map((e) => e.toJson()).toList();
}
set base(Location? value) {
  if (value == null) { _json.remove('base'); }
  else { _json['base'] = value.toJson(); }
}
set keyedDays(Map<String, ItineraryDay>? value) {
  ... v.toJson() ...
}
```

- single `Schema`, `List<Schema>`, and `Map<K, Schema>` (the Map case was previously missing entirely)
- nullable field + nullable item handling