### PR TITLE
docs: clarify Firestore project id discovery requirements

### DIFF
--- a/packages/genkit_google_cloud/README.md
+++ b/packages/genkit_google_cloud/README.md
@@ -34,6 +34,13 @@ final store = FirestoreSessionStore(
 );
 ```
 
+> **Project id:** the default `Firestore()` uses Application Default
+> Credentials, but ADC alone does not always carry a project id. If the client
+> cannot discover one it throws at read/write time with
+> `Project ID has not been discovered yet`. Set the `GOOGLE_CLOUD_PROJECT`
+> environment variable (often required even when ADC is present) or pass an
+> explicit `Firestore` configured with a project id.
+
 ### Storage layout
 
 For a per-tenant `<prefix>` (see `snapshotPathPrefix`, default `"global"`):

--- a/packages/genkit_google_cloud/README.md
+++ b/packages/genkit_google_cloud/README.md
@@ -34,12 +34,12 @@ final store = FirestoreSessionStore(
 );
 ```
 
-> **Project id:** the default `Firestore()` uses Application Default
-> Credentials, but ADC alone does not always carry a project id. If the client
+> **Project ID:** the default `Firestore()` uses Application Default
+> Credentials, but ADC alone does not always carry a project ID. If the client
 > cannot discover one it throws at read/write time with
 > `Project ID has not been discovered yet`. Set the `GOOGLE_CLOUD_PROJECT`
 > environment variable (often required even when ADC is present) or pass an
-> explicit `Firestore` configured with a project id.
+> explicit `Firestore` configured with a project ID.
 
 ### Storage layout
 

--- a/packages/genkit_google_cloud/lib/firestore_session_store.dart
+++ b/packages/genkit_google_cloud/lib/firestore_session_store.dart
@@ -348,12 +348,24 @@ bool _isNewerLeaf(
 /// Dart Firestore client has no real-time listener, so
 /// [onSnapshotStateChange] is implemented by polling. Tune the latency via the
 /// `snapshotWatchPollInterval` constructor argument.
+///
+/// ## Project id
+///
+/// The default [Firestore] instance uses Application Default Credentials, but
+/// ADC alone does not always carry a project id. If the client cannot discover
+/// one it throws at read/write time with "Project ID has not been discovered
+/// yet". To avoid this, either set the `GOOGLE_CLOUD_PROJECT` environment
+/// variable (often required even when ADC is present) or pass an explicit
+/// [Firestore] instance configured with a project id to the constructor.
 class FirestoreSessionStore implements SessionStore, SnapshotChangeNotifier {
   /// Creates a Firestore-backed session store.
   ///
   /// - [db]: an explicit [Firestore] instance. Defaults to a new [Firestore]
   ///   (which picks up Application Default Credentials and the
-  ///   `FIRESTORE_EMULATOR_HOST` environment variable).
+  ///   `FIRESTORE_EMULATOR_HOST` environment variable). Note that ADC alone may
+  ///   not carry a project id; set `GOOGLE_CLOUD_PROJECT` or pass an explicit
+  ///   [Firestore] with a project id if you hit "Project ID has not been
+  ///   discovered yet".
   /// - [collection]: the collection where snapshot documents are stored.
   ///   Defaults to `"genkit-sessions"`. Two companion collections are derived
   ///   from it: `"<collection>-pointers"` and `"<collection>-shards"`.

--- a/packages/genkit_google_cloud/lib/firestore_session_store.dart
+++ b/packages/genkit_google_cloud/lib/firestore_session_store.dart
@@ -349,22 +349,22 @@ bool _isNewerLeaf(
 /// [onSnapshotStateChange] is implemented by polling. Tune the latency via the
 /// `snapshotWatchPollInterval` constructor argument.
 ///
-/// ## Project id
+/// ## Project ID
 ///
 /// The default [Firestore] instance uses Application Default Credentials, but
-/// ADC alone does not always carry a project id. If the client cannot discover
+/// ADC alone does not always carry a project ID. If the client cannot discover
 /// one it throws at read/write time with "Project ID has not been discovered
 /// yet". To avoid this, either set the `GOOGLE_CLOUD_PROJECT` environment
 /// variable (often required even when ADC is present) or pass an explicit
-/// [Firestore] instance configured with a project id to the constructor.
+/// [Firestore] instance configured with a project ID to the constructor.
 class FirestoreSessionStore implements SessionStore, SnapshotChangeNotifier {
   /// Creates a Firestore-backed session store.
   ///
   /// - [db]: an explicit [Firestore] instance. Defaults to a new [Firestore]
   ///   (which picks up Application Default Credentials and the
   ///   `FIRESTORE_EMULATOR_HOST` environment variable). Note that ADC alone may
-  ///   not carry a project id; set `GOOGLE_CLOUD_PROJECT` or pass an explicit
-  ///   [Firestore] with a project id if you hit "Project ID has not been
+  ///   not carry a project ID; set `GOOGLE_CLOUD_PROJECT` or pass an explicit
+  ///   [Firestore] with a project ID if you hit "Project ID has not been
   ///   discovered yet".
   /// - [collection]: the collection where snapshot documents are stored.
   ///   Defaults to `"genkit-sessions"`. Two companion collections are derived


### PR DESCRIPTION
Add documentation to README and FirestoreSessionStore explaining that Application Default Credentials may not carry a project id, causing "Project ID has not been discovered yet" errors. Guide users to set GOOGLE_CLOUD_PROJECT or pass an explicit Firestore instance.