### PR TITLE
fix(genkit_google_genai): gate responseJsonSchema on constrained JSON mode

### DIFF
--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -78,6 +78,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             options,
             req.output?.schema,
             isJsonMode,
+            constrained: req.output?.constrained ?? false,
           );
           safetySettings = toGeminiSafetySettings(options.safetySettings);
           tools = toGeminiTools(
@@ -95,6 +96,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             options,
             req.output?.schema,
             isJsonMode,
+            constrained: req.output?.constrained ?? false,
           );
           safetySettings = toGeminiSafetySettings(options.safetySettings);
           tools = toGeminiTools(
@@ -260,8 +262,9 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
 gcl.GenerationConfig toGeminiSettings(
   GeminiOptions options,
   Map<String, dynamic>? outputSchema,
-  bool isJsonMode,
-) {
+  bool isJsonMode, {
+  bool constrained = false,
+}) {
   return gcl.GenerationConfig(
     candidateCount: options.candidateCount,
     stopSequences: options.stopSequences?.isEmpty ?? true
@@ -273,8 +276,10 @@ gcl.GenerationConfig toGeminiSettings(
     topK: options.topK,
     responseMimeType: isJsonMode
         ? 'application/json'
-        : (options.responseMimeType ?? ''),
-    responseJsonSchema: outputSchema,
+        : (options.responseMimeType?.isEmpty ?? true
+              ? null
+              : options.responseMimeType),
+    responseJsonSchema: constrained && isJsonMode ? outputSchema : null,
     presencePenalty: options.presencePenalty,
     frequencyPenalty: options.frequencyPenalty,
     responseLogprobs: options.responseLogprobs,
@@ -297,8 +302,9 @@ gcl.GenerationConfig toGeminiSettings(
 gcl.GenerationConfig toGeminiTtsSettings(
   GeminiTtsOptions options,
   Map<String, dynamic>? outputSchema,
-  bool isJsonMode,
-) {
+  bool isJsonMode, {
+  bool constrained = false,
+}) {
   return gcl.GenerationConfig(
     candidateCount: options.candidateCount,
     stopSequences: options.stopSequences?.isEmpty ?? true
@@ -313,7 +319,7 @@ gcl.GenerationConfig toGeminiTtsSettings(
         : (options.responseMimeType?.isEmpty ?? true
               ? null
               : options.responseMimeType),
-    responseJsonSchema: outputSchema,
+    responseJsonSchema: constrained && isJsonMode ? outputSchema : null,
     presencePenalty: options.presencePenalty,
     frequencyPenalty: options.frequencyPenalty,
     responseLogprobs: options.responseLogprobs,

--- a/packages/genkit_google_genai/test/generation_config_wire_test.dart
+++ b/packages/genkit_google_genai/test/generation_config_wire_test.dart
@@ -144,5 +144,32 @@ void main() {
       );
       expect(config, isNot(contains('responseJsonSchema')));
     });
+
+    test('TTS model JSON-mode unconstrained request sends no '
+        'responseJsonSchema', () async {
+      final config = await _generationConfigOnTheWire(
+        model: 'gemini-2.5-flash-preview-tts',
+        output: OutputConfig(
+          format: 'json',
+          schema: _schema,
+          constrained: false,
+        ),
+      );
+      expect(config['responseMimeType'], 'application/json');
+      expect(config, isNot(contains('responseJsonSchema')));
+    });
+
+    test('TTS model JSON-mode constrained request sends the '
+        'schema', () async {
+      final config = await _generationConfigOnTheWire(
+        model: 'gemini-2.5-flash-preview-tts',
+        output: OutputConfig(
+          format: 'json',
+          schema: _schema,
+          constrained: true,
+        ),
+      );
+      expect(config['responseJsonSchema'], _schema);
+    });
   });
 }

--- a/packages/genkit_google_genai/test/generation_config_wire_test.dart
+++ b/packages/genkit_google_genai/test/generation_config_wire_test.dart
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/src/api_client.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+// TODO(#366): consolidate with the shared wire harness once it lands.
+/// Captures every generateContent request body the plugin puts on the wire
+/// and serves a canned Gemini response.
+class _WirePlugin extends GoogleGenAiPluginImpl {
+  final List<Map<String, dynamic>> captured;
+
+  _WirePlugin(this.captured) : super(apiKey: 'test-key');
+
+  @override
+  Future<GenerativeLanguageBaseClient> getApiClient([
+    String? requestApiKey,
+  ]) async {
+    return GenerativeLanguageBaseClient(
+      baseUrl: 'https://example.test/',
+      client: MockClient((request) async {
+        captured.add((jsonDecode(request.body) as Map).cast<String, dynamic>());
+        return http.Response(
+          jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': 'ok'},
+                  ],
+                },
+                'finishReason': 'STOP',
+              },
+            ],
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+    );
+  }
+}
+
+const _schema = {
+  'type': 'object',
+  'properties': {
+    'answer': {'type': 'string'},
+  },
+};
+
+Future<Map<String, dynamic>> _generationConfigOnTheWire({
+  OutputConfig? output,
+  String model = 'gemini-2.0-flash',
+}) async {
+  final captured = <Map<String, dynamic>>[];
+  final plugin = _WirePlugin(captured);
+  final action = plugin.resolve('model', model) as Model;
+  await action(
+    ModelRequest(
+      messages: [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hello')],
+        ),
+      ],
+      output: output,
+    ),
+  );
+  return (captured.single['generationConfig'] as Map).cast<String, dynamic>();
+}
+
+void main() {
+  group('generationConfig on the wire', () {
+    test('text-mode request with an output schema sends no '
+        'responseJsonSchema', () async {
+      final config = await _generationConfigOnTheWire(
+        output: OutputConfig(
+          format: 'text',
+          schema: _schema,
+          constrained: true,
+        ),
+      );
+      expect(config, isNot(contains('responseJsonSchema')));
+    });
+
+    test('request without output omits responseMimeType entirely', () async {
+      final config = await _generationConfigOnTheWire();
+      expect(config, isNot(contains('responseMimeType')));
+    });
+
+    test('JSON-mode unconstrained request sends mime type but no '
+        'schema', () async {
+      final config = await _generationConfigOnTheWire(
+        output: OutputConfig(
+          format: 'json',
+          schema: _schema,
+          constrained: false,
+        ),
+      );
+      expect(config['responseMimeType'], 'application/json');
+      expect(config, isNot(contains('responseJsonSchema')));
+    });
+
+    test('JSON-mode constrained request sends application/json and the '
+        'schema', () async {
+      final config = await _generationConfigOnTheWire(
+        output: OutputConfig(
+          format: 'json',
+          schema: _schema,
+          constrained: true,
+        ),
+      );
+      expect(config['responseMimeType'], 'application/json');
+      expect(config['responseJsonSchema'], _schema);
+    });
+
+    test('TTS model text-mode request with an output schema sends no '
+        'responseJsonSchema', () async {
+      final config = await _generationConfigOnTheWire(
+        model: 'gemini-2.5-flash-preview-tts',
+        output: OutputConfig(
+          format: 'text',
+          schema: _schema,
+          constrained: true,
+        ),
+      );
+      expect(config, isNot(contains('responseJsonSchema')));
+    });
+  });
+}

--- a/packages/genkit_google_genai/test/generation_config_wire_test.dart
+++ b/packages/genkit_google_genai/test/generation_config_wire_test.dart
@@ -44,7 +44,7 @@ class _WirePlugin extends GoogleGenAiPluginImpl {
                 'content': {
                   'role': 'model',
                   'parts': [
-                    {'text': 'ok'},
+                    {'text': '"ok"'},
                   ],
                 },
                 'finishReason': 'STOP',
@@ -68,6 +68,7 @@ const _schema = {
 
 Future<Map<String, dynamic>> _generationConfigOnTheWire({
   OutputConfig? output,
+  Map<String, dynamic>? config,
   String model = 'gemini-2.0-flash',
 }) async {
   final captured = <Map<String, dynamic>>[];
@@ -81,6 +82,7 @@ Future<Map<String, dynamic>> _generationConfigOnTheWire({
           content: [TextPart(text: 'hello')],
         ),
       ],
+      config: config,
       output: output,
     ),
   );
@@ -170,6 +172,48 @@ void main() {
         ),
       );
       expect(config['responseJsonSchema'], _schema);
+    });
+
+    test('non-JSON mode passes a user-configured responseMimeType '
+        'through', () async {
+      final config = await _generationConfigOnTheWire(
+        config: {'responseMimeType': 'text/x-foo'},
+        output: OutputConfig(format: 'text'),
+      );
+      expect(config['responseMimeType'], 'text/x-foo');
+    });
+
+    test('contentType application/json alone selects JSON mode and sends '
+        'the schema', () async {
+      final config = await _generationConfigOnTheWire(
+        output: OutputConfig(
+          contentType: 'application/json',
+          schema: _schema,
+          constrained: true,
+        ),
+      );
+      expect(config['responseMimeType'], 'application/json');
+      expect(config['responseJsonSchema'], _schema);
+    });
+
+    test('full Genkit generate with outputSchema sends schema and '
+        'application/json', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [_WirePlugin(captured)],
+        promptDir: null,
+        isDevEnv: false,
+      );
+      addTearDown(ai.shutdown);
+      await ai.generate(
+        model: modelRef('googleai/gemini-2.0-flash'),
+        prompt: 'hello',
+        outputSchema: .string(),
+      );
+      final config = (captured.single['generationConfig'] as Map)
+          .cast<String, dynamic>();
+      expect(config['responseMimeType'], 'application/json');
+      expect(config['responseJsonSchema'], isNotNull);
     });
   });
 }


### PR DESCRIPTION
## Problem

Any request with an output schema attaches `responseJsonSchema`, even in text mode, and unset `responseMimeType` serializes as `""` on the wire (`common_plugin.dart:274-277`). The TTS converter shares the unconditional schema attachment. JS gates on `output.constrained && jsonMode` (`js/plugins/google-genai/src/googleai/gemini.ts:854-860`).

## Fix

Attach `responseJsonSchema` only when `constrained && isJsonMode` (both converters); omit `responseMimeType` when unset. Not porting JS's `legacyResponseSchema`: migration-only, Dart pre-1.0 has no legacy users.

One deliberate divergence: a user-configured `responseMimeType` still passes through in non-JSON mode. JS clobbers it via spread order (`gemini.ts:839-841`), which reads as a bug, not intent. Pinned by a wire test so a parity sweep can't silently revert it.

`genkit_vertexai` inherits this code path (`VertexAiPluginImpl extends CommonGoogleGenPlugin`) - same narrowing, safe direction, worth a line in its release notes.

## Tests

Wire-level: injected MockClient captures the serialized `generationConfig` (pattern from #370/#374, consolidation in #366). Red commit first; pins cover both converters in both JSON-mode directions, mimeType passthrough, `contentType: application/json` selecting JSON mode, and a full `Genkit.generate(outputSchema:)` path exercising `applyFormat`. Each pin was verified by reverting the code it guards and confirming the test fails.

Fixes #364

## Release ordering

Safe for `lite.generate` only with #377 (merged, unreleased - published core is 0.15.1): before it, lite never configured formatters and this gate would drop schemas. Bump the min `genkit` constraint to the release shipping #377 before publishing this plugin.

