### PR TITLE
fix: map tool role to "user" for Gemini API compatibility

### DIFF
--- a/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
+++ b/packages/genkit_firebase_ai/lib/genkit_firebase_ai.dart
@@ -419,7 +419,7 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
         } else {
           // Fallback for others
           await session.send(
-            input: fai.Content(msg.role.value, [part]),
+            input: fai.Content(toGeminiRole(msg.role), [part]),
             turnComplete: true,
           );
         }
@@ -431,11 +431,25 @@ class _FirebaseGenAiPlugin extends GenkitPlugin {
   }
 }
 
+/// Maps a Genkit [Role] to the role string expected by the Gemini API.
+///
+/// Gemini's Content API only understands `user` and `model` roles. Tool
+/// (function response) messages must be sent with the `user` role for
+/// compatibility.
+@visibleForTesting
+String toGeminiRole(Role role) {
+  if (role == Role.model) return 'model';
+  // user, tool and anything else map to 'user'.
+  return 'user';
+}
+
 @visibleForTesting
 Iterable<fai.Content> toGeminiContent(List<Message> messages) {
   return messages.map(
-    (msg) =>
-        fai.Content(msg.role.value, msg.content.map(toGeminiPart).toList()),
+    (msg) => fai.Content(
+      toGeminiRole(msg.role),
+      msg.content.map(toGeminiPart).toList(),
+    ),
   );
 }
 

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -428,12 +428,24 @@ gcl.ToolConfig? toGeminiToolConfig(
   );
 }
 
+/// Maps a Genkit [Role] to the role string expected by the Gemini API.
+///
+/// Gemini's Content API only understands `user` and `model` roles. Tool
+/// (function response) messages must be sent with the `user` role for
+/// compatibility.
+@visibleForTesting
+String toGeminiRole(Role role) {
+  if (role == Role.model) return 'model';
+  // user, tool and anything else map to 'user'.
+  return 'user';
+}
+
 @visibleForTesting
 List<gcl.Content> toGeminiContent(List<Message> messages) {
   return messages
       .map(
         (m) => gcl.Content(
-          role: m.role.value,
+          role: toGeminiRole(m.role),
           parts: m.content.map(toGeminiPart).toList(),
         ),
       )

--- a/packages/genkit_google_genai/test/converter_test.dart
+++ b/packages/genkit_google_genai/test/converter_test.dart
@@ -168,6 +168,56 @@ void main() {
     });
   });
 
+  group('toGeminiContent', () {
+    test('maps model role to "model"', () {
+      final contents = toGeminiContent([
+        Message(
+          role: Role.model,
+          content: [TextPart(text: 'hi')],
+        ),
+      ]);
+      expect(contents.single.role, 'model');
+    });
+
+    test('maps user role to "user"', () {
+      final contents = toGeminiContent([
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hi')],
+        ),
+      ]);
+      expect(contents.single.role, 'user');
+    });
+
+    test('maps tool role to "user" for Gemini compatibility', () {
+      final contents = toGeminiContent([
+        Message(
+          role: Role.tool,
+          content: [
+            ToolResponsePart(
+              toolResponse: ToolResponse(name: 'myTool', output: {'ok': true}),
+            ),
+          ],
+        ),
+      ]);
+      expect(contents.single.role, 'user');
+    });
+  });
+
+  group('toGeminiRole', () {
+    test('model maps to "model"', () {
+      expect(toGeminiRole(Role.model), 'model');
+    });
+
+    test('user maps to "user"', () {
+      expect(toGeminiRole(Role.user), 'user');
+    });
+
+    test('tool maps to "user"', () {
+      expect(toGeminiRole(Role.tool), 'user');
+    });
+  });
+
   group('extractUsage', () {
     test('extracts standard usage', () {
       final usage = gcl.UsageMetadata(


### PR DESCRIPTION
Gemini's Content API only understands `user` and `model` roles, but Genkit also supports a `tool` role for function responses. Previously the raw role value was passed through, which caused invalid requests for tool messages.

Add a `toGeminiRole` helper in both the Firebase AI and Google GenAI plugins that maps `model` to "model" and everything else (including `tool`) to "user". Include tests covering the role mapping behavior.