### PR TITLE
feat(googleai): classify gemini-embedding-* as embedders and embed media parts

### DIFF
--- a/packages/genkit_google_genai/lib/common.dart
+++ b/packages/genkit_google_genai/lib/common.dart
@@ -16,6 +16,6 @@
 library;
 
 export 'src/api_client.dart';
-export 'src/common_plugin.dart';
+export 'src/common_plugin.dart' hide toGeminiPart;
 export 'src/known_models.dart';
 export 'src/model.dart';

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -446,6 +446,11 @@ String toGeminiRole(Role role) {
   return 'user';
 }
 
+/// Whether [name] (bare or resource-prefixed) names an embedding model:
+/// any name containing `embedding`, such as `text-embedding-004`,
+/// `gemini-embedding-2`, or `multimodalembedding`.
+bool isEmbedderModelName(String name) => name.contains('embedding');
+
 @visibleForTesting
 List<gcl.Content> toGeminiContent(List<Message> messages) {
   return messages
@@ -458,7 +463,7 @@ List<gcl.Content> toGeminiContent(List<Message> messages) {
       .toList();
 }
 
-@visibleForTesting
+@internal
 gcl.Part toGeminiPart(Part p) {
   final thoughtSignature = p.metadata?['thoughtSignature'] != null
       ? p.metadata!['thoughtSignature'] as String

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -100,7 +100,8 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
                 (model.supportedGenerationMethods ?? []).contains(
                   'embedContent',
                 ) &&
-                !(model.description?.contains('deprecated') ?? false),
+                !(model.description?.toLowerCase().contains('deprecated') ??
+                    false),
           )
           .map((model) {
             return embedderMetadata('$name/${model.name!.split('/').last}');
@@ -141,6 +142,15 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
           final options = req.options != null
               ? TextEmbedderOptions.fromJson(req.options!)
               : null;
+
+          for (final (index, doc) in req.input.indexed) {
+            if (doc.content.isEmpty) {
+              throw GenkitException(
+                'Cannot embed the document at index $index: it has no content.',
+                status: StatusCodes.INVALID_ARGUMENT,
+              );
+            }
+          }
 
           final futures = req.input.map((doc) async {
             final content = gcl.Content(

--- a/packages/genkit_google_genai/lib/src/google_api_client.dart
+++ b/packages/genkit_google_genai/lib/src/google_api_client.dart
@@ -70,7 +70,8 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
       final models = (modelsResponse.models ?? [])
           .where((model) {
             return model.name != null &&
-                model.name!.startsWith('models/gemini-');
+                model.name!.startsWith('models/gemini-') &&
+                !isEmbedderModelName(model.name!);
           })
           .map((model) {
             final bareName = model.name!.split('/').last;
@@ -95,8 +96,11 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
           .where(
             (model) =>
                 model.name != null &&
-                (model.name!.startsWith('models/text-embedding-') ||
-                    model.name!.startsWith('models/embedding-')),
+                isEmbedderModelName(model.name!) &&
+                (model.supportedGenerationMethods ?? []).contains(
+                  'embedContent',
+                ) &&
+                !(model.description?.contains('deprecated') ?? false),
           )
           .map((model) {
             return embedderMetadata('$name/${model.name!.split('/').last}');
@@ -138,13 +142,11 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
               ? TextEmbedderOptions.fromJson(req.options!)
               : null;
 
-          if (req.input.length == 1) {
-            final doc = req.input.first;
-            final text = doc.content
-                .where((p) => p.isText)
-                .map((p) => p.text)
-                .join('\n');
-            final content = gcl.Content(parts: [gcl.Part(text: text)]);
+          final futures = req.input.map((doc) async {
+            final content = gcl.Content(
+              role: 'user',
+              parts: doc.content.map(toGeminiPart).toList(),
+            );
             final res = await service.embedContent(
               gcl.EmbedContentRequest(
                 content: content,
@@ -154,30 +156,10 @@ class GoogleGenAiPluginImpl extends CommonGoogleGenPlugin {
               ),
               model: 'models/$embedderName',
             );
-            return EmbedResponse(
-              embeddings: [Embedding(embedding: res.embedding?.values ?? [])],
-            );
-          } else {
-            final futures = req.input.map((doc) async {
-              final text = doc.content
-                  .where((p) => p.isText)
-                  .map((p) => p.text)
-                  .join('\n');
-              final content = gcl.Content(parts: [gcl.Part(text: text)]);
-              final res = await service.embedContent(
-                gcl.EmbedContentRequest(
-                  content: content,
-                  outputDimensionality: options?.outputDimensionality,
-                  taskType: options?.taskType,
-                  title: options?.title,
-                ),
-                model: 'models/$embedderName',
-              );
-              return Embedding(embedding: res.embedding?.values ?? []);
-            });
-            final embeddings = await Future.wait(futures);
-            return EmbedResponse(embeddings: embeddings);
-          }
+            return Embedding(embedding: res.embedding?.values ?? []);
+          });
+          final embeddings = await Future.wait(futures);
+          return EmbedResponse(embeddings: embeddings);
         } catch (e, stack) {
           throw handleException(e, stack);
         } finally {

--- a/packages/genkit_google_genai/test/embedder_wire_test.dart
+++ b/packages/genkit_google_genai/test/embedder_wire_test.dart
@@ -1,0 +1,274 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/src/api_client.dart';
+import 'package:genkit_google_genai/src/common_plugin.dart';
+import 'package:genkit_google_genai/src/google_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Captures every embedContent request body the plugin puts on the wire and
+/// serves a canned embedding response.
+class _EmbedWirePlugin extends GoogleGenAiPluginImpl {
+  final List<Map<String, dynamic>> captured;
+  final List<Uri> urls;
+
+  _EmbedWirePlugin(this.captured, this.urls) : super(apiKey: 'test-key');
+
+  @override
+  Future<GenerativeLanguageBaseClient> getApiClient([
+    String? requestApiKey,
+  ]) async {
+    return GenerativeLanguageBaseClient(
+      baseUrl: 'https://example.test/',
+      client: MockClient((request) async {
+        captured.add((jsonDecode(request.body) as Map).cast<String, dynamic>());
+        urls.add(request.url);
+        return http.Response(
+          jsonEncode({
+            'embedding': {
+              'values': [0.1, 0.2, 0.3],
+            },
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+    );
+  }
+}
+
+typedef _EmbedderAction = Action<EmbedRequest, EmbedResponse, void, void>;
+
+GoogleGenAiPluginImpl _discoveryPlugin(List<Map<String, dynamic>> models) {
+  return GoogleGenAiPluginImpl(
+    apiKey: 'test-key',
+    httpClient: MockClient((request) async {
+      return http.Response(
+        jsonEncode({'models': models}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }),
+  );
+}
+
+void main() {
+  group('isEmbedderModelName', () {
+    test('classifies every embedding family, gemini-embedding included', () {
+      expect(isEmbedderModelName('gemini-embedding-2'), isTrue);
+      expect(isEmbedderModelName('gemini-embedding-2-preview'), isTrue);
+      expect(isEmbedderModelName('gemini-embedding-001'), isTrue);
+      expect(isEmbedderModelName('text-embedding-004'), isTrue);
+      expect(isEmbedderModelName('embedding-gecko-001'), isTrue);
+      expect(isEmbedderModelName('multimodalembedding'), isTrue);
+    });
+
+    test('leaves generative models unclassified', () {
+      expect(isEmbedderModelName('gemini-2.0-flash'), isFalse);
+      expect(isEmbedderModelName('gemini-2.5-pro'), isFalse);
+      expect(isEmbedderModelName('gemma-3-27b-it'), isFalse);
+    });
+  });
+
+  group('list() classification', () {
+    final discovered = [
+      {
+        'name': 'models/gemini-2.0-flash',
+        'supportedGenerationMethods': ['generateContent'],
+      },
+      {
+        'name': 'models/gemini-embedding-2',
+        'supportedGenerationMethods': ['embedContent'],
+      },
+      {
+        'name': 'models/text-embedding-004',
+        'supportedGenerationMethods': ['embedContent'],
+      },
+      {
+        'name': 'models/embedding-gecko-001',
+        'supportedGenerationMethods': ['embedText'],
+      },
+      {
+        'name': 'models/embedding-001',
+        'description': 'A deprecated embedding model.',
+        'supportedGenerationMethods': ['embedContent'],
+      },
+    ];
+
+    test('routes gemini-embedding-* to the embedder path, not the model '
+        'path', () async {
+      final actions = await _discoveryPlugin(discovered).list();
+
+      final embedders = actions
+          .where((a) => a.actionType == 'embedder')
+          .map((a) => a.name);
+      final models = actions
+          .where((a) => a.actionType == 'model')
+          .map((a) => a.name);
+
+      expect(embedders, contains('googleai/gemini-embedding-2'));
+      expect(models, isNot(contains('googleai/gemini-embedding-2')));
+      expect(models, contains('googleai/gemini-2.0-flash'));
+    });
+
+    test('lists only embedders that support embedContent', () async {
+      final actions = await _discoveryPlugin(discovered).list();
+
+      final embedders = actions
+          .where((a) => a.actionType == 'embedder')
+          .map((a) => a.name);
+      final models = actions
+          .where((a) => a.actionType == 'model')
+          .map((a) => a.name);
+
+      expect(embedders, contains('googleai/text-embedding-004'));
+      expect(embedders, isNot(contains('googleai/embedding-gecko-001')));
+      expect(models, isNot(contains('googleai/embedding-gecko-001')));
+    });
+
+    test('drops deprecated embedders', () async {
+      final actions = await _discoveryPlugin(discovered).list();
+
+      final embedders = actions
+          .where((a) => a.actionType == 'embedder')
+          .map((a) => a.name);
+      expect(embedders, isNot(contains('googleai/embedding-001')));
+    });
+  });
+
+  group('embedContent on the wire', () {
+    test('maps media parts to inlineData alongside text', () async {
+      final captured = <Map<String, dynamic>>[];
+      final urls = <Uri>[];
+      final plugin = _EmbedWirePlugin(captured, urls);
+      final embedder =
+          plugin.resolve('embedder', 'gemini-embedding-2')! as _EmbedderAction;
+
+      final response = await embedder.run(
+        EmbedRequest(
+          input: [
+            DocumentData(
+              content: [
+                TextPart(text: 'hello'),
+                MediaPart(media: Media(url: 'data:image/png;base64,AAAA')),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(
+        urls.single.path,
+        endsWith('models/gemini-embedding-2:embedContent'),
+      );
+      final content = captured.single['content'] as Map;
+      expect(content['role'], 'user');
+      final parts = content['parts'] as List;
+      expect(parts, [
+        {'text': 'hello'},
+        {
+          'inlineData': {'mimeType': 'image/png', 'data': 'AAAA'},
+        },
+      ]);
+      expect(response.result.embeddings.single.embedding, [0.1, 0.2, 0.3]);
+    });
+
+    test('keeps contentType over the data-URI mime type', () async {
+      final captured = <Map<String, dynamic>>[];
+      final plugin = _EmbedWirePlugin(captured, <Uri>[]);
+      final embedder =
+          plugin.resolve('embedder', 'gemini-embedding-2')! as _EmbedderAction;
+
+      await embedder.run(
+        EmbedRequest(
+          input: [
+            DocumentData(
+              content: [
+                MediaPart(
+                  media: Media(
+                    url: 'data:application/octet-stream;base64,AAAA',
+                    contentType: 'video/mp4',
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      final parts = (captured.single['content'] as Map)['parts'] as List;
+      expect(parts.single, {
+        'inlineData': {'mimeType': 'video/mp4', 'data': 'AAAA'},
+      });
+    });
+
+    test('sends one request per document and preserves order', () async {
+      final captured = <Map<String, dynamic>>[];
+      final plugin = _EmbedWirePlugin(captured, <Uri>[]);
+      final embedder =
+          plugin.resolve('embedder', 'gemini-embedding-2')! as _EmbedderAction;
+
+      final response = await embedder.run(
+        EmbedRequest(
+          input: [
+            DocumentData(content: [TextPart(text: 'first')]),
+            DocumentData(
+              content: [
+                MediaPart(media: Media(url: 'data:image/png;base64,AAAA')),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(captured, hasLength(2));
+      expect((captured[0]['content'] as Map)['role'], 'user');
+      expect(((captured[0]['content'] as Map)['parts'] as List).single, {
+        'text': 'first',
+      });
+      expect(((captured[1]['content'] as Map)['parts'] as List).single, {
+        'inlineData': {'mimeType': 'image/png', 'data': 'AAAA'},
+      });
+      expect(response.result.embeddings, hasLength(2));
+    });
+
+    test('still forwards embedder options on media requests', () async {
+      final captured = <Map<String, dynamic>>[];
+      final plugin = _EmbedWirePlugin(captured, <Uri>[]);
+      final embedder =
+          plugin.resolve('embedder', 'gemini-embedding-2')! as _EmbedderAction;
+
+      await embedder.run(
+        EmbedRequest(
+          input: [
+            DocumentData(
+              content: [
+                MediaPart(media: Media(url: 'data:image/png;base64,AAAA')),
+              ],
+            ),
+          ],
+          options: {'outputDimensionality': 256, 'taskType': 'RETRIEVAL_QUERY'},
+        ),
+      );
+
+      expect(captured.single['outputDimensionality'], 256);
+      expect(captured.single['taskType'], 'RETRIEVAL_QUERY');
+    });
+  });
+}

--- a/packages/genkit_google_genai/test/embedder_wire_test.dart
+++ b/packages/genkit_google_genai/test/embedder_wire_test.dart
@@ -109,6 +109,11 @@ void main() {
         'description': 'A deprecated embedding model.',
         'supportedGenerationMethods': ['embedContent'],
       },
+      {
+        'name': 'models/text-embedding-003',
+        'description': 'Deprecated: use gemini-embedding-001 instead.',
+        'supportedGenerationMethods': ['embedContent'],
+      },
     ];
 
     test('routes gemini-embedding-* to the embedder path, not the model '
@@ -142,14 +147,18 @@ void main() {
       expect(models, isNot(contains('googleai/embedding-gecko-001')));
     });
 
-    test('drops deprecated embedders', () async {
-      final actions = await _discoveryPlugin(discovered).list();
+    test(
+      'drops deprecated embedders whatever the description casing',
+      () async {
+        final actions = await _discoveryPlugin(discovered).list();
 
-      final embedders = actions
-          .where((a) => a.actionType == 'embedder')
-          .map((a) => a.name);
-      expect(embedders, isNot(contains('googleai/embedding-001')));
-    });
+        final embedders = actions
+            .where((a) => a.actionType == 'embedder')
+            .map((a) => a.name);
+        expect(embedders, isNot(contains('googleai/embedding-001')));
+        expect(embedders, isNot(contains('googleai/text-embedding-003')));
+      },
+    );
   });
 
   group('embedContent on the wire', () {
@@ -247,6 +256,34 @@ void main() {
       });
       expect(response.result.embeddings, hasLength(2));
     });
+
+    test(
+      'rejects a document with no content before any request goes out',
+      () async {
+        final captured = <Map<String, dynamic>>[];
+        final plugin = _EmbedWirePlugin(captured, <Uri>[]);
+        final embedder =
+            plugin.resolve('embedder', 'gemini-embedding-2')!
+                as _EmbedderAction;
+
+        await expectLater(
+          embedder.run(
+            EmbedRequest(
+              input: [
+                DocumentData(content: [TextPart(text: 'first')]),
+                DocumentData(content: []),
+              ],
+            ),
+          ),
+          throwsA(
+            isA<GenkitException>()
+                .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+                .having((e) => e.message, 'message', contains('index 1')),
+          ),
+        );
+        expect(captured, isEmpty);
+      },
+    );
 
     test('still forwards embedder options on media requests', () async {
       final captured = <Map<String, dynamic>>[];

--- a/packages/genkit_google_genai/test/known_models_wiring_test.dart
+++ b/packages/genkit_google_genai/test/known_models_wiring_test.dart
@@ -39,7 +39,8 @@ class MockHttpClient extends http.BaseClient {
         modelsResponse ??
         '{"models": ['
             '{"name": "models/gemini-2.0-flash"}, '
-            '{"name": "models/text-embedding-004"}]}';
+            '{"name": "models/text-embedding-004", '
+            '"supportedGenerationMethods": ["embedContent"]}]}';
     return http.StreamedResponse(
       Stream.value(utf8.encode(body)),
       listStatus,

--- a/packages/genkit_vertexai/lib/src/embedders.dart
+++ b/packages/genkit_vertexai/lib/src/embedders.dart
@@ -25,7 +25,7 @@ List<ActionMetadata<dynamic, dynamic, dynamic, dynamic>> listVertexEmbedders({
       .whereType<Map>()
       .where((modelMap) {
         final name = modelMap['name'] as String?;
-        return name != null && name.contains('embedding');
+        return name != null && google.isEmbedderModelName(name);
       })
       .map((modelMap) {
         final modelName = (modelMap['name'] as String).split('/').last;


### PR DESCRIPTION
Fixes items 1 and 2 of #328.

`gemini-embedding-2` was misclassified in `list()` discovery: the model filter matched the `models/gemini-` prefix while the embedder filter only knew `text-embedding-`/`embedding-`, so it registered as a generative model and never appeared as an embedder. Names now route through a shared `isEmbedderModelName`, reused by the Vertex publisher-model filter, and discovered embedders are listed only when they support `embedContent` and are not deprecated. The deprecation match lowercases the description, a superset of the JS plugin's case-sensitive check.

`createEmbedder` joined text parts and silently dropped media. It now converts every document part with `toGeminiPart` under the `user` role, so data-URI media reaches the API as `inlineData` and image and video input works. Two behavior changes, both pinned by wire tests: non-text parts produce real parts, or a hard error for unsupported types, instead of a joined string (JS parity); and an empty document is rejected up front with `INVALID_ARGUMENT` rather than sending an empty text part.

Item 3 (curated embedder metadata) is deferred until #327 lands.
