### PR TITLE
fix(genkit): register formatters in lite.generate

### DIFF
--- a/packages/genkit/lib/lite.dart
+++ b/packages/genkit/lib/lite.dart
@@ -25,6 +25,7 @@ import 'dart:async';
 
 import 'package:schemantic/schemantic.dart';
 
+import 'src/ai/formatters/formatters.dart';
 import 'src/ai/generate.dart';
 import 'src/ai/generate_middleware.dart';
 import 'src/ai/generate_types.dart';
@@ -88,6 +89,7 @@ Future<GenerateResponseHelper> generate<C>({
   }
 
   final registry = Registry();
+  configureFormats(registry);
   registry.register(model);
   tools?.forEach(registry.register);
   GenerateActionOutputConfig? outputConfig;

--- a/packages/genkit/test/lite_test.dart
+++ b/packages/genkit/test/lite_test.dart
@@ -49,6 +49,62 @@ void main() {
     expect(response.text, '{"result": "success"}');
   });
 
+  test('lite generate with outputSchema delivers constrained json request '
+      'to the model', () async {
+    ModelRequest? captured;
+    final model = Model<void>(
+      name: 'constrainedTestModel',
+      fn: (request, context) async {
+        captured = request;
+        return ModelResponse(
+          finishReason: FinishReason.stop,
+          message: Message(
+            role: Role.model,
+            content: [TextPart(text: '{"result": "ok"}')],
+          ),
+        );
+      },
+    );
+
+    await lite.generate(model: model, prompt: 'Hello', outputSchema: .string());
+
+    expect(captured, isNotNull);
+    expect(captured!.output?.format, 'json');
+    expect(captured!.output?.constrained, isTrue);
+    expect(captured!.output?.schema, isNotNull);
+  });
+
+  test('lite generate with custom outputInstructions injects them into '
+      'the prompt', () async {
+    ModelRequest? captured;
+    final model = Model<void>(
+      name: 'instructionsTestModel',
+      fn: (request, context) async {
+        captured = request;
+        return ModelResponse(
+          finishReason: FinishReason.stop,
+          message: Message(
+            role: Role.model,
+            content: [TextPart(text: '{"result": "ok"}')],
+          ),
+        );
+      },
+    );
+
+    await lite.generate(
+      model: model,
+      prompt: 'Hello',
+      outputSchema: .string(),
+      outputInstructions: 'Respond in JSON matching the schema.',
+    );
+
+    final allText = captured!.messages
+        .expand((m) => m.content)
+        .map((p) => p.toJson()['text'] ?? '')
+        .join('\n');
+    expect(allText, contains('Respond in JSON matching the schema.'));
+  });
+
   test('lite generate prepends system message before prompt', () async {
     ModelRequest? captured;
     final model = Model<void>(

--- a/packages/genkit/test/lite_test.dart
+++ b/packages/genkit/test/lite_test.dart
@@ -100,7 +100,8 @@ void main() {
 
     final allText = captured!.messages
         .expand((m) => m.content)
-        .map((p) => p.toJson()['text'] ?? '')
+        .where((p) => p.isText)
+        .map((p) => p.text!)
         .join('\n');
     expect(allText, contains('Respond in JSON matching the schema.'));
   });


### PR DESCRIPTION
## Problem

`lite.generate` builds an ephemeral `Registry` and never calls `configureFormats` (only the `Genkit` class does, `genkit_class.dart:102`), so the formatter pipeline silently no-ops for lite calls:

- the json formatter's `constrained: true` default is never merged; the model plugin receives `constrained: null`
- `outputInstructions` are silently dropped

This was masked by genkit_google_genai attaching `responseJsonSchema` unconditionally; #375 makes the plugin gate on `constrained` (JS parity), which would break lite structured output without this fix. Land this first.

## Fix

One line: `configureFormats(registry)` in `lite.generate`, matching the `Genkit` class. `generateStream` delegates to `generate`, so it is covered.

Side effect worth noting: with the json formatter registered, lite responses now go through its `parseMessage` (`extractJson`) like full-Genkit responses do.

## Tests

Red commit pins both behaviors at the model-fn boundary with an in-process capture model: constrained json request delivered to the model, and custom `outputInstructions` injected into the prompt. Full core suite plus google_genai, openai, and anthropic suites pass.

Fixes #376