### PR TITLE
fix(genkit_openai): reject non-object tool input schemas with a clear error

### DIFF
--- a/packages/genkit_openai/lib/src/converters.dart
+++ b/packages/genkit_openai/lib/src/converters.dart
@@ -205,6 +205,14 @@ abstract final class GenkitConverter {
     } else if (!parameters.containsKey('type')) {
       // Ensure the schema has a type field
       parameters = {'type': 'object', ...parameters};
+    } else if (parameters['type'] != 'object') {
+      // OpenAI only accepts object-typed tool parameter schemas.
+      throw GenkitException(
+        'OpenAI requires tool parameters to be an object schema; tool '
+        '"${tool.name}" declares type "${parameters['type']}". '
+        'Wrap the input in an object schema.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
     }
 
     return sdk.Tool.function(

--- a/packages/genkit_openai/test/openai_plugin_converter_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_converter_test.dart
@@ -277,27 +277,29 @@ void main() {
     });
 
     test('converts JSON content', () {
-      final message = ChatMessage.assistant(
-        content: '{"name": "Test", "age": 25}',
-      ) as AssistantMessage;
+      final message =
+          ChatMessage.assistant(content: '{"name": "Test", "age": 25}')
+              as AssistantMessage;
       final genkitMessage = GenkitConverter.fromOpenAIAssistantMessage(message);
       expect(genkitMessage.role, Role.model);
       expect(genkitMessage.text, '{"name": "Test", "age": 25}');
     });
 
     test('converts message with tool calls', () {
-      final message = ChatMessage.assistant(
-        content: '{"result": "ok"}',
-        toolCalls: [
-          ToolCall.functionCall(
-            id: 'call_123',
-            call: FunctionCall(
-              name: 'getWeather',
-              arguments: '{"location": "NYC"}',
-            ),
-          ),
-        ],
-      ) as AssistantMessage;
+      final message =
+          ChatMessage.assistant(
+                content: '{"result": "ok"}',
+                toolCalls: [
+                  ToolCall.functionCall(
+                    id: 'call_123',
+                    call: FunctionCall(
+                      name: 'getWeather',
+                      arguments: '{"location": "NYC"}',
+                    ),
+                  ),
+                ],
+              )
+              as AssistantMessage;
       final genkitMessage = GenkitConverter.fromOpenAIAssistantMessage(message);
       expect(genkitMessage.text, '{"result": "ok"}');
       final toolParts = genkitMessage.content

--- a/packages/genkit_openai/test/openai_plugin_converter_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_converter_test.dart
@@ -277,29 +277,27 @@ void main() {
     });
 
     test('converts JSON content', () {
-      final message =
-          ChatMessage.assistant(content: '{"name": "Test", "age": 25}')
-              as AssistantMessage;
+      final message = ChatMessage.assistant(
+        content: '{"name": "Test", "age": 25}',
+      ) as AssistantMessage;
       final genkitMessage = GenkitConverter.fromOpenAIAssistantMessage(message);
       expect(genkitMessage.role, Role.model);
       expect(genkitMessage.text, '{"name": "Test", "age": 25}');
     });
 
     test('converts message with tool calls', () {
-      final message =
-          ChatMessage.assistant(
-                content: '{"result": "ok"}',
-                toolCalls: [
-                  ToolCall.functionCall(
-                    id: 'call_123',
-                    call: FunctionCall(
-                      name: 'getWeather',
-                      arguments: '{"location": "NYC"}',
-                    ),
-                  ),
-                ],
-              )
-              as AssistantMessage;
+      final message = ChatMessage.assistant(
+        content: '{"result": "ok"}',
+        toolCalls: [
+          ToolCall.functionCall(
+            id: 'call_123',
+            call: FunctionCall(
+              name: 'getWeather',
+              arguments: '{"location": "NYC"}',
+            ),
+          ),
+        ],
+      ) as AssistantMessage;
       final genkitMessage = GenkitConverter.fromOpenAIAssistantMessage(message);
       expect(genkitMessage.text, '{"result": "ok"}');
       final toolParts = genkitMessage.content
@@ -367,6 +365,27 @@ void main() {
 
     test('null usage maps to null', () {
       expect(GenkitConverter.mapUsage(null), isNull);
+    });
+  });
+
+  group('GenkitConverter.toOpenAITool schema guards', () {
+    test('non-object input schema throws INVALID_ARGUMENT', () {
+      expect(
+        () => GenkitConverter.toOpenAITool(
+          ToolDefinition(
+            name: 'echo',
+            description: 'Echoes the input',
+            inputSchema: {'type': 'string'},
+          ),
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('echo'), contains('object')),
+          ),
+        ),
+      );
     });
   });
 }

--- a/packages/genkit_openai/test/openai_plugin_converter_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_converter_test.dart
@@ -369,6 +369,26 @@ void main() {
   });
 
   group('GenkitConverter.toOpenAITool schema guards', () {
+    test('schema without a type key is defaulted to object', () {
+      final result = GenkitConverter.toOpenAITool(
+        ToolDefinition(
+          name: 'echo',
+          description: 'Echoes the input',
+          inputSchema: {
+            'properties': {
+              'text': {'type': 'string'},
+            },
+          },
+        ),
+      );
+      expect(result.function.parameters, {
+        'type': 'object',
+        'properties': {
+          'text': {'type': 'string'},
+        },
+      });
+    });
+
     test('non-object input schema throws INVALID_ARGUMENT', () {
       expect(
         () => GenkitConverter.toOpenAITool(

--- a/packages/genkit_openai/test/openai_plugin_tool_schema_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_tool_schema_wire_test.dart
@@ -1,0 +1,169 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+// TODO(#366): consolidate with the shared wire harness once it lands.
+/// Captures every chat-completions request body the plugin puts on the wire
+/// and serves canned OpenAI responses.
+MockClient wireClient(List<Map<String, dynamic>> capturedBodies) {
+  return MockClient((request) async {
+    if (request.url.path.endsWith('/models')) {
+      return http.Response(
+        jsonEncode({
+          'object': 'list',
+          'data': [
+            {
+              'id': 'gpt-4o',
+              'object': 'model',
+              'created': 0,
+              'owned_by': 'openai',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (request.url.path.endsWith('/chat/completions')) {
+      capturedBodies.add(
+        (jsonDecode(request.body) as Map).cast<String, dynamic>(),
+      );
+      return http.Response(
+        jsonEncode({
+          'id': 'chatcmpl-test',
+          'object': 'chat.completion',
+          'created': 0,
+          'model': 'gpt-4o',
+          'choices': [
+            {
+              'index': 0,
+              'message': {'role': 'assistant', 'content': 'ok'},
+              'finish_reason': 'stop',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('not found', 404);
+  });
+}
+
+void main() {
+  group('tool parameter schemas on the wire', () {
+    test('schema-less tool goes out as an empty object schema', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+      ai.defineTool(
+        name: 'getWeather',
+        description: 'Get the weather for a location',
+        fn: (input, ctx) async => {'temperature': 72},
+      );
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'What is the weather in Boston?',
+        toolNames: ['getWeather'],
+      );
+
+      final tools = (captured.single['tools'] as List)
+          .cast<Map<String, dynamic>>();
+      final function = (tools.single['function'] as Map)
+          .cast<String, dynamic>();
+      expect(function['parameters'], {'type': 'object', 'properties': {}});
+
+      await ai.shutdown();
+    });
+
+    test(
+      'tool with a primitive input schema fails before any request',
+      () async {
+        final captured = <Map<String, dynamic>>[];
+        final ai = Genkit(
+          plugins: [
+            openAI(apiKey: 'test-key', httpClient: wireClient(captured)),
+          ],
+        );
+        ai.defineTool<String, String>(
+          name: 'echo',
+          description: 'Echoes the input',
+          inputSchema: .string(),
+          outputSchema: .string(),
+          fn: (input, ctx) async => input,
+        );
+
+        await expectLater(
+          ai.generate(
+            model: openAI.model('gpt-4o'),
+            prompt: 'Echo hello.',
+            toolNames: ['echo'],
+          ),
+          throwsA(
+            isA<GenkitException>().having(
+              (e) => e.message,
+              'message',
+              allOf(contains('echo'), contains('object')),
+            ),
+          ),
+        );
+        expect(captured, isEmpty);
+
+        await ai.shutdown();
+      },
+    );
+  });
+
+  group('live', () {
+    final apiKey = Platform.environment['OPENAI_API_KEY'];
+
+    test('schema-less tool round-trips against the real API', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+      var toolRan = false;
+      ai.defineTool(
+        name: 'getTime',
+        description: 'Returns the current time',
+        fn: (input, ctx) async {
+          toolRan = true;
+          return {'time': '12:00'};
+        },
+      );
+
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Use the getTime tool to tell me the current time.',
+        toolNames: ['getTime'],
+      );
+
+      expect(response.message, isNotNull);
+      expect(toolRan, isTrue);
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+  });
+}


### PR DESCRIPTION
Fixes #371

A tool with a primitive input schema (`.string()`, int, bool, list) reached OpenAI as `parameters: {"type": "string"}` and died as a cryptic server 400 mid-generate. OpenAI's tool channel is object-only end to end - function arguments are a JSON object, and the plugin decodes them as a `Map` - so primitive schemas cannot work; wrapping them would be a Dart-only protocol no other Genkit SDK speaks (JS and Go forward the schema as-is and share the footgun).

Fix: `toOpenAITool` rejects non-object schemas immediately with `INVALID_ARGUMENT`, naming the tool and the remedy. Schema-less tools are unaffected - they go out as an empty object schema, which the live API accepts (pinned by a key-gated test in this PR).

Red/green commits: pins for the two correct behaviors (schema-less → empty object on the wire, missing `type` → object) plus failing tests for the guard (wire: no request leaves; converter unit), then the guard.

Wire harness duplicated pending #366. Independent of #370 and #373; merges in any order.
