### PR TITLE
feat(genkit_anthropic): extend curated catalog to the JS/Go union with two-tier capability profiles

### DIFF
--- a/packages/genkit_anthropic/lib/src/known_models.dart
+++ b/packages/genkit_anthropic/lib/src/known_models.dart
@@ -14,25 +14,31 @@
 
 import 'package:genkit/plugin.dart';
 
-/// Capabilities every Claude model has: multiturn chat, vision (media input),
-/// tool calling with tool choice, a system role, and text output.
-final baseClaudeSupports = Map<String, dynamic>.unmodifiable({
+// A const map literal rejects duplicate keys, so 'output' cannot be spread in
+// from the base tier and then overridden.
+const _claudeSupportsCore = <String, dynamic>{
   'multiturn': true,
   'media': true,
   'tools': true,
   'toolChoice': true,
   'systemRole': true,
-  'output': List<String>.unmodifiable(['text']),
-});
+};
+
+/// Capabilities every Claude model has: multiturn chat, vision (media input),
+/// tool calling with tool choice, a system role, and text output.
+const baseClaudeSupports = <String, dynamic>{
+  ..._claudeSupportsCore,
+  'output': ['text'],
+};
 
 /// [baseClaudeSupports] plus JSON output and native constrained generation.
 ///
 /// Only models on Anthropic's Structured Outputs list may claim `constrained`.
-final structuredClaudeSupports = Map<String, dynamic>.unmodifiable({
-  ...baseClaudeSupports,
-  'output': List<String>.unmodifiable(['text', 'json']),
+const structuredClaudeSupports = <String, dynamic>{
+  ..._claudeSupportsCore,
+  'output': ['text', 'json'],
   'constrained': true,
-});
+};
 
 /// Claude models the Anthropic plugin curates capability metadata for.
 ///

--- a/packages/genkit_anthropic/lib/src/known_models.dart
+++ b/packages/genkit_anthropic/lib/src/known_models.dart
@@ -14,22 +14,47 @@
 
 import 'package:genkit/plugin.dart';
 
+/// Capabilities every Claude model has: multiturn chat, vision (media input),
+/// tool calling with tool choice, a system role, and text output.
+final baseClaudeSupports = Map<String, dynamic>.unmodifiable({
+  'multiturn': true,
+  'media': true,
+  'tools': true,
+  'toolChoice': true,
+  'systemRole': true,
+  'output': List<String>.unmodifiable(['text']),
+});
+
+/// [baseClaudeSupports] plus JSON output and native constrained generation.
+///
+/// Only models on Anthropic's Structured Outputs list may claim `constrained`.
+final structuredClaudeSupports = Map<String, dynamic>.unmodifiable({
+  ...baseClaudeSupports,
+  'output': List<String>.unmodifiable(['text', 'json']),
+  'constrained': true,
+});
+
 /// Claude models the Anthropic plugin curates capability metadata for.
 ///
 /// Each value pairs a bare model [id] (no plugin prefix) with a display
-/// [label]; [info] builds the shared Claude capability preset. Other model
-/// names still resolve dynamically via the plugin's `commonModelInfo`
+/// [label]; [info] picks the capability tier via [structuredOutputs]. Other
+/// model names still resolve dynamically via the plugin's `commonModelInfo`
 /// fallback, so this enum only enriches the names listed here.
 enum KnownClaudeModel {
   fable5('claude-fable-5', 'Claude Fable 5'),
+  opus5('claude-opus-5', 'Claude Opus 5'),
   opus48('claude-opus-4-8', 'Claude Opus 4.8'),
   opus47('claude-opus-4-7', 'Claude Opus 4.7'),
+  opus46('claude-opus-4-6', 'Claude Opus 4.6'),
+  opus45('claude-opus-4-5', 'Claude Opus 4.5'),
   sonnet5('claude-sonnet-5', 'Claude Sonnet 5'),
   sonnet46('claude-sonnet-4-6', 'Claude Sonnet 4.6'),
   sonnet45('claude-sonnet-4-5', 'Claude Sonnet 4.5'),
   haiku45('claude-haiku-4-5', 'Claude Haiku 4.5');
 
-  const KnownClaudeModel(this.id, this.label);
+  // The base tier currently has no curated member.
+  // ignore: unused_element_parameter
+  const KnownClaudeModel(this.id, this.label, {this.structuredOutputs = true});
 
   /// Bare model name (no plugin prefix).
   final String id;
@@ -37,22 +62,14 @@ enum KnownClaudeModel {
   /// Human-readable label surfaced in listings.
   final String label;
 
-  /// The capability profile shared by every current Claude model: multiturn
-  /// chat, vision (media input), tool calling with tool choice, a system role,
-  /// and native constrained generation. Mirrors the single `defaultClaudeOpts`
-  /// profile the Go plugin applies to every Claude model.
+  /// Whether the model is on Anthropic's Structured Outputs list and may
+  /// claim native constrained generation and JSON output.
+  final bool structuredOutputs;
+
+  /// Capability metadata registered for this model.
   ModelInfo get info => ModelInfo(
     label: label,
-    // Unmodifiable: curated entries are shared across every resolution of the
-    // model, so accidental mutation through action metadata must fail loudly.
-    supports: Map.unmodifiable({
-      'multiturn': true,
-      'media': true,
-      'tools': true,
-      'toolChoice': true,
-      'systemRole': true,
-      'constrained': true,
-    }),
+    supports: structuredOutputs ? structuredClaudeSupports : baseClaudeSupports,
     stage: 'stable',
   );
 }

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -27,18 +27,9 @@ import 'model.dart';
 
 final _logger = Logger('genkit_anthropic');
 
-/// Default model capabilities shared by all Anthropic Claude models.
-final commonModelInfo = ModelInfo(
-  supports: {
-    'multiturn': true,
-    'media': true,
-    'tools': true,
-    'toolChoice': true, // Anthropic supports tool choice
-    'systemRole': true,
-    'constrained':
-        true, // Supports JSON schema (via tool/constrained mode usually, or just prompt)
-  },
-);
+/// Fallback capabilities for Claude models resolved by name without a curated
+/// entry.
+final commonModelInfo = ModelInfo(supports: baseClaudeSupports);
 
 /// Core Genkit plugin implementation for Anthropic Claude models.
 ///

--- a/packages/genkit_anthropic/test/known_models_test.dart
+++ b/packages/genkit_anthropic/test/known_models_test.dart
@@ -80,6 +80,15 @@ void main() {
       expect(info.containsKey('stage'), isFalse);
     });
 
+    test('fallback metadata does not claim constrained generation', () {
+      final action = plugin().resolve('model', 'claude-unknown-model');
+
+      final supports = (modelInfoOf(action!)['supports'] as Map)
+          .cast<String, dynamic>();
+      expect(supports.containsKey('constrained'), isFalse);
+      expect(supports['output'], ['text']);
+    });
+
     test('non-model action types do not resolve', () {
       expect(plugin().resolve('embedder', 'claude-opus-4-8'), isNull);
     });
@@ -172,7 +181,7 @@ void main() {
   });
 
   group('KnownClaudeModel', () {
-    test('info carries the label, stable stage, and shared supports', () {
+    test('info carries the label, stable stage, and tiered supports', () {
       for (final model in KnownClaudeModel.values) {
         final info = model.info;
         expect(info.label, model.label);
@@ -183,27 +192,50 @@ void main() {
           'tools': true,
           'toolChoice': true,
           'systemRole': true,
-          'constrained': true,
+          if (model.structuredOutputs) ...{
+            'output': ['text', 'json'],
+            'constrained': true,
+          } else
+            'output': ['text'],
         });
       }
     });
 
-    test('supports map is unmodifiable', () {
+    test('every curated model is on the structured tier', () {
+      for (final model in KnownClaudeModel.values) {
+        expect(model.structuredOutputs, isTrue, reason: model.id);
+        expect(model.info.supports, structuredClaudeSupports);
+      }
+    });
+
+    test('base tier advertises no constrained generation', () {
+      expect(baseClaudeSupports.containsKey('constrained'), isFalse);
+      expect(baseClaudeSupports['output'], ['text']);
+    });
+
+    test('supports maps are unmodifiable on both tiers', () {
       expect(
-        () => KnownClaudeModel.opus48.info.supports!['multiturn'] = false,
+        () => structuredClaudeSupports['multiturn'] = false,
+        throwsUnsupportedError,
+      );
+      expect(
+        () => baseClaudeSupports['multiturn'] = false,
         throwsUnsupportedError,
       );
     });
   });
 
   group('knownClaudeModels', () {
-    test('exposes the curated bare model names', () {
+    test('curates exactly the supported model catalog', () {
       expect(
         knownClaudeModels.keys,
-        containsAll([
+        unorderedEquals([
           'claude-fable-5',
+          'claude-opus-5',
           'claude-opus-4-8',
           'claude-opus-4-7',
+          'claude-opus-4-6',
+          'claude-opus-4-5',
           'claude-sonnet-5',
           'claude-sonnet-4-6',
           'claude-sonnet-4-5',


### PR DESCRIPTION
Fixes #369

Follow-up to #322: grows `KnownClaudeModel` 7 -> 10, adding opus-5 (Go only) and opus-4-6/opus-4-5 (JS+Go). This is the JS/Go union MINUS three API-retired models the issue's union included: claude-opus-4-1 (retired 2026-08-05), claude-opus-4 and claude-sonnet-4 (retired 2026-06-15), per platform.claude.com/docs/en/about-claude/model-deprecations. `list()` force-lists curated entries as stable even when discovery omits them, so retired entries would advertise models that always fail on invoke. Go already pruned exactly these three; JS is stale.

The shared capability preset splits into two tiers: structured (constrained + JSON output, for models on Anthropic's Structured Outputs list) and base (text output, no constrained claim). Every surviving curated model is structured-tier; the base tier backs the dynamic-discovery fallback (`commonModelInfo`), downgraded since un-curated names may predate Structured Outputs. Tool-steered schema output still works everywhere, so nothing breaks. Pins verified red first.
