### PR TITLE
fix(genkit_google_genai): drop safety settings with unset category instead of sending UNSPECIFIED

### DIFF
--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -388,14 +388,21 @@ Map<String, Object?>? _toPrebuiltVoiceConfig(PrebuiltVoiceConfig? config) {
 List<gcl.SafetySetting>? toGeminiSafetySettings(
   List<SafetySettings>? safetySettings,
 ) {
-  return safetySettings
-      ?.where(
-        (s) => s.category != null && s.category != 'HARM_CATEGORY_UNSPECIFIED',
-      )
-      .map(
-        (s) => gcl.SafetySetting(category: s.category, threshold: s.threshold),
-      )
-      .toList();
+  if (safetySettings == null) return null;
+  final settings = <gcl.SafetySetting>[];
+  for (final s in safetySettings) {
+    if (s.category == null || s.category == 'HARM_CATEGORY_UNSPECIFIED') {
+      logger.warning(
+        'Dropping safety setting with unset or UNSPECIFIED category: '
+        'the API rejects HARM_CATEGORY_UNSPECIFIED.',
+      );
+      continue;
+    }
+    settings.add(
+      gcl.SafetySetting(category: s.category, threshold: s.threshold),
+    );
+  }
+  return settings;
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -389,11 +389,11 @@ List<gcl.SafetySetting>? toGeminiSafetySettings(
   List<SafetySettings>? safetySettings,
 ) {
   return safetySettings
-      ?.map(
-        (s) => gcl.SafetySetting(
-          category: s.category ?? 'HARM_CATEGORY_UNSPECIFIED',
-          threshold: s.threshold ?? 'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
-        ),
+      ?.where(
+        (s) => s.category != null && s.category != 'HARM_CATEGORY_UNSPECIFIED',
+      )
+      .map(
+        (s) => gcl.SafetySetting(category: s.category, threshold: s.threshold),
       )
       .toList();
 }

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -391,16 +391,15 @@ List<gcl.SafetySetting>? toGeminiSafetySettings(
   if (safetySettings == null) return null;
   final settings = <gcl.SafetySetting>[];
   for (final s in safetySettings) {
-    if (s.category == null || s.category == 'HARM_CATEGORY_UNSPECIFIED') {
+    final category = s.category;
+    if (category == null || category == 'HARM_CATEGORY_UNSPECIFIED') {
       logger.warning(
         'Dropping safety setting with unset or UNSPECIFIED category: '
         'the API rejects HARM_CATEGORY_UNSPECIFIED.',
       );
       continue;
     }
-    settings.add(
-      gcl.SafetySetting(category: s.category, threshold: s.threshold),
-    );
+    settings.add(gcl.SafetySetting(category: category, threshold: s.threshold));
   }
   return settings;
 }

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -85,6 +85,53 @@ void main() {
       expect(settings!.first.category, 'HARM_CATEGORY_DANGEROUS_CONTENT');
       expect(settings.first.threshold, 'BLOCK_ONLY_HIGH');
     });
+
+    test('returns null for null input', () {
+      expect(toGeminiSafetySettings(null), isNull);
+    });
+
+    test('returns empty list for empty input', () {
+      expect(toGeminiSafetySettings([]), isEmpty);
+    });
+
+    test('drops an entry with unset category', () {
+      final settings = toGeminiSafetySettings([
+        SafetySettings(threshold: 'BLOCK_ONLY_HIGH'),
+        SafetySettings(
+          category: 'HARM_CATEGORY_HARASSMENT',
+          threshold: 'BLOCK_LOW_AND_ABOVE',
+        ),
+      ]);
+
+      expect(settings, hasLength(1));
+      expect(settings!.first.category, 'HARM_CATEGORY_HARASSMENT');
+    });
+
+    test('drops an entry with explicit HARM_CATEGORY_UNSPECIFIED', () {
+      final settings = toGeminiSafetySettings([
+        SafetySettings(
+          category: 'HARM_CATEGORY_UNSPECIFIED',
+          threshold: 'BLOCK_ONLY_HIGH',
+        ),
+      ]);
+
+      expect(settings, isEmpty);
+    });
+
+    test('drops an entry with neither category nor threshold', () {
+      expect(toGeminiSafetySettings([SafetySettings()]), isEmpty);
+    });
+
+    test('omits threshold from the wire body when unset', () {
+      final settings = toGeminiSafetySettings([
+        SafetySettings(category: 'HARM_CATEGORY_HATE_SPEECH'),
+      ]);
+
+      expect(settings, hasLength(1));
+      expect(settings!.first.toJson(), {
+        'category': 'HARM_CATEGORY_HATE_SPEECH',
+      });
+    });
   });
 
   group('toGeminiTools', () {

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -12,8 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
 import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_google_genai/src/api_client.dart';
 import 'package:genkit_google_genai/src/common_plugin.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -132,6 +140,81 @@ void main() {
         'category': 'HARM_CATEGORY_HATE_SPEECH',
       });
     });
+
+    test('warns once per dropped entry, kept entries stay silent', () {
+      final records = <LogRecord>[];
+      final subscription = Logger.root.onRecord.listen(records.add);
+      addTearDown(subscription.cancel);
+
+      toGeminiSafetySettings([
+        SafetySettings(threshold: 'BLOCK_ONLY_HIGH'),
+        SafetySettings(
+          category: 'HARM_CATEGORY_UNSPECIFIED',
+          threshold: 'BLOCK_ONLY_HIGH',
+        ),
+        SafetySettings(
+          category: 'HARM_CATEGORY_HARASSMENT',
+          threshold: 'BLOCK_LOW_AND_ABOVE',
+        ),
+      ]);
+
+      expect(records, hasLength(2));
+      for (final record in records) {
+        expect(record.level, Level.WARNING);
+        expect(record.loggerName, 'genkit_google_genai');
+        expect(record.message, contains('category'));
+      }
+    });
+  });
+
+  group('safety settings request body', () {
+    test('omits safetySettings key when every entry is dropped', () async {
+      Map<String, dynamic>? capturedBody;
+      final plugin = StubClientPlugin((request) async {
+        capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': 'ok'},
+                  ],
+                },
+                'finishReason': 'STOP',
+              },
+            ],
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final model = plugin.createModel(
+        'gemini-2.5-flash',
+        GeminiOptions.$schema,
+      );
+      await model.call(
+        ModelRequest(
+          messages: [
+            Message(role: Role.user, content: [TextPart(text: 'hi')]),
+          ],
+          config: {
+            'safetySettings': [
+              {
+                'category': 'HARM_CATEGORY_UNSPECIFIED',
+                'threshold': 'BLOCK_ONLY_HIGH',
+              },
+              {'threshold': 'BLOCK_ONLY_HIGH'},
+            ],
+          },
+        ),
+      );
+
+      expect(capturedBody, isNotNull);
+      expect(capturedBody, isNot(contains('safetySettings')));
+    });
   });
 
   group('toGeminiTools', () {
@@ -198,4 +281,20 @@ void main() {
       expect(settings.responseMimeType, 'audio/mp3');
     });
   });
+}
+
+class StubClientPlugin extends GoogleGenAiPluginImpl {
+  StubClientPlugin(this.handler);
+
+  final Future<http.Response> Function(http.Request) handler;
+
+  @override
+  Future<GenerativeLanguageBaseClient> getApiClient([
+    String? requestApiKey,
+  ]) async {
+    return GenerativeLanguageBaseClient(
+      baseUrl: 'https://test.invalid/',
+      client: MockClient(handler),
+    );
+  }
 }

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -198,7 +198,10 @@ void main() {
       await model.call(
         ModelRequest(
           messages: [
-            Message(role: Role.user, content: [TextPart(text: 'hi')]),
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'hi')],
+            ),
           ],
           config: {
             'safetySettings': [


### PR DESCRIPTION
Fixes #365

Safety-setting entries with unset category went to the wire as `HARM_CATEGORY_UNSPECIFIED`, which the API rejects with 400 INVALID_ARGUMENT (verified live, v1beta). Unset threshold became `HARM_BLOCK_THRESHOLD_UNSPECIFIED`, accepted but redundant.

Fix: drop entries whose category is unset or explicitly `HARM_CATEGORY_UNSPECIFIED` (JS filter parity, `googleai/gemini.ts:867-868`), logging a warning per dropped entry since the Dart config is cast-only where JS requires a category. Unset threshold is omitted from the wire body so the server default applies. A list that filters to empty sends no `safetySettings` key.

Caveats: `genkit_vertexai` inherits the filter (JS vertexai maps entries verbatim); threshold omission relies on proto3 absent-field == UNSPECIFIED semantics, live-verified only in the explicit form.

Tests: new-behavior pins red first, plus characterization pins including a MockClient wire test for the all-dropped path; each pin verified by reverting the code it guards.
