### PR TITLE
fix(genkit_openai): populate usage metadata for streaming and non-streaming responses

### DIFF
--- a/packages/genkit_openai/lib/src/converters.dart
+++ b/packages/genkit_openai/lib/src/converters.dart
@@ -263,4 +263,17 @@ abstract final class GenkitConverter {
       _ => FinishReason.unknown,
     };
   }
+
+  /// Map OpenAI token usage to Genkit [GenerationUsage].
+  static GenerationUsage? mapUsage(sdk.Usage? usage) {
+    if (usage == null) return null;
+    return GenerationUsage(
+      inputTokens: usage.promptTokens.toDouble(),
+      outputTokens: usage.completionTokens?.toDouble(),
+      totalTokens: usage.totalTokens.toDouble(),
+      thoughtsTokens: usage.completionTokensDetails?.reasoningTokens
+          ?.toDouble(),
+      cachedContentTokens: usage.promptTokensDetails?.cachedTokens?.toDouble(),
+    );
+  }
 }

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -298,7 +298,10 @@ class OpenAIPlugin extends GenkitPlugin {
     })
     ctx,
   ) async {
-    final stream = client.chat.completions.createStream(request);
+    final streamRequest = request.copyWith(
+      streamOptions: const sdk.StreamOptions(includeUsage: true),
+    );
+    final stream = client.chat.completions.createStream(streamRequest);
     final accumulator = sdk.ChatStreamAccumulator();
 
     try {
@@ -328,6 +331,7 @@ class OpenAIPlugin extends GenkitPlugin {
     return ModelResponse(
       finishReason: GenkitConverter.mapFinishReason(choice.finishReason?.name),
       message: message,
+      usage: GenkitConverter.mapUsage(response.usage),
       raw: response.toJson(),
     );
   }
@@ -349,6 +353,7 @@ class OpenAIPlugin extends GenkitPlugin {
     return ModelResponse(
       finishReason: GenkitConverter.mapFinishReason(choice.finishReason?.name),
       message: message,
+      usage: GenkitConverter.mapUsage(response.usage),
       raw: response.toJson(),
     );
   }

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -37,6 +37,9 @@ class OpenAIPlugin extends GenkitPlugin {
   final OpenAIApiKeyProvider? apiKeyProvider;
 
   /// Custom base URL for OpenAI-compatible APIs (e.g. Groq, DeepSeek).
+  ///
+  /// Streaming requests always send `stream_options.include_usage`; endpoints
+  /// that reject unknown stream options will refuse streaming calls.
   final String? baseUrl;
 
   /// Additional models to register beyond those discovered from the API.

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -25,122 +25,106 @@ void main() {
   final apiKey = Platform.environment['OPENAI_API_KEY'];
 
   group('Integration Tests', () {
-    test(
-      'generates text with GPT-4o',
-      () async {
-        if (apiKey == null || apiKey.isEmpty) {
-          fail(
-            'OPENAI_API_KEY environment variable must be set to run integration tests',
-          );
-        }
-
-        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
-
-        final response = await ai.generate(
-          model: openAI.model('gpt-4o'),
-          prompt: 'Say "hello" and nothing else.',
+    test('generates text with GPT-4o', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
         );
+      }
 
-        expect(response.text, isNotEmpty);
-        expect(response.text.toLowerCase(), contains('hello'));
-      },
-      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
-    );
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
-    test(
-      'generates text with custom options',
-      () async {
-        if (apiKey == null || apiKey.isEmpty) {
-          fail(
-            'OPENAI_API_KEY environment variable must be set to run integration tests',
-          );
-        }
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Say "hello" and nothing else.',
+      );
 
-        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+      expect(response.text, isNotEmpty);
+      expect(response.text.toLowerCase(), contains('hello'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
 
-        final response = await ai.generate(
-          model: openAI.model('gpt-4o'),
-          prompt: 'Write a haiku about Dart.',
-          config: OpenAIChatOptions(temperature: 0.7, maxTokens: 100),
+    test('generates text with custom options', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
         );
+      }
 
-        expect(response.text, isNotEmpty);
-        expect(response.text.length, lessThan(200));
-      },
-      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
-    );
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
-    test(
-      'streaming generation',
-      () async {
-        if (apiKey == null || apiKey.isEmpty) {
-          fail(
-            'OPENAI_API_KEY environment variable must be set to run integration tests',
-          );
-        }
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Write a haiku about Dart.',
+        config: OpenAIChatOptions(temperature: 0.7, maxTokens: 100),
+      );
 
-        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+      expect(response.text, isNotEmpty);
+      expect(response.text.length, lessThan(200));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
 
-        final chunks = <GenerateResponseChunk>[];
-        await for (final chunk in ai.generateStream(
-          model: openAI.model('gpt-4o'),
-          prompt: 'Count from 1 to 5.',
-        )) {
-          chunks.add(chunk);
-        }
-
-        expect(chunks.length, greaterThan(0));
-        final fullText = chunks
-            .expand((c) => c.content)
-            .where((p) => p.isText)
-            .map((p) => p.text!)
-            .join('');
-        expect(fullText.toLowerCase(), contains('1'));
-      },
-      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
-    );
-
-    test(
-      'tool calling',
-      () async {
-        if (apiKey == null || apiKey.isEmpty) {
-          fail(
-            'OPENAI_API_KEY environment variable must be set to run integration tests',
-          );
-        }
-
-        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
-
-        ai.defineTool(
-          name: 'getWeather',
-          description: 'Get the weather for a location',
-          inputSchema: WeatherInputSchema.$schema,
-          fn: (input, ctx) async {
-            return {'temperature': 72, 'condition': 'sunny'};
-          },
+    test('streaming generation', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
         );
+      }
 
-        final response = await ai.generate(
-          model: openAI.model('gpt-4o'),
-          prompt: 'What\'s the weather in Boston?',
-          toolNames: ['getWeather'],
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final chunks = <GenerateResponseChunk>[];
+      await for (final chunk in ai.generateStream(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Count from 1 to 5.',
+      )) {
+        chunks.add(chunk);
+      }
+
+      expect(chunks.length, greaterThan(0));
+      final fullText = chunks
+          .expand((c) => c.content)
+          .where((p) => p.isText)
+          .map((p) => p.text!)
+          .join('');
+      expect(fullText.toLowerCase(), contains('1'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('tool calling', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
         );
+      }
 
-        // Note: This test verifies that tools can be called successfully.
-        // However, GPT-4o may choose to answer directly without calling the tool
-        // since it has general knowledge about typical weather patterns.
-        // The important thing is that the request succeeds and we get a response.
-        expect(response.message, isNotNull);
-        expect(response.message!.content, isNotEmpty);
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
-        // Verify the response has either text or tool requests (both are valid)
-        final hasContent = response.message!.content.any(
-          (p) => p.isText || p.isToolRequest,
-        );
-        expect(hasContent, isTrue);
-      },
-      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
-    );
+      ai.defineTool(
+        name: 'getWeather',
+        description: 'Get the weather for a location',
+        inputSchema: WeatherInputSchema.$schema,
+        fn: (input, ctx) async {
+          return {'temperature': 72, 'condition': 'sunny'};
+        },
+      );
+
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'What\'s the weather in Boston?',
+        toolNames: ['getWeather'],
+      );
+
+      // Note: This test verifies that tools can be called successfully.
+      // However, GPT-4o may choose to answer directly without calling the tool
+      // since it has general knowledge about typical weather patterns.
+      // The important thing is that the request succeeds and we get a response.
+      expect(response.message, isNotNull);
+      expect(response.message!.content, isNotEmpty);
+
+      // Verify the response has either text or tool requests (both are valid)
+      final hasContent = response.message!.content.any(
+        (p) => p.isText || p.isToolRequest,
+      );
+      expect(hasContent, isTrue);
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
 
     group('Structured output', () {
       test(
@@ -199,75 +183,67 @@ void main() {
       );
     });
 
-    test(
-      'multi-turn conversation',
-      () async {
-        if (apiKey == null || apiKey.isEmpty) {
-          fail(
-            'OPENAI_API_KEY environment variable must be set to run integration tests',
-          );
-        }
-
-        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
-
-        final response1 = await ai.generate(
-          model: openAI.model('gpt-4o'),
-          prompt: 'My name is Alice.',
+    test('multi-turn conversation', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
         );
+      }
 
-        final response2 = await ai.generate(
-          model: openAI.model('gpt-4o'),
-          messages: [
-            Message(
-              role: Role.user,
-              content: [TextPart(text: 'My name is Alice.')],
-            ),
-            Message(
-              role: Role.model,
-              content: [TextPart(text: response1.text)],
-            ),
-            Message(
-              role: Role.user,
-              content: [TextPart(text: 'What is my name?')],
-            ),
-          ],
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final response1 = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'My name is Alice.',
+      );
+
+      final response2 = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        messages: [
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'My name is Alice.')],
+          ),
+          Message(
+            role: Role.model,
+            content: [TextPart(text: response1.text)],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'What is my name?')],
+          ),
+        ],
+      );
+
+      expect(response2.text, isNotEmpty);
+      expect(response2.text.toLowerCase(), contains('alice'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('reports token usage for non-streaming and streaming', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
         );
+      }
 
-        expect(response2.text, isNotEmpty);
-        expect(response2.text.toLowerCase(), contains('alice'));
-      },
-      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
-    );
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
-    test(
-      'reports token usage for non-streaming and streaming',
-      () async {
-        if (apiKey == null || apiKey.isEmpty) {
-          fail(
-            'OPENAI_API_KEY environment variable must be set to run integration tests',
-          );
-        }
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Say hello.',
+      );
+      expect(response.usage?.inputTokens, greaterThan(0));
+      expect(response.usage?.outputTokens, greaterThan(0));
+      expect(response.usage?.totalTokens, greaterThan(0));
 
-        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
-
-        final response = await ai.generate(
-          model: openAI.model('gpt-4o'),
-          prompt: 'Say hello.',
-        );
-        expect(response.usage?.inputTokens, greaterThan(0));
-        expect(response.usage?.outputTokens, greaterThan(0));
-        expect(response.usage?.totalTokens, greaterThan(0));
-
-        final stream = ai.generateStream(
-          model: openAI.model('gpt-4o'),
-          prompt: 'Say hello.',
-        );
-        await for (final _ in stream) {}
-        final result = await stream.onResult;
-        expect(result.usage?.totalTokens, greaterThan(0));
-      },
-      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
-    );
+      final stream = ai.generateStream(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Say hello.',
+      );
+      await for (final _ in stream) {}
+      final result = await stream.onResult;
+      expect(result.usage?.totalTokens, greaterThan(0));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
   });
 }
 

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -25,106 +25,122 @@ void main() {
   final apiKey = Platform.environment['OPENAI_API_KEY'];
 
   group('Integration Tests', () {
-    test('generates text with GPT-4o', () async {
-      if (apiKey == null || apiKey.isEmpty) {
-        fail(
-          'OPENAI_API_KEY environment variable must be set to run integration tests',
+    test(
+      'generates text with GPT-4o',
+      () async {
+        if (apiKey == null || apiKey.isEmpty) {
+          fail(
+            'OPENAI_API_KEY environment variable must be set to run integration tests',
+          );
+        }
+
+        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+        final response = await ai.generate(
+          model: openAI.model('gpt-4o'),
+          prompt: 'Say "hello" and nothing else.',
         );
-      }
 
-      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+        expect(response.text, isNotEmpty);
+        expect(response.text.toLowerCase(), contains('hello'));
+      },
+      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
+    );
 
-      final response = await ai.generate(
-        model: openAI.model('gpt-4o'),
-        prompt: 'Say "hello" and nothing else.',
-      );
+    test(
+      'generates text with custom options',
+      () async {
+        if (apiKey == null || apiKey.isEmpty) {
+          fail(
+            'OPENAI_API_KEY environment variable must be set to run integration tests',
+          );
+        }
 
-      expect(response.text, isNotEmpty);
-      expect(response.text.toLowerCase(), contains('hello'));
-    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
-    test('generates text with custom options', () async {
-      if (apiKey == null || apiKey.isEmpty) {
-        fail(
-          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        final response = await ai.generate(
+          model: openAI.model('gpt-4o'),
+          prompt: 'Write a haiku about Dart.',
+          config: OpenAIChatOptions(temperature: 0.7, maxTokens: 100),
         );
-      }
 
-      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+        expect(response.text, isNotEmpty);
+        expect(response.text.length, lessThan(200));
+      },
+      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
+    );
 
-      final response = await ai.generate(
-        model: openAI.model('gpt-4o'),
-        prompt: 'Write a haiku about Dart.',
-        config: OpenAIChatOptions(temperature: 0.7, maxTokens: 100),
-      );
+    test(
+      'streaming generation',
+      () async {
+        if (apiKey == null || apiKey.isEmpty) {
+          fail(
+            'OPENAI_API_KEY environment variable must be set to run integration tests',
+          );
+        }
 
-      expect(response.text, isNotEmpty);
-      expect(response.text.length, lessThan(200));
-    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
-    test('streaming generation', () async {
-      if (apiKey == null || apiKey.isEmpty) {
-        fail(
-          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        final chunks = <GenerateResponseChunk>[];
+        await for (final chunk in ai.generateStream(
+          model: openAI.model('gpt-4o'),
+          prompt: 'Count from 1 to 5.',
+        )) {
+          chunks.add(chunk);
+        }
+
+        expect(chunks.length, greaterThan(0));
+        final fullText = chunks
+            .expand((c) => c.content)
+            .where((p) => p.isText)
+            .map((p) => p.text!)
+            .join('');
+        expect(fullText.toLowerCase(), contains('1'));
+      },
+      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
+    );
+
+    test(
+      'tool calling',
+      () async {
+        if (apiKey == null || apiKey.isEmpty) {
+          fail(
+            'OPENAI_API_KEY environment variable must be set to run integration tests',
+          );
+        }
+
+        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+        ai.defineTool(
+          name: 'getWeather',
+          description: 'Get the weather for a location',
+          inputSchema: WeatherInputSchema.$schema,
+          fn: (input, ctx) async {
+            return {'temperature': 72, 'condition': 'sunny'};
+          },
         );
-      }
 
-      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
-
-      final chunks = <GenerateResponseChunk>[];
-      await for (final chunk in ai.generateStream(
-        model: openAI.model('gpt-4o'),
-        prompt: 'Count from 1 to 5.',
-      )) {
-        chunks.add(chunk);
-      }
-
-      expect(chunks.length, greaterThan(0));
-      final fullText = chunks
-          .expand((c) => c.content)
-          .where((p) => p.isText)
-          .map((p) => p.text!)
-          .join('');
-      expect(fullText.toLowerCase(), contains('1'));
-    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
-
-    test('tool calling', () async {
-      if (apiKey == null || apiKey.isEmpty) {
-        fail(
-          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        final response = await ai.generate(
+          model: openAI.model('gpt-4o'),
+          prompt: 'What\'s the weather in Boston?',
+          toolNames: ['getWeather'],
         );
-      }
 
-      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+        // Note: This test verifies that tools can be called successfully.
+        // However, GPT-4o may choose to answer directly without calling the tool
+        // since it has general knowledge about typical weather patterns.
+        // The important thing is that the request succeeds and we get a response.
+        expect(response.message, isNotNull);
+        expect(response.message!.content, isNotEmpty);
 
-      ai.defineTool(
-        name: 'getWeather',
-        description: 'Get the weather for a location',
-        inputSchema: WeatherInputSchema.$schema,
-        fn: (input, ctx) async {
-          return {'temperature': 72, 'condition': 'sunny'};
-        },
-      );
-
-      final response = await ai.generate(
-        model: openAI.model('gpt-4o'),
-        prompt: 'What\'s the weather in Boston?',
-        toolNames: ['getWeather'],
-      );
-
-      // Note: This test verifies that tools can be called successfully.
-      // However, GPT-4o may choose to answer directly without calling the tool
-      // since it has general knowledge about typical weather patterns.
-      // The important thing is that the request succeeds and we get a response.
-      expect(response.message, isNotNull);
-      expect(response.message!.content, isNotEmpty);
-
-      // Verify the response has either text or tool requests (both are valid)
-      final hasContent = response.message!.content.any(
-        (p) => p.isText || p.isToolRequest,
-      );
-      expect(hasContent, isTrue);
-    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+        // Verify the response has either text or tool requests (both are valid)
+        final hasContent = response.message!.content.any(
+          (p) => p.isText || p.isToolRequest,
+        );
+        expect(hasContent, isTrue);
+      },
+      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
+    );
 
     group('Structured output', () {
       test(
@@ -183,41 +199,75 @@ void main() {
       );
     });
 
-    test('multi-turn conversation', () async {
-      if (apiKey == null || apiKey.isEmpty) {
-        fail(
-          'OPENAI_API_KEY environment variable must be set to run integration tests',
+    test(
+      'multi-turn conversation',
+      () async {
+        if (apiKey == null || apiKey.isEmpty) {
+          fail(
+            'OPENAI_API_KEY environment variable must be set to run integration tests',
+          );
+        }
+
+        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+        final response1 = await ai.generate(
+          model: openAI.model('gpt-4o'),
+          prompt: 'My name is Alice.',
         );
-      }
 
-      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+        final response2 = await ai.generate(
+          model: openAI.model('gpt-4o'),
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'My name is Alice.')],
+            ),
+            Message(
+              role: Role.model,
+              content: [TextPart(text: response1.text)],
+            ),
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'What is my name?')],
+            ),
+          ],
+        );
 
-      final response1 = await ai.generate(
-        model: openAI.model('gpt-4o'),
-        prompt: 'My name is Alice.',
-      );
+        expect(response2.text, isNotEmpty);
+        expect(response2.text.toLowerCase(), contains('alice'));
+      },
+      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
+    );
 
-      final response2 = await ai.generate(
-        model: openAI.model('gpt-4o'),
-        messages: [
-          Message(
-            role: Role.user,
-            content: [TextPart(text: 'My name is Alice.')],
-          ),
-          Message(
-            role: Role.model,
-            content: [TextPart(text: response1.text)],
-          ),
-          Message(
-            role: Role.user,
-            content: [TextPart(text: 'What is my name?')],
-          ),
-        ],
-      );
+    test(
+      'reports token usage for non-streaming and streaming',
+      () async {
+        if (apiKey == null || apiKey.isEmpty) {
+          fail(
+            'OPENAI_API_KEY environment variable must be set to run integration tests',
+          );
+        }
 
-      expect(response2.text, isNotEmpty);
-      expect(response2.text.toLowerCase(), contains('alice'));
-    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+        final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+        final response = await ai.generate(
+          model: openAI.model('gpt-4o'),
+          prompt: 'Say hello.',
+        );
+        expect(response.usage?.inputTokens, greaterThan(0));
+        expect(response.usage?.outputTokens, greaterThan(0));
+        expect(response.usage?.totalTokens, greaterThan(0));
+
+        final stream = ai.generateStream(
+          model: openAI.model('gpt-4o'),
+          prompt: 'Say hello.',
+        );
+        await for (final _ in stream) {}
+        final result = await stream.onResult;
+        expect(result.usage?.totalTokens, greaterThan(0));
+      },
+      skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null,
+    );
   });
 }
 

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -242,6 +242,8 @@ void main() {
       );
       await for (final _ in stream) {}
       final result = await stream.onResult;
+      expect(result.usage?.inputTokens, greaterThan(0));
+      expect(result.usage?.outputTokens, greaterThan(0));
       expect(result.usage?.totalTokens, greaterThan(0));
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
   });

--- a/packages/genkit_openai/test/openai_plugin_converter_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_converter_test.dart
@@ -18,11 +18,14 @@ import 'package:openai_dart/openai_dart.dart'
     show
         AssistantMessage,
         ChatMessage,
+        CompletionTokensDetails,
         ContentPart,
         FunctionCall,
+        PromptTokensDetails,
         SystemMessage,
         ToolCall,
         ToolMessage,
+        Usage,
         UserMessage;
 import 'package:test/test.dart';
 
@@ -330,6 +333,40 @@ void main() {
     test('maps unknown', () {
       expect(GenkitConverter.mapFinishReason('unknown'), FinishReason.unknown);
       expect(GenkitConverter.mapFinishReason(null), FinishReason.unknown);
+    });
+  });
+  group('GenkitConverter.mapUsage', () {
+    test('maps all fields including details', () {
+      final usage = GenkitConverter.mapUsage(
+        const Usage(
+          promptTokens: 15,
+          completionTokens: 7,
+          totalTokens: 22,
+          promptTokensDetails: PromptTokensDetails(cachedTokens: 5),
+          completionTokensDetails: CompletionTokensDetails(reasoningTokens: 3),
+        ),
+      );
+
+      expect(usage?.inputTokens, 15);
+      expect(usage?.outputTokens, 7);
+      expect(usage?.totalTokens, 22);
+      expect(usage?.cachedContentTokens, 5);
+      expect(usage?.thoughtsTokens, 3);
+    });
+
+    test('nullable fields stay null', () {
+      final usage = GenkitConverter.mapUsage(
+        const Usage(promptTokens: 15, totalTokens: 15),
+      );
+
+      expect(usage?.inputTokens, 15);
+      expect(usage?.outputTokens, isNull);
+      expect(usage?.thoughtsTokens, isNull);
+      expect(usage?.cachedContentTokens, isNull);
+    });
+
+    test('null usage maps to null', () {
+      expect(GenkitConverter.mapUsage(null), isNull);
     });
   });
 }

--- a/packages/genkit_openai/test/openai_plugin_usage_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_usage_wire_test.dart
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+// TODO(#366): consolidate with the wire harness in other wire tests once the
+// shared fake-server harness lands.
+/// Captures every chat-completions request body the plugin puts on the wire
+/// and serves canned OpenAI responses (JSON or SSE for streaming requests).
+MockClient wireClient(List<Map<String, dynamic>> capturedBodies) {
+  return MockClient((request) async {
+    if (request.url.path.endsWith('/models')) {
+      return http.Response(
+        jsonEncode({
+          'object': 'list',
+          'data': [
+            {
+              'id': 'gpt-4o',
+              'object': 'model',
+              'created': 0,
+              'owned_by': 'openai',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (request.url.path.endsWith('/chat/completions')) {
+      final body = (jsonDecode(request.body) as Map).cast<String, dynamic>();
+      capturedBodies.add(body);
+      if (body['stream'] == true) {
+        return http.Response(
+          '''
+data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}
+
+data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":7,"total_tokens":22}}
+
+data: [DONE]
+
+''',
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        );
+      }
+      return http.Response(
+        jsonEncode({
+          'id': 'chatcmpl-test',
+          'object': 'chat.completion',
+          'created': 0,
+          'model': 'gpt-4o',
+          'choices': [
+            {
+              'index': 0,
+              'message': {'role': 'assistant', 'content': 'ok'},
+              'finish_reason': 'stop',
+            },
+          ],
+          'usage': {
+            'prompt_tokens': 15,
+            'completion_tokens': 7,
+            'total_tokens': 22,
+            'prompt_tokens_details': {'cached_tokens': 5},
+            'completion_tokens_details': {'reasoning_tokens': 3},
+          },
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('not found', 404);
+  });
+}
+
+void main() {
+  group('usage metadata on the wire', () {
+    test('non-streaming response populates usage', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Say hello.',
+      );
+
+      expect(response.usage, isNotNull);
+      expect(response.usage?.inputTokens, 15);
+      expect(response.usage?.outputTokens, 7);
+      expect(response.usage?.totalTokens, 22);
+      expect(response.usage?.thoughtsTokens, 3);
+      expect(response.usage?.cachedContentTokens, 5);
+
+      await ai.shutdown();
+    });
+
+    test('streaming request opts into usage reporting', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+
+      final stream = ai.generateStream(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Say hello.',
+      );
+      await for (final _ in stream) {}
+
+      expect(captured.single['stream_options'], {'include_usage': true});
+
+      await ai.shutdown();
+    });
+
+    test('streaming response populates usage from the final chunk', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+
+      final stream = ai.generateStream(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Say hello.',
+      );
+      await for (final _ in stream) {}
+      final result = await stream.onResult;
+
+      expect(result.usage, isNotNull);
+      expect(result.usage?.inputTokens, 15);
+      expect(result.usage?.outputTokens, 7);
+      expect(result.usage?.totalTokens, 22);
+
+      await ai.shutdown();
+    });
+  });
+}

--- a/packages/genkit_openai/test/openai_plugin_usage_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_usage_wire_test.dart
@@ -141,8 +141,16 @@ void main() {
         model: openAI.model('gpt-4o'),
         prompt: 'Say hello.',
       );
-      await for (final _ in stream) {}
+      final chunks = <GenerateResponseChunk>[];
+      await for (final chunk in stream) {
+        chunks.add(chunk);
+      }
       final result = await stream.onResult;
+
+      // The terminal usage frame has an empty choices array and must not
+      // surface as a content chunk.
+      expect(chunks, hasLength(1));
+      expect(chunks.single.text, 'Hello');
 
       expect(result.usage, isNotNull);
       expect(result.usage?.inputTokens, 15);


### PR DESCRIPTION
Fixes #358

`ModelResponse.usage` was never populated - token accounting blank for every user, both modes. Verified live: `response.usage: null` while the raw response carried `{prompt_tokens: 31, completion_tokens: 2, total_tokens: 33}`.

Fix: map the SDK usage block (prompt/completion/total + cached and reasoning details) into `GenerationUsage` on both response paths, and opt streaming requests in via `stream_options.include_usage` (JS parity). The SDK accumulator already carries final-chunk usage, so streaming needed only the opt-in and the mapping.

Red/green commits: four failing tests first (wire non-streaming incl. detail fields, streaming request body, streaming usage from the terminal SSE frame incl. a no-spurious-chunk pin, key-gated live), then the fix + converter unit tests.

Notes: `include_usage` is sent unconditionally, matching JS - strict compat endpoints that reject unknown stream options have no opt-out, same as JS. Wire harness duplicated from #370 pending #366; the two PRs merge in any order.
