### PR TITLE
chore: bump dotprompt and handlebars_dart to 1.0.0

### DIFF
--- a/packages/genkit/pubspec.yaml
+++ b/packages/genkit/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  dotprompt: ^0.0.1
-  handlebars_dart: ^0.0.1
+  dotprompt: ^1.0.0
+  handlebars_dart: ^1.0.0
   http: ^1.6.0
   json_annotation: ^4.9.0
   json_schema_builder: ^0.1.3


### PR DESCRIPTION
Update dotprompt and handlebars_dart dependencies from ^0.0.1 to ^1.0.0 to use the stable releases.