### PR TITLE
fix(genkit_openai): stop dropping tools and mark o-series models as tool-capable

### DIFF
--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -222,7 +222,6 @@ class OpenAIPlugin extends GenkitPlugin {
         );
 
         try {
-          // Some OpenAI-compatible providers reject an empty tools array.
           final tools = modelRequest.tools
               ?.map(GenkitConverter.toOpenAITool)
               .toList();
@@ -240,6 +239,7 @@ class OpenAIPlugin extends GenkitPlugin {
               modelRequest.messages,
               options.visualDetailLevel,
             ),
+            // Some OpenAI-compatible providers reject an empty tools array.
             tools: (tools == null || tools.isEmpty) ? null : tools,
             temperature: options.temperature,
             topP: options.topP,

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -222,6 +222,11 @@ class OpenAIPlugin extends GenkitPlugin {
         );
 
         try {
+          // Some OpenAI-compatible providers reject an empty tools array.
+          final tools = modelRequest.tools
+              ?.map(GenkitConverter.toOpenAITool)
+              .toList();
+
           final isJsonMode = chat.isJsonStructuredOutput(
             modelRequest.output?.format,
             modelRequest.output?.contentType,
@@ -235,12 +240,7 @@ class OpenAIPlugin extends GenkitPlugin {
               modelRequest.messages,
               options.visualDetailLevel,
             ),
-            // Passed through even when supports.tools is false: a model that
-            // truly lacks tool support should error loudly from the API, not
-            // silently lose its tools.
-            tools: modelRequest.tools
-                ?.map(GenkitConverter.toOpenAITool)
-                .toList(),
+            tools: (tools == null || tools.isEmpty) ? null : tools,
             temperature: options.temperature,
             topP: options.topP,
             maxCompletionTokens: options.maxTokens,

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -222,9 +222,6 @@ class OpenAIPlugin extends GenkitPlugin {
         );
 
         try {
-          final supports = modelInfo.supports;
-          final supportsTools = supports?['tools'] == true;
-
           final isJsonMode = chat.isJsonStructuredOutput(
             modelRequest.output?.format,
             modelRequest.output?.contentType,
@@ -238,9 +235,12 @@ class OpenAIPlugin extends GenkitPlugin {
               modelRequest.messages,
               options.visualDetailLevel,
             ),
-            tools: supportsTools
-                ? modelRequest.tools?.map(GenkitConverter.toOpenAITool).toList()
-                : null,
+            // Passed through even when supports.tools is false: a model that
+            // truly lacks tool support should error loudly from the API, not
+            // silently lose its tools.
+            tools: modelRequest.tools
+                ?.map(GenkitConverter.toOpenAITool)
+                .toList(),
             temperature: options.temperature,
             topP: options.topP,
             maxCompletionTokens: options.maxTokens,

--- a/packages/genkit_openai/lib/src/utils.dart
+++ b/packages/genkit_openai/lib/src/utils.dart
@@ -69,17 +69,22 @@ class _DefaultModelCapabilities extends _ModelCapabilities {
 }
 
 /// O-series reasoning models override key capability defaults.
+///
+/// Tools are not overridden: o-series models support tool calling; they
+/// only reject the system role.
 class _OSeriesModelCapabilities extends _DefaultModelCapabilities {
   const _OSeriesModelCapabilities(super.modelId);
 
   @override
-  bool get supportsTools => false;
-
-  @override
   bool get supportsSystemRole => false;
 
+  // o3-mini, o1-mini, and o1-preview (incl. dated variants) are text-only;
+  // the rest of the o-series accepts images.
   @override
-  bool get supportsMedia => true;
+  bool get supportsMedia =>
+      !id.startsWith('o3-mini') &&
+      !id.startsWith('o1-mini') &&
+      !id.startsWith('o1-preview');
 }
 
 bool _supportsToolsByHeuristics(String id) {

--- a/packages/genkit_openai/lib/src/utils.dart
+++ b/packages/genkit_openai/lib/src/utils.dart
@@ -72,8 +72,8 @@ class _DefaultModelCapabilities extends _ModelCapabilities {
 class _OSeriesModelCapabilities extends _DefaultModelCapabilities {
   const _OSeriesModelCapabilities(super.modelId);
 
-  // o1-mini and o1-preview predate function calling on the chat API;
-  // every later o-series model supports tools.
+  // o1-mini and o1-preview never had function calling on the chat API;
+  // every other o-series model supports tools.
   @override
   bool get supportsTools =>
       !id.startsWith('o1-mini') && !id.startsWith('o1-preview');

--- a/packages/genkit_openai/lib/src/utils.dart
+++ b/packages/genkit_openai/lib/src/utils.dart
@@ -69,11 +69,14 @@ class _DefaultModelCapabilities extends _ModelCapabilities {
 }
 
 /// O-series reasoning models override key capability defaults.
-///
-/// Tools are not overridden: o-series models support tool calling; they
-/// only reject the system role.
 class _OSeriesModelCapabilities extends _DefaultModelCapabilities {
   const _OSeriesModelCapabilities(super.modelId);
+
+  // o1-mini and o1-preview predate function calling on the chat API;
+  // every later o-series model supports tools.
+  @override
+  bool get supportsTools =>
+      !id.startsWith('o1-mini') && !id.startsWith('o1-preview');
 
   @override
   bool get supportsSystemRole => false;

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -126,6 +126,43 @@ void main() {
       expect(hasContent, isTrue);
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
 
+    test('o-series tool calling executes the tool', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      var toolRan = false;
+      ai.defineTool(
+        name: 'getWeather',
+        description: 'Get the weather for a location',
+        inputSchema: WeatherInputSchema.$schema,
+        fn: (input, ctx) async {
+          toolRan = true;
+          return {'temperature': 72, 'condition': 'sunny'};
+        },
+      );
+
+      final response = await ai.generate(
+        model: openAI.model('o4-mini'),
+        prompt: 'Use the getWeather tool to find the weather in Boston.',
+        toolNames: ['getWeather'],
+      );
+
+      expect(response.message, isNotNull);
+      // Unlike the tolerant gpt-4o test above, this asserts the tool actually
+      // executed: with tools silently stripped (bug #357) o-series models
+      // hallucinate a JSON tool call as plain text and the tool never runs.
+      expect(
+        toolRan,
+        isTrue,
+        reason: 'getWeather must actually execute for o4-mini',
+      );
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
     group('Structured output', () {
       test(
         'non-streaming: outputSchema parses response to schema type',

--- a/packages/genkit_openai/test/openai_plugin_utils_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_utils_test.dart
@@ -56,6 +56,7 @@ void main() {
       expect(supportsVision('gpt-4-vision'), true);
       expect(supportsVision('gpt-4-vision-preview'), true);
       expect(supportsVision('o1'), true);
+      expect(supportsVision('o1-mini'), false);
       expect(supportsVision('o1-preview'), false);
       expect(supportsVision('o3'), true);
       expect(supportsVision('o3-mini'), false);
@@ -83,7 +84,7 @@ void main() {
       // Non-tool models
       expect(supportsTools('o1'), true);
       expect(supportsTools('o3-mini'), true);
-      // o1-mini and o1-preview predate function calling.
+      // o1-mini and o1-preview never had function calling.
       expect(supportsTools('o1-mini'), false);
       expect(supportsTools('o1-preview'), false);
       expect(supportsTools('chatgpt-4o-latest'), false);

--- a/packages/genkit_openai/test/openai_plugin_utils_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_utils_test.dart
@@ -28,7 +28,8 @@ void main() {
     test('oSeriesModelInfo sets correct supports', () {
       final info = oSeriesModelInfo('o1');
       expect(info.supports?['multiturn'], true);
-      expect(info.supports?['tools'], false);
+      // O-series models support tool calling (JS and Go plugins agree).
+      expect(info.supports?['tools'], true);
       expect(info.supports?['systemRole'], false);
       expect(info.supports?['media'], true);
     });
@@ -39,9 +40,10 @@ void main() {
       expect(defaultInfo.supports?['systemRole'], true);
 
       final oSeriesInfo = modelInfoFor('o3-mini');
-      expect(oSeriesInfo.supports?['tools'], false);
+      expect(oSeriesInfo.supports?['tools'], true);
       expect(oSeriesInfo.supports?['systemRole'], false);
-      expect(oSeriesInfo.supports?['media'], true);
+      // o3-mini is text-only (JS marks it media:false).
+      expect(oSeriesInfo.supports?['media'], false);
     });
 
     test('supportsVision identifies vision models', () {
@@ -55,9 +57,9 @@ void main() {
       expect(supportsVision('gpt-4-vision'), true);
       expect(supportsVision('gpt-4-vision-preview'), true);
       expect(supportsVision('o1'), true);
-      expect(supportsVision('o1-preview'), true);
+      expect(supportsVision('o1-preview'), false);
       expect(supportsVision('o3'), true);
-      expect(supportsVision('o3-mini'), true);
+      expect(supportsVision('o3-mini'), false);
       expect(supportsVision('gpt-5o'), true);
       expect(supportsVision('gpt-5.1o'), true);
       expect(supportsVision('gpt-6o-mini'), true);
@@ -80,9 +82,9 @@ void main() {
       expect(supportsTools('gpt-5.1'), true);
 
       // Non-tool models
-      expect(supportsTools('o1'), false);
-      expect(supportsTools('o1-mini'), false);
-      expect(supportsTools('o3-mini'), false);
+      expect(supportsTools('o1'), true);
+      expect(supportsTools('o1-mini'), true);
+      expect(supportsTools('o3-mini'), true);
       expect(supportsTools('chatgpt-4o-latest'), false);
       expect(supportsTools('chatgpt-5-latest'), false);
       expect(supportsTools('gpt-3.5-turbo-instruct'), false);

--- a/packages/genkit_openai/test/openai_plugin_utils_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_utils_test.dart
@@ -28,7 +28,6 @@ void main() {
     test('oSeriesModelInfo sets correct supports', () {
       final info = oSeriesModelInfo('o1');
       expect(info.supports?['multiturn'], true);
-      // O-series models support tool calling (JS and Go plugins agree).
       expect(info.supports?['tools'], true);
       expect(info.supports?['systemRole'], false);
       expect(info.supports?['media'], true);
@@ -83,8 +82,10 @@ void main() {
 
       // Non-tool models
       expect(supportsTools('o1'), true);
-      expect(supportsTools('o1-mini'), true);
       expect(supportsTools('o3-mini'), true);
+      // o1-mini and o1-preview predate function calling.
+      expect(supportsTools('o1-mini'), false);
+      expect(supportsTools('o1-preview'), false);
       expect(supportsTools('chatgpt-4o-latest'), false);
       expect(supportsTools('chatgpt-5-latest'), false);
       expect(supportsTools('gpt-3.5-turbo-instruct'), false);

--- a/packages/genkit_openai/test/openai_plugin_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_wire_test.dart
@@ -104,6 +104,39 @@ void main() {
       await ai.shutdown();
     });
 
+    test(
+      'tools reach the wire even when model metadata says tools unsupported',
+      () async {
+        // chatgpt-4o-latest advertises tools: false via the heuristics.
+        // The request builder must not gate on that metadata: passing tools
+        // through unconditionally is what keeps misdeclared models loud
+        // instead of silently degraded (bug #357's second layer).
+        final captured = <Map<String, dynamic>>[];
+        final ai = Genkit(
+          plugins: [
+            openAI(apiKey: 'test-key', httpClient: wireClient(captured)),
+          ],
+        );
+        ai.defineTool(
+          name: 'getWeather',
+          description: 'Get the weather for a location',
+          fn: (input, ctx) async => {'temperature': 72},
+        );
+
+        expect(supportsTools('chatgpt-4o-latest'), isFalse);
+
+        await ai.generate(
+          model: openAI.model('chatgpt-4o-latest'),
+          prompt: 'What is the weather in Boston?',
+          toolNames: ['getWeather'],
+        );
+
+        expect(captured.first.containsKey('tools'), isTrue);
+
+        await ai.shutdown();
+      },
+    );
+
     test('tools reach the wire for standard GPT models', () async {
       final captured = <Map<String, dynamic>>[];
       final ai = Genkit(

--- a/packages/genkit_openai/test/openai_plugin_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_wire_test.dart
@@ -137,6 +137,21 @@ void main() {
       },
     );
 
+    test('no tools requested leaves the tools key off the wire', () async {
+      // Core hands the plugin a non-null (possibly empty) tools list; some
+      // OpenAI-compatible providers reject "tools": [].
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+
+      await ai.generate(model: openAI.model('o4-mini'), prompt: 'Say hello.');
+
+      expect(captured.first.containsKey('tools'), isFalse);
+
+      await ai.shutdown();
+    });
+
     test('tools reach the wire for standard GPT models', () async {
       final captured = <Map<String, dynamic>>[];
       final ai = Genkit(

--- a/packages/genkit_openai/test/openai_plugin_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_wire_test.dart
@@ -1,0 +1,129 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Captures every chat-completions request body the plugin puts on the wire
+/// and serves canned OpenAI responses, so tests can assert on the actual
+/// JSON sent rather than on plugin internals.
+MockClient wireClient(List<Map<String, dynamic>> capturedBodies) {
+  return MockClient((request) async {
+    if (request.url.path.endsWith('/models')) {
+      return http.Response(
+        jsonEncode({
+          'object': 'list',
+          'data': [
+            {
+              'id': 'gpt-4o',
+              'object': 'model',
+              'created': 0,
+              'owned_by': 'openai',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (request.url.path.endsWith('/chat/completions')) {
+      capturedBodies.add(
+        (jsonDecode(request.body) as Map).cast<String, dynamic>(),
+      );
+      return http.Response(
+        jsonEncode({
+          'id': 'chatcmpl-test',
+          'object': 'chat.completion',
+          'created': 0,
+          'model': 'o4-mini',
+          'choices': [
+            {
+              'index': 0,
+              'message': {'role': 'assistant', 'content': 'ok'},
+              'finish_reason': 'stop',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('not found', 404);
+  });
+}
+
+void main() {
+  group('wire-level request assembly', () {
+    test('tools reach the wire for o-series models', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+      ai.defineTool(
+        name: 'getWeather',
+        description: 'Get the weather for a location',
+        fn: (input, ctx) async => {'temperature': 72},
+      );
+
+      await ai.generate(
+        model: openAI.model('o4-mini'),
+        prompt: 'What is the weather in Boston?',
+        toolNames: ['getWeather'],
+      );
+
+      expect(captured, isNotEmpty);
+      final body = captured.first;
+      expect(
+        body.containsKey('tools'),
+        isTrue,
+        reason:
+            'request body must carry the tools array; the plugin silently '
+            'dropping tools for o-series models is bug #357',
+      );
+      final tools = (body['tools'] as List).cast<Map<String, dynamic>>();
+      final function = (tools.single['function'] as Map)
+          .cast<String, dynamic>();
+      expect(function['name'], 'getWeather');
+
+      await ai.shutdown();
+    });
+
+    test('tools reach the wire for standard GPT models', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+      ai.defineTool(
+        name: 'getWeather',
+        description: 'Get the weather for a location',
+        fn: (input, ctx) async => {'temperature': 72},
+      );
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'What is the weather in Boston?',
+        toolNames: ['getWeather'],
+      );
+
+      expect(captured.first.containsKey('tools'), isTrue);
+
+      await ai.shutdown();
+    });
+  });
+}


### PR DESCRIPTION
Fixes #357

o-series tool calls never reach the API: `_OSeriesModelCapabilities` declares `supportsTools => false` (utils.dart:76) and the request builder silently strips tools for any model whose metadata says unsupported (openai_plugin.dart:241-243). The model then hallucinates a tool call as plain text.

Reproduced live against o4-mini via the plugin's `httpClient` param:

```
# before
has "tools" key: false
plugin response text: {"tool": "getWeather", "input": "Boston"}
# after
has "tools" key: true
live test: getWeather executes
```

Fix follows JS and Go, neither of which drops silently: tools pass through whenever present (empty arrays stay off the wire), and a model that truly lacks them errors loudly from the API. Also corrects o-series metadata: o3-mini text-only (matches JS `gpt.ts:98-108`); o1-mini/o1-preview text-only and tools-unsupported (they never had chat function calling; neither reference plugin curates them).

Caveat: loud failure holds against OpenAI proper; a compat `baseUrl` provider may still ignore the field server-side. JS/Go mitigate with framework-level warning/middleware, which Dart core does not have yet.

Commits are red/green; wire tests via injected `MockClient` are the package's first request-path coverage. Found in passing, tracked separately: schema-less tools produce `type: "string"` parameters, rejected with a 400 (#371).

