### PR TITLE
fix(genkit_google_genai)!: wire seed and fileSearch into the request

### DIFF
--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -388,14 +388,21 @@ Map<String, Object?>? _toPrebuiltVoiceConfig(PrebuiltVoiceConfig? config) {
 List<gcl.SafetySetting>? toGeminiSafetySettings(
   List<SafetySettings>? safetySettings,
 ) {
-  return safetySettings
-      ?.where(
-        (s) => s.category != null && s.category != 'HARM_CATEGORY_UNSPECIFIED',
-      )
-      .map(
-        (s) => gcl.SafetySetting(category: s.category, threshold: s.threshold),
-      )
-      .toList();
+  if (safetySettings == null) return null;
+  final settings = <gcl.SafetySetting>[];
+  for (final s in safetySettings) {
+    if (s.category == null || s.category == 'HARM_CATEGORY_UNSPECIFIED') {
+      logger.warning(
+        'Dropping safety setting with unset or UNSPECIFIED category: '
+        'the API rejects HARM_CATEGORY_UNSPECIFIED.',
+      );
+      continue;
+    }
+    settings.add(
+      gcl.SafetySetting(category: s.category, threshold: s.threshold),
+    );
+  }
+  return settings;
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -84,6 +84,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             req.tools,
             codeExecution: options.codeExecution,
             googleSearch: options.googleSearch,
+            fileSearch: options.fileSearch,
           );
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         } else {
@@ -101,6 +102,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             req.tools,
             codeExecution: options.codeExecution,
             googleSearch: options.googleSearch,
+            fileSearch: options.fileSearch,
           );
           toolConfig = toGeminiToolConfig(options.functionCallingConfig);
         }
@@ -279,6 +281,7 @@ gcl.GenerationConfig toGeminiSettings(
     frequencyPenalty: options.frequencyPenalty,
     responseLogprobs: options.responseLogprobs,
     logprobs: options.logprobs,
+    seed: options.seed,
     responseModalities: options.responseModalities?.isEmpty ?? true
         ? null
         : options.responseModalities!.map((m) => m.toUpperCase()).toList(),
@@ -318,6 +321,7 @@ gcl.GenerationConfig toGeminiTtsSettings(
     frequencyPenalty: options.frequencyPenalty,
     responseLogprobs: options.responseLogprobs,
     logprobs: options.logprobs,
+    seed: options.seed,
     responseModalities: options.responseModalities?.isEmpty ?? true
         ? null
         : options.responseModalities!.map((m) => m.toUpperCase()).toList(),
@@ -410,11 +414,14 @@ List<gcl.Tool> toGeminiTools(
   List<ToolDefinition>? tools, {
   bool? codeExecution,
   GoogleSearch? googleSearch,
+  FileSearch? fileSearch,
 }) {
   return [
     ...(tools?.map(_toGeminiTool) ?? []),
     if (codeExecution == true) gcl.Tool(codeExecution: gcl.CodeExecution()),
     if (googleSearch != null) gcl.Tool(googleSearch: gcl.GoogleSearch()),
+    if (fileSearch != null)
+      gcl.Tool(fileSearch: gcl.FileSearch.fromJson(fileSearch.toJson())),
   ];
 }
 

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -389,11 +389,11 @@ List<gcl.SafetySetting>? toGeminiSafetySettings(
   List<SafetySettings>? safetySettings,
 ) {
   return safetySettings
-      ?.map(
-        (s) => gcl.SafetySetting(
-          category: s.category ?? 'HARM_CATEGORY_UNSPECIFIED',
-          threshold: s.threshold ?? 'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
-        ),
+      ?.where(
+        (s) => s.category != null && s.category != 'HARM_CATEGORY_UNSPECIFIED',
+      )
+      .map(
+        (s) => gcl.SafetySetting(category: s.category, threshold: s.threshold),
       )
       .toList();
 }

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -421,7 +421,13 @@ List<gcl.Tool> toGeminiTools(
     if (codeExecution == true) gcl.Tool(codeExecution: gcl.CodeExecution()),
     if (googleSearch != null) gcl.Tool(googleSearch: gcl.GoogleSearch()),
     if (fileSearch != null)
-      gcl.Tool(fileSearch: gcl.FileSearch.fromJson(fileSearch.toJson())),
+      gcl.Tool(
+        fileSearch: gcl.FileSearch(
+          fileSearchStoreNames: fileSearch.fileSearchStoreNames,
+          metadataFilter: fileSearch.metadataFilter,
+          topK: fileSearch.topK,
+        ),
+      ),
   ];
 }
 

--- a/packages/genkit_google_genai/lib/src/generated/generativelanguage.dart
+++ b/packages/genkit_google_genai/lib/src/generated/generativelanguage.dart
@@ -1769,7 +1769,7 @@ extension type ContentEmbedding._(Map<String, Object?> _data) {
 
   set values(List<double>? value) => _data['values'] = value;
 
-  /// This field stores the soft tokens tensor frame shape (e.g. `[1, 1, 256, 2048]`).
+  /// This field stores the soft tokens tensor frame shape (e.g. [1, 1, 256, 2048]).
   List<int>? get shape {
     final v = _data['shape'];
     if (v == null) return null;
@@ -3127,10 +3127,12 @@ extension type Tool._(Map<String, Object?> _data) {
     List<FunctionDeclaration>? functionDeclarations,
     GoogleSearch? googleSearch,
     CodeExecution? codeExecution,
+    FileSearch? fileSearch,
   }) : this._({
          'functionDeclarations': ?functionDeclarations,
          'googleSearch': ?googleSearch,
          'codeExecution': ?codeExecution,
+         'fileSearch': ?fileSearch,
        });
 
   Tool.fromJson(Map<String, dynamic> json) : this._(json);
@@ -3160,6 +3162,51 @@ extension type Tool._(Map<String, Object?> _data) {
   }
 
   set codeExecution(CodeExecution? value) => _data['codeExecution'] = value;
+  FileSearch? get fileSearch {
+    final v = _data['fileSearch'];
+    if (v == null) return null;
+    return FileSearch._(v as Map<String, Object?>);
+  }
+
+  set fileSearch(FileSearch? value) => _data['fileSearch'] = value;
+}
+
+extension type FileSearch._(Map<String, Object?> _data) {
+  FileSearch({
+    List<String>? fileSearchStoreNames,
+    String? metadataFilter,
+    int? topK,
+  }) : this._({
+         'fileSearchStoreNames': ?fileSearchStoreNames,
+         'metadataFilter': ?metadataFilter,
+         'topK': ?topK,
+       });
+
+  FileSearch.fromJson(Map<String, dynamic> json) : this._(json);
+  Map<String, dynamic> toJson() => _data as Map<String, dynamic>;
+
+  List<String>? get fileSearchStoreNames {
+    final v = _data['fileSearchStoreNames'];
+    if (v == null) return null;
+    return (v as List).cast<String>();
+  }
+
+  set fileSearchStoreNames(List<String>? value) =>
+      _data['fileSearchStoreNames'] = value;
+  String? get metadataFilter {
+    final v = _data['metadataFilter'];
+    if (v == null) return null;
+    return v as String;
+  }
+
+  set metadataFilter(String? value) => _data['metadataFilter'] = value;
+  int? get topK {
+    final v = _data['topK'];
+    if (v == null) return null;
+    return v as int;
+  }
+
+  set topK(int? value) => _data['topK'] = value;
 }
 
 extension type ToolConfig._(Map<String, Object?> _data) {

--- a/packages/genkit_google_genai/lib/src/model.dart
+++ b/packages/genkit_google_genai/lib/src/model.dart
@@ -121,7 +121,24 @@ abstract class $FunctionCallingConfig {
 
 @Schema()
 abstract class $FileSearch {
-  List<String>? get fileSearchStoreNames;
+  @Field(
+    description:
+        'The names of the fileSearchStores to retrieve from. '
+        'Example: fileSearchStores/my-file-search-store-123',
+  )
+  List<String> get fileSearchStoreNames;
+
+  @StringField(
+    description:
+        'Metadata filter to apply to the semantic retrieval documents '
+        'and chunks.',
+  )
+  String? get metadataFilter;
+
+  @IntegerField(
+    description: 'The number of semantic retrieval chunks to retrieve.',
+  )
+  int? get topK;
 }
 
 @Schema()

--- a/packages/genkit_google_genai/lib/src/model.g.dart
+++ b/packages/genkit_google_genai/lib/src/model.g.dart
@@ -699,8 +699,16 @@ base class FileSearch {
 
   FileSearch._(this._json);
 
-  FileSearch({List<String>? fileSearchStoreNames}) {
-    _json = {'fileSearchStoreNames': ?fileSearchStoreNames};
+  FileSearch({
+    required List<String> fileSearchStoreNames,
+    String? metadataFilter,
+    int? topK,
+  }) {
+    _json = {
+      'fileSearchStoreNames': fileSearchStoreNames,
+      'metadataFilter': ?metadataFilter,
+      'topK': ?topK,
+    };
   }
 
   late final Map<String, dynamic> _json;
@@ -708,15 +716,35 @@ base class FileSearch {
   /// The JSON schema and type descriptor for [FileSearch].
   static const SchemanticType<FileSearch> $schema = _FileSearchTypeFactory();
 
-  List<String>? get fileSearchStoreNames {
-    return (_json['fileSearchStoreNames'] as List?)?.cast<String>();
+  List<String> get fileSearchStoreNames {
+    return (_json['fileSearchStoreNames'] as List).cast<String>();
   }
 
-  set fileSearchStoreNames(List<String>? value) {
+  set fileSearchStoreNames(List<String> value) {
+    _json['fileSearchStoreNames'] = value;
+  }
+
+  String? get metadataFilter {
+    return _json['metadataFilter'] as String?;
+  }
+
+  set metadataFilter(String? value) {
     if (value == null) {
-      _json.remove('fileSearchStoreNames');
+      _json.remove('metadataFilter');
     } else {
-      _json['fileSearchStoreNames'] = value;
+      _json['metadataFilter'] = value;
+    }
+  }
+
+  int? get topK {
+    return _json['topK'] as int?;
+  }
+
+  set topK(int? value) {
+    if (value == null) {
+      _json.remove('topK');
+    } else {
+      _json['topK'] = value;
     }
   }
 
@@ -745,8 +773,21 @@ base class _FileSearchTypeFactory extends SchemanticType<FileSearch> {
     definition: $Schema
         .object(
           properties: {
-            'fileSearchStoreNames': $Schema.list(items: $Schema.string()),
+            'fileSearchStoreNames': $Schema.list(
+              description:
+                  'The names of the fileSearchStores to retrieve from. Example: fileSearchStores/my-file-search-store-123',
+              items: $Schema.string(),
+            ),
+            'metadataFilter': $Schema.string(
+              description:
+                  'Metadata filter to apply to the semantic retrieval documents and chunks.',
+            ),
+            'topK': $Schema.integer(
+              description:
+                  'The number of semantic retrieval chunks to retrieve.',
+            ),
           },
+          required: ['fileSearchStoreNames'],
         )
         .value,
     dependencies: [],

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -85,6 +85,53 @@ void main() {
       expect(settings!.first.category, 'HARM_CATEGORY_DANGEROUS_CONTENT');
       expect(settings.first.threshold, 'BLOCK_ONLY_HIGH');
     });
+
+    test('returns null for null input', () {
+      expect(toGeminiSafetySettings(null), isNull);
+    });
+
+    test('returns empty list for empty input', () {
+      expect(toGeminiSafetySettings([]), isEmpty);
+    });
+
+    test('drops an entry with unset category', () {
+      final settings = toGeminiSafetySettings([
+        SafetySettings(threshold: 'BLOCK_ONLY_HIGH'),
+        SafetySettings(
+          category: 'HARM_CATEGORY_HARASSMENT',
+          threshold: 'BLOCK_LOW_AND_ABOVE',
+        ),
+      ]);
+
+      expect(settings, hasLength(1));
+      expect(settings!.first.category, 'HARM_CATEGORY_HARASSMENT');
+    });
+
+    test('drops an entry with explicit HARM_CATEGORY_UNSPECIFIED', () {
+      final settings = toGeminiSafetySettings([
+        SafetySettings(
+          category: 'HARM_CATEGORY_UNSPECIFIED',
+          threshold: 'BLOCK_ONLY_HIGH',
+        ),
+      ]);
+
+      expect(settings, isEmpty);
+    });
+
+    test('drops an entry with neither category nor threshold', () {
+      expect(toGeminiSafetySettings([SafetySettings()]), isEmpty);
+    });
+
+    test('omits threshold from the wire body when unset', () {
+      final settings = toGeminiSafetySettings([
+        SafetySettings(category: 'HARM_CATEGORY_HATE_SPEECH'),
+      ]);
+
+      expect(settings, hasLength(1));
+      expect(settings!.first.toJson(), {
+        'category': 'HARM_CATEGORY_HATE_SPEECH',
+      });
+    });
   });
 
   group('toGeminiTools', () {

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -65,6 +65,18 @@ void main() {
       expect(settings.thinkingConfig!.thinkingLevel, 'HIGH');
     });
 
+    test('maps seed', () {
+      final settings = toGeminiSettings(GeminiOptions(seed: 42), null, false);
+
+      expect(settings.seed, 42);
+    });
+
+    test('omits seed when unset', () {
+      final settings = toGeminiSettings(GeminiOptions(), null, false);
+
+      expect(settings.toJson(), isNot(contains('seed')));
+    });
+
     test('maps response modalities', () {
       final options = GeminiOptions(
         responseModalities: ['TEXT', 'audio', 'IMAGE'],
@@ -220,6 +232,26 @@ void main() {
     });
   });
 
+  group('generation config request body', () {
+    test('sends seed inside generationConfig', () async {
+      final body = await _captureRequestBody(config: {'seed': 42});
+
+      expect((body['generationConfig'] as Map)['seed'], 42);
+    });
+
+    test('omits seed when config has none', () async {
+      final body = await _captureRequestBody(config: {'temperature': 0.5});
+
+      expect(body['generationConfig'] as Map, isNot(contains('seed')));
+    });
+
+    test('sends seed inside generationConfig on the TTS path', () async {
+      final body = await _captureRequestBody(config: {'seed': 11}, tts: true);
+
+      expect((body['generationConfig'] as Map)['seed'], 11);
+    });
+  });
+
   group('toGeminiTools', () {
     test('maps code execution', () {
       final options = GeminiOptions(codeExecution: true);
@@ -235,6 +267,71 @@ void main() {
 
       expect(tools, hasLength(1));
       expect(tools.first.googleSearch, isNotNull);
+    });
+
+    test('maps file search with all fields passed through', () {
+      final options = GeminiOptions(
+        fileSearch: FileSearch(
+          fileSearchStoreNames: ['fileSearchStores/my-store'],
+          metadataFilter: 'author=jane',
+          topK: 3,
+        ),
+      );
+      final tools = toGeminiTools(null, fileSearch: options.fileSearch);
+
+      expect(tools, hasLength(1));
+      expect(tools.first.fileSearch?.toJson(), {
+        'fileSearchStoreNames': ['fileSearchStores/my-store'],
+        'metadataFilter': 'author=jane',
+        'topK': 3,
+      });
+    });
+  });
+
+  group('tools request body', () {
+    test('sends the fileSearch tool', () async {
+      final body = await _captureRequestBody(
+        config: {
+          'fileSearch': {
+            'fileSearchStoreNames': ['fileSearchStores/my-store'],
+            'topK': 5,
+          },
+        },
+      );
+
+      expect(body['tools'], [
+        {
+          'fileSearch': {
+            'fileSearchStoreNames': ['fileSearchStores/my-store'],
+            'topK': 5,
+          },
+        },
+      ]);
+    });
+
+    test('omits tools when config has no fileSearch', () async {
+      final body = await _captureRequestBody(config: {'temperature': 0.5});
+
+      expect(body, isNot(contains('tools')));
+    });
+
+    test('sends the fileSearch tool on the TTS path', () async {
+      final body = await _captureRequestBody(
+        config: {
+          'fileSearch': {
+            'fileSearchStoreNames': ['fileSearchStores/my-store'],
+          },
+        },
+        tts: true,
+      );
+
+      expect(body['tools'], [
+        {
+          'fileSearch': {
+            'fileSearchStoreNames': ['fileSearchStores/my-store'],
+          },
+        },
+      ]);
     });
   });
 
@@ -283,7 +380,63 @@ void main() {
       expect(settings.temperature, 0.5);
       expect(settings.responseMimeType, 'audio/mp3');
     });
+
+    test('maps seed', () {
+      final settings = toGeminiTtsSettings(
+        GeminiTtsOptions(seed: 7),
+        null,
+        false,
+      );
+
+      expect(settings.seed, 7);
+    });
   });
+}
+
+Future<Map<String, dynamic>> _captureRequestBody({
+  Map<String, dynamic>? config,
+  bool tts = false,
+}) async {
+  Map<String, dynamic>? capturedBody;
+  final plugin = StubClientPlugin((request) async {
+    capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+    return http.Response(
+      jsonEncode({
+        'candidates': [
+          {
+            'content': {
+              'role': 'model',
+              'parts': [
+                {'text': 'ok'},
+              ],
+            },
+            'finishReason': 'STOP',
+          },
+        ],
+      }),
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  });
+
+  final model = tts
+      ? plugin.createModel(
+          'gemini-2.5-flash-preview-tts',
+          GeminiTtsOptions.$schema,
+        )
+      : plugin.createModel('gemini-2.5-flash', GeminiOptions.$schema);
+  await model.call(
+    ModelRequest(
+      messages: [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hi')],
+        ),
+      ],
+      config: config,
+    ),
+  );
+  return capturedBody!;
 }
 
 class StubClientPlugin extends GoogleGenAiPluginImpl {

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -309,6 +309,26 @@ void main() {
       ]);
     });
 
+    test('omits fileSearch fields left null in config', () async {
+      final body = await _captureRequestBody(
+        config: {
+          'fileSearch': {
+            'fileSearchStoreNames': ['fileSearchStores/my-store'],
+            'metadataFilter': null,
+            'topK': null,
+          },
+        },
+      );
+
+      expect(body['tools'], [
+        {
+          'fileSearch': {
+            'fileSearchStoreNames': ['fileSearchStores/my-store'],
+          },
+        },
+      ]);
+    });
+
     test('omits tools when config has no fileSearch', () async {
       final body = await _captureRequestBody(config: {'temperature': 0.5});
 

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -12,8 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
 import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_google_genai/src/api_client.dart';
 import 'package:genkit_google_genai/src/common_plugin.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -132,6 +140,81 @@ void main() {
         'category': 'HARM_CATEGORY_HATE_SPEECH',
       });
     });
+
+    test('warns once per dropped entry, kept entries stay silent', () {
+      final records = <LogRecord>[];
+      final subscription = Logger.root.onRecord.listen(records.add);
+      addTearDown(subscription.cancel);
+
+      toGeminiSafetySettings([
+        SafetySettings(threshold: 'BLOCK_ONLY_HIGH'),
+        SafetySettings(
+          category: 'HARM_CATEGORY_UNSPECIFIED',
+          threshold: 'BLOCK_ONLY_HIGH',
+        ),
+        SafetySettings(
+          category: 'HARM_CATEGORY_HARASSMENT',
+          threshold: 'BLOCK_LOW_AND_ABOVE',
+        ),
+      ]);
+
+      expect(records, hasLength(2));
+      for (final record in records) {
+        expect(record.level, Level.WARNING);
+        expect(record.loggerName, 'genkit_google_genai');
+        expect(record.message, contains('category'));
+      }
+    });
+  });
+
+  group('safety settings request body', () {
+    test('omits safetySettings key when every entry is dropped', () async {
+      Map<String, dynamic>? capturedBody;
+      final plugin = StubClientPlugin((request) async {
+        capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': 'ok'},
+                  ],
+                },
+                'finishReason': 'STOP',
+              },
+            ],
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final model = plugin.createModel(
+        'gemini-2.5-flash',
+        GeminiOptions.$schema,
+      );
+      await model.call(
+        ModelRequest(
+          messages: [
+            Message(role: Role.user, content: [TextPart(text: 'hi')]),
+          ],
+          config: {
+            'safetySettings': [
+              {
+                'category': 'HARM_CATEGORY_UNSPECIFIED',
+                'threshold': 'BLOCK_ONLY_HIGH',
+              },
+              {'threshold': 'BLOCK_ONLY_HIGH'},
+            ],
+          },
+        ),
+      );
+
+      expect(capturedBody, isNotNull);
+      expect(capturedBody, isNot(contains('safetySettings')));
+    });
   });
 
   group('toGeminiTools', () {
@@ -198,4 +281,20 @@ void main() {
       expect(settings.responseMimeType, 'audio/mp3');
     });
   });
+}
+
+class StubClientPlugin extends GoogleGenAiPluginImpl {
+  StubClientPlugin(this.handler);
+
+  final Future<http.Response> Function(http.Request) handler;
+
+  @override
+  Future<GenerativeLanguageBaseClient> getApiClient([
+    String? requestApiKey,
+  ]) async {
+    return GenerativeLanguageBaseClient(
+      baseUrl: 'https://test.invalid/',
+      client: MockClient(handler),
+    );
+  }
 }

--- a/packages/genkit_google_genai/test/options_test.dart
+++ b/packages/genkit_google_genai/test/options_test.dart
@@ -198,7 +198,10 @@ void main() {
       await model.call(
         ModelRequest(
           messages: [
-            Message(role: Role.user, content: [TextPart(text: 'hi')]),
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'hi')],
+            ),
           ],
           config: {
             'safetySettings': [

--- a/packages/genkit_google_genai/tool/generate_client.dart
+++ b/packages/genkit_google_genai/tool/generate_client.dart
@@ -93,6 +93,15 @@ final Map<String, Map<String, dynamic>> schemaOverrides = {
     },
     'googleSearch': {'\$ref': 'GoogleSearch'},
     'codeExecution': {'\$ref': 'CodeExecution'},
+    'fileSearch': {'\$ref': 'FileSearch'},
+  },
+  'FileSearch': {
+    'fileSearchStoreNames': {
+      'type': 'array',
+      'items': {'type': 'string'},
+    },
+    'metadataFilter': {'type': 'string'},
+    'topK': {'type': 'integer'},
   },
   'ToolConfig': {
     'functionCallingConfig': {'\$ref': 'FunctionCallingConfig'},


### PR DESCRIPTION
Fixes #363. Stacked on #392 (targets `fix/googlegenai-safety-settings-unset`).

`seed` and `fileSearch` were accepted by `GeminiOptions`/`GeminiTtsOptions` but silently dropped when building the request. This wires both: `seed` is mapped into `GenerationConfig` in both settings builders, and `fileSearch` becomes a tool entry - the generated client's hand-authored `Tool` type gains a `fileSearch` member via `schemaOverrides` (the discovery doc has no Tool schema), with the config passed through verbatim, matching the JS plugin. Wire-level tests cover both the standard and TTS paths and pin omission when unset.

The `FileSearch` config schema is aligned with the JS plugin, which is a breaking change to the exported `FileSearch` API: `fileSearchStoreNames` is now required and non-nullable; `metadataFilter` and `topK` are added.

Caveat: fileSearch is a Google AI-only feature reachable from the shared `GeminiOptions` schema; Vertex callers setting it will get the API's error. Flagging the schema layering question for maintainers.
