### PR TITLE
fix(genkit_anthropic): send PDF media as document blocks, not image/png

### DIFF
--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -351,17 +351,26 @@ sdk.InputMessage toAnthropicMessage(Message m) {
       : sdk.InputMessage.assistantBlocks(blocks);
 }
 
+final _base64DataUrl = RegExp(r'^data:([^;,]*);base64,(.+)$');
+
 List<sdk.InputContentBlock> _convertMediaFromJson(
   String url,
   String? contentType,
 ) {
+  final declaredMime = contentType?.toLowerCase();
   if (url.startsWith('data:')) {
-    final commaIdx = url.indexOf(',');
-    final base64Data = url.substring(commaIdx + 1);
-    final urlMime = commaIdx < 0
-        ? ''
-        : url.substring('data:'.length, commaIdx).split(';').first;
-    final mimeType = urlMime.isNotEmpty ? urlMime : contentType;
+    final match = _base64DataUrl.firstMatch(url);
+    if (match == null) {
+      final preview = url.length > 64 ? '${url.substring(0, 64)}...' : url;
+      throw GenkitException(
+        'Invalid media data URL for Anthropic: expected '
+        '"data:<mime>;base64,<data>", got "$preview".',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+    final urlMime = match.group(1)!.toLowerCase();
+    final mimeType = urlMime.isNotEmpty ? urlMime : declaredMime;
+    final base64Data = match.group(2)!;
     if (mimeType == 'application/pdf') {
       return [
         sdk.InputContentBlock.document(
@@ -373,18 +382,21 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
       sdk.InputContentBlock.image(
         sdk.ImageSource.base64(
           data: base64Data,
-          mediaType: _mapImageMediaType(mimeType),
+          mediaType: _requireImageMediaType(mimeType),
         ),
       ),
     ];
   }
-  if (contentType == 'application/pdf') {
+  if (declaredMime == 'application/pdf') {
     return [sdk.InputContentBlock.document(sdk.DocumentSource.url(url))];
+  }
+  if (declaredMime != null) {
+    _requireImageMediaType(declaredMime);
   }
   return [sdk.InputContentBlock.image(sdk.ImageSource.url(url))];
 }
 
-sdk.ImageMediaType _mapImageMediaType(String? mimeType) {
+sdk.ImageMediaType _requireImageMediaType(String? mimeType) {
   return switch (mimeType) {
     'image/jpeg' || 'image/jpg' => sdk.ImageMediaType.jpeg,
     'image/png' => sdk.ImageMediaType.png,

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -358,7 +358,7 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
   String url,
   String? contentType,
 ) {
-  final declaredMime = contentType?.toLowerCase();
+  final declaredMime = _cleanMimeType(contentType);
   if (url.startsWith('data:')) {
     final comma = url.indexOf(',');
     final header = comma < 0
@@ -375,11 +375,10 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
         status: StatusCodes.INVALID_ARGUMENT,
       );
     }
-    final urlMime = header
-        .substring(0, header.length - _base64Marker.length)
-        .split(';')
-        .first;
-    final mimeType = urlMime.isNotEmpty ? urlMime : declaredMime;
+    final urlMime = _cleanMimeType(
+      header.substring(0, header.length - _base64Marker.length),
+    );
+    final mimeType = urlMime ?? declaredMime;
     if (mimeType == 'application/pdf') {
       return [
         sdk.InputContentBlock.document(
@@ -403,6 +402,11 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
     _requireImageMediaType(declaredMime);
   }
   return [sdk.InputContentBlock.image(sdk.ImageSource.url(url))];
+}
+
+String? _cleanMimeType(String? contentType) {
+  final mimeType = contentType?.split(';').first.trim().toLowerCase();
+  return mimeType?.isEmpty ?? true ? null : mimeType;
 }
 
 sdk.ImageMediaType _requireImageMediaType(String? mimeType) {

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -358,7 +358,17 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
   if (url.startsWith('data:')) {
     final commaIdx = url.indexOf(',');
     final base64Data = url.substring(commaIdx + 1);
-    final mimeType = contentType ?? 'image/png';
+    final urlMime = commaIdx < 0
+        ? ''
+        : url.substring('data:'.length, commaIdx).split(';').first;
+    final mimeType = urlMime.isNotEmpty ? urlMime : contentType;
+    if (mimeType == 'application/pdf') {
+      return [
+        sdk.InputContentBlock.document(
+          sdk.DocumentSource.base64Pdf(base64Data),
+        ),
+      ];
+    }
     return [
       sdk.InputContentBlock.image(
         sdk.ImageSource.base64(
@@ -367,17 +377,25 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
         ),
       ),
     ];
-  } else {
-    return [sdk.InputContentBlock.image(sdk.ImageSource.url(url))];
   }
+  if (contentType == 'application/pdf') {
+    return [sdk.InputContentBlock.document(sdk.DocumentSource.url(url))];
+  }
+  return [sdk.InputContentBlock.image(sdk.ImageSource.url(url))];
 }
 
-sdk.ImageMediaType _mapImageMediaType(String mimeType) {
+sdk.ImageMediaType _mapImageMediaType(String? mimeType) {
   return switch (mimeType) {
     'image/jpeg' || 'image/jpg' => sdk.ImageMediaType.jpeg,
+    'image/png' => sdk.ImageMediaType.png,
     'image/gif' => sdk.ImageMediaType.gif,
     'image/webp' => sdk.ImageMediaType.webp,
-    _ => sdk.ImageMediaType.png,
+    _ => throw GenkitException(
+      'Unsupported media type for Anthropic: ${mimeType ?? '(none)'}. '
+      'Supported: image/jpeg, image/png, image/gif, image/webp, '
+      'application/pdf.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    ),
   };
 }
 

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -351,7 +351,8 @@ sdk.InputMessage toAnthropicMessage(Message m) {
       : sdk.InputMessage.assistantBlocks(blocks);
 }
 
-final _base64DataUrl = RegExp(r'^data:([^;,]*);base64,(.+)$');
+const _base64Marker = ';base64';
+final _whitespace = RegExp(r'\s');
 
 List<sdk.InputContentBlock> _convertMediaFromJson(
   String url,
@@ -359,8 +360,14 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
 ) {
   final declaredMime = contentType?.toLowerCase();
   if (url.startsWith('data:')) {
-    final match = _base64DataUrl.firstMatch(url);
-    if (match == null) {
+    final comma = url.indexOf(',');
+    final header = comma < 0
+        ? ''
+        : url.substring('data:'.length, comma).toLowerCase();
+    final base64Data = comma < 0
+        ? ''
+        : url.substring(comma + 1).replaceAll(_whitespace, '');
+    if (!header.endsWith(_base64Marker) || base64Data.isEmpty) {
       final preview = url.length > 64 ? '${url.substring(0, 64)}...' : url;
       throw GenkitException(
         'Invalid media data URL for Anthropic: expected '
@@ -368,9 +375,11 @@ List<sdk.InputContentBlock> _convertMediaFromJson(
         status: StatusCodes.INVALID_ARGUMENT,
       );
     }
-    final urlMime = match.group(1)!.toLowerCase();
+    final urlMime = header
+        .substring(0, header.length - _base64Marker.length)
+        .split(';')
+        .first;
     final mimeType = urlMime.isNotEmpty ? urlMime : declaredMime;
-    final base64Data = match.group(2)!;
     if (mimeType == 'application/pdf') {
       return [
         sdk.InputContentBlock.document(

--- a/packages/genkit_anthropic/test/unit_test.dart
+++ b/packages/genkit_anthropic/test/unit_test.dart
@@ -196,6 +196,156 @@ void main() {
       expect(source.data, '/9j/4AAQSkZJRg==');
     });
 
+    test('should throw INVALID_ARGUMENT for a data URL without a comma', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'data:application/pdf',
+              contentType: 'application/pdf',
+            ),
+          ),
+        ],
+      );
+      expect(
+        () => toAnthropicMessage(input),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
+    test('should throw INVALID_ARGUMENT for a non-base64 data URL', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'data:application/pdf,%25PDF-1.4',
+              contentType: 'application/pdf',
+            ),
+          ),
+        ],
+      );
+      expect(
+        () => toAnthropicMessage(input),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
+    test('should throw INVALID_ARGUMENT for a remote URL with unsupported '
+        'contentType', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'https://example.com/notes.txt',
+              contentType: 'text/plain',
+            ),
+          ),
+        ],
+      );
+      expect(
+        () => toAnthropicMessage(input),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
+    test('should map remote URL without contentType to an image URL block', () {
+      final input = Message(
+        role: Role.user,
+        content: [MediaPart(media: Media(url: 'https://example.com/picture'))],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.ImageInputBlock;
+      final source = block.source as sdk.UrlImageSource;
+      expect(source.url, 'https://example.com/picture');
+    });
+
+    test('should prefer the data URL mime over contentType', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+              contentType: 'image/png',
+            ),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.ImageInputBlock;
+      final source = block.source as sdk.Base64ImageSource;
+      expect(source.mediaType, sdk.ImageMediaType.jpeg);
+    });
+
+    test('should treat media types case-insensitively', () {
+      final pdfInput = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'https://example.com/paper.pdf',
+              contentType: 'Application/PDF',
+            ),
+          ),
+        ],
+      );
+      final pdfBlock =
+          toAnthropicMessage(pdfInput).blocks.single as sdk.DocumentInputBlock;
+      expect(pdfBlock.source, isA<sdk.UrlPdfSource>());
+
+      final imageInput = Message(
+        role: Role.user,
+        content: [
+          MediaPart(media: Media(url: 'data:IMAGE/JPEG;base64,/9j/4AAQ=')),
+        ],
+      );
+      final imageBlock =
+          toAnthropicMessage(imageInput).blocks.single as sdk.ImageInputBlock;
+      expect(
+        (imageBlock.source as sdk.Base64ImageSource).mediaType,
+        sdk.ImageMediaType.jpeg,
+      );
+    });
+
+    for (final (mime, expected) in [
+      ('image/png', sdk.ImageMediaType.png),
+      ('image/jpeg', sdk.ImageMediaType.jpeg),
+      ('image/jpg', sdk.ImageMediaType.jpeg),
+      ('image/gif', sdk.ImageMediaType.gif),
+      ('image/webp', sdk.ImageMediaType.webp),
+    ]) {
+      test('should map $mime data URI to ${expected.name} media type', () {
+        final input = Message(
+          role: Role.user,
+          content: [MediaPart(media: Media(url: 'data:$mime;base64,AAAA'))],
+        );
+        final result = toAnthropicMessage(input);
+        final block = result.blocks.single as sdk.ImageInputBlock;
+        expect((block.source as sdk.Base64ImageSource).mediaType, expected);
+      });
+    }
+
     test('should throw INVALID_ARGUMENT for unsupported media types', () {
       final input = Message(
         role: Role.user,

--- a/packages/genkit_anthropic/test/unit_test.dart
+++ b/packages/genkit_anthropic/test/unit_test.dart
@@ -180,6 +180,24 @@ void main() {
       expect(source.url, 'https://example.com/paper.pdf');
     });
 
+    test('should strip media type parameters from PDF contentType', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'https://example.com/paper.pdf',
+              contentType: 'application/pdf; charset=utf-8',
+            ),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.DocumentInputBlock;
+      final source = block.source as sdk.UrlPdfSource;
+      expect(source.url, 'https://example.com/paper.pdf');
+    });
+
     test('should take image media type from the data URI', () {
       final input = Message(
         role: Role.user,
@@ -202,6 +220,26 @@ void main() {
         content: [
           MediaPart(
             media: Media(url: 'data:image/png;charset=utf-8;base64,AAAA'),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.ImageInputBlock;
+      final source = block.source as sdk.Base64ImageSource;
+      expect(source.mediaType, sdk.ImageMediaType.png);
+      expect(source.data, 'AAAA');
+    });
+
+    test('should use parameter-stripped contentType when data URL has no '
+        'media type', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'data:;base64,AAAA',
+              contentType: 'image/png; charset=utf-8',
+            ),
           ),
         ],
       );

--- a/packages/genkit_anthropic/test/unit_test.dart
+++ b/packages/genkit_anthropic/test/unit_test.dart
@@ -127,6 +127,99 @@ void main() {
       expect(blocks.first, isA<sdk.ImageInputBlock>());
     });
 
+    test('should map PDF data URI to a base64 document block', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'data:application/pdf;base64,JVBERi0xLjQ=',
+              contentType: 'application/pdf',
+            ),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final blocks = result.blocks;
+      expect(blocks.length, 1);
+      final block = blocks.first as sdk.DocumentInputBlock;
+      final source = block.source as sdk.Base64PdfSource;
+      expect(source.data, 'JVBERi0xLjQ=');
+    });
+
+    test('should map PDF data URI without contentType to a document block', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(url: 'data:application/pdf;base64,JVBERi0xLjQ='),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.DocumentInputBlock;
+      final source = block.source as sdk.Base64PdfSource;
+      expect(source.data, 'JVBERi0xLjQ=');
+    });
+
+    test('should map remote PDF URL to a URL document source', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'https://example.com/paper.pdf',
+              contentType: 'application/pdf',
+            ),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.DocumentInputBlock;
+      final source = block.source as sdk.UrlPdfSource;
+      expect(source.url, 'https://example.com/paper.pdf');
+    });
+
+    test('should take image media type from the data URI', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(url: 'data:image/jpeg;base64,/9j/4AAQSkZJRg=='),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.ImageInputBlock;
+      final source = block.source as sdk.Base64ImageSource;
+      expect(source.mediaType, sdk.ImageMediaType.jpeg);
+      expect(source.data, '/9j/4AAQSkZJRg==');
+    });
+
+    test('should throw INVALID_ARGUMENT for unsupported media types', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(
+              url: 'data:text/plain;base64,aGVsbG8=',
+              contentType: 'text/plain',
+            ),
+          ),
+        ],
+      );
+      expect(
+        () => toAnthropicMessage(input),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
     test('should filter ReasoningPart from input', () {
       final input = Message(
         role: Role.user,

--- a/packages/genkit_anthropic/test/unit_test.dart
+++ b/packages/genkit_anthropic/test/unit_test.dart
@@ -196,6 +196,37 @@ void main() {
       expect(source.data, '/9j/4AAQSkZJRg==');
     });
 
+    test('should ignore media type parameters in a data URL', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(url: 'data:image/png;charset=utf-8;base64,AAAA'),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.ImageInputBlock;
+      final source = block.source as sdk.Base64ImageSource;
+      expect(source.mediaType, sdk.ImageMediaType.png);
+      expect(source.data, 'AAAA');
+    });
+
+    test('should strip whitespace from a wrapped base64 payload', () {
+      final input = Message(
+        role: Role.user,
+        content: [
+          MediaPart(
+            media: Media(url: 'data:application/pdf;base64,JVBERi0x\nLjQ='),
+          ),
+        ],
+      );
+      final result = toAnthropicMessage(input);
+      final block = result.blocks.single as sdk.DocumentInputBlock;
+      final source = block.source as sdk.Base64PdfSource;
+      expect(source.data, 'JVBERi0xLjQ=');
+    });
+
     test('should throw INVALID_ARGUMENT for a data URL without a comma', () {
       final input = Message(
         role: Role.user,


### PR DESCRIPTION
Fixes #352

Every media part became an `InputContentBlock.image`, and `_mapImageMediaType` silently defaulted unknown mimes to `png`, so `application/pdf` input went out as an image block with PDF bytes - a guaranteed API error. The mime was never parsed from the data URL, only from `contentType`, and malformed data URLs shipped garbage payloads for the API to 400 on.

Fix: route `application/pdf` to `InputContentBlock.document` (base64 source for data URLs, URL source for remote URLs - JS parity, `runner/base.ts:125-155`). Parse the mime from the data URL header (contentType as fallback, case-insensitive) and throw `INVALID_ARGUMENT` locally on malformed input, applying the same policy to remote URLs. The data URL parse tolerates RFC 2397 media type parameters and strips whitespace from wrapped base64 payloads, both of which the Messages API needs handled before the request goes out. One deliberate deviation from the issue wording: non-PDF non-image mimes throw `INVALID_ARGUMENT` rather than becoming document blocks, matching JS, since Anthropic document sources only accept PDF/plain-text.

Red/green throughout - the package suite goes from 45 to 63 tests, and each new pin was verified by reverting the hunk it guards and confirming it fails.
