### PR TITLE
fix(anthropic): handle model-specific thinking defaults

### DIFF
--- a/packages/genkit_anthropic/README.md
+++ b/packages/genkit_anthropic/README.md
@@ -78,18 +78,29 @@ final response = await ai.generate(
 print(response.text);
 ```
 
-### Thinking (Claude 3.7+)
+### Thinking
 
 ```dart
 final response = await ai.generate(
-  model: anthropic.model('claude-sonnet-4-5'),
+  model: anthropic.model('claude-sonnet-5'),
   prompt: 'Solve this 24 game: 2, 3, 10, 10',
-  config: AnthropicOptions(thinking: ThinkingConfig(budgetTokens: 2048)),
+  config: AnthropicOptions(
+    // Uses the model's compatible default thinking mode.
+    thinking: ThinkingConfig(),
+    outputConfig: AnthropicOutputConfig(effort: 'high'),
+  ),
 );
 
 // The thinking content is available in the message parts
 print(response.message?.content);
 ```
+
+An omitted thinking type resolves to the model's own default: Claude 4.6 and
+newer default to `adaptive`, while Claude 4.5 models default to `enabled`,
+which uses a manual token budget. You can also select a mode explicitly with
+`ThinkingConfig(type: 'enabled', budgetTokens: 2048)`. For model names outside
+the curated catalog, set `thinking.type` explicitly so the plugin does not
+guess an incompatible mode.
 
 ### Structured Output
 

--- a/packages/genkit_anthropic/lib/src/known_models.dart
+++ b/packages/genkit_anthropic/lib/src/known_models.dart
@@ -47,26 +47,43 @@ const structuredClaudeSupports = <String, dynamic>{
 /// model names still resolve dynamically via the plugin's `commonModelInfo`
 /// fallback, so this enum only enriches the names listed here.
 enum KnownClaudeModel {
-  fable5('claude-fable-5', 'Claude Fable 5'),
-  opus5('claude-opus-5', 'Claude Opus 5'),
-  opus48('claude-opus-4-8', 'Claude Opus 4.8'),
-  opus47('claude-opus-4-7', 'Claude Opus 4.7'),
-  opus46('claude-opus-4-6', 'Claude Opus 4.6'),
-  opus45('claude-opus-4-5', 'Claude Opus 4.5'),
-  sonnet5('claude-sonnet-5', 'Claude Sonnet 5'),
-  sonnet46('claude-sonnet-4-6', 'Claude Sonnet 4.6'),
-  sonnet45('claude-sonnet-4-5', 'Claude Sonnet 4.5'),
-  haiku45('claude-haiku-4-5', 'Claude Haiku 4.5');
+  fable5('claude-fable-5', 'Claude Fable 5', ClaudeThinkingMode.adaptive),
+  opus5('claude-opus-5', 'Claude Opus 5', ClaudeThinkingMode.adaptive),
+  opus48('claude-opus-4-8', 'Claude Opus 4.8', ClaudeThinkingMode.adaptive),
+  opus47('claude-opus-4-7', 'Claude Opus 4.7', ClaudeThinkingMode.adaptive),
+  opus46('claude-opus-4-6', 'Claude Opus 4.6', ClaudeThinkingMode.adaptive),
+  opus45('claude-opus-4-5', 'Claude Opus 4.5', ClaudeThinkingMode.enabled),
+  sonnet5('claude-sonnet-5', 'Claude Sonnet 5', ClaudeThinkingMode.adaptive),
+  sonnet46(
+    'claude-sonnet-4-6',
+    'Claude Sonnet 4.6',
+    ClaudeThinkingMode.adaptive,
+  ),
+  sonnet45(
+    'claude-sonnet-4-5',
+    'Claude Sonnet 4.5',
+    ClaudeThinkingMode.enabled,
+  ),
+  haiku45('claude-haiku-4-5', 'Claude Haiku 4.5', ClaudeThinkingMode.enabled);
 
   // The base tier currently has no curated member.
-  // ignore: unused_element_parameter
-  const KnownClaudeModel(this.id, this.label, {this.structuredOutputs = true});
+  const KnownClaudeModel(
+    this.id,
+    this.label,
+    this.defaultThinkingMode, {
+    // ignore: unused_element_parameter
+    this.structuredOutputs = true,
+  });
 
   /// Bare model name (no plugin prefix).
   final String id;
 
   /// Human-readable label surfaced in listings.
   final String label;
+
+  /// Thinking mode used when a request supplies a thinking configuration but
+  /// does not select a mode explicitly.
+  final ClaudeThinkingMode defaultThinkingMode;
 
   /// Whether the model is on Anthropic's Structured Outputs list and may
   /// claim native constrained generation and JSON output.
@@ -79,6 +96,23 @@ enum KnownClaudeModel {
     stage: 'stable',
   );
 }
+
+/// Thinking modes that can be safely selected by default for curated models.
+enum ClaudeThinkingMode { enabled, adaptive }
+
+final _datedSuffixRegExp = RegExp(r'-\d{8}$');
+
+/// Returns the curated alias for [modelName], removing a dated snapshot suffix.
+String claudeModelAlias(String modelName) =>
+    modelName.replaceFirst(_datedSuffixRegExp, '');
+
+final _knownClaudeModelsById = <String, KnownClaudeModel>{
+  for (final model in KnownClaudeModel.values) model.id: model,
+};
+
+/// Returns the curated model matching [modelName], including dated snapshots.
+KnownClaudeModel? knownClaudeModelFor(String modelName) =>
+    _knownClaudeModelsById[claudeModelAlias(modelName)];
 
 /// Curated capability metadata for known Claude models, keyed by bare model
 /// name (no plugin prefix).

--- a/packages/genkit_anthropic/lib/src/model.dart
+++ b/packages/genkit_anthropic/lib/src/model.dart
@@ -61,6 +61,9 @@ abstract class $AnthropicOptions {
 
   /// Extended thinking configuration for supported Anthropic models (like Claude 3.7 Sonnet).
   $ThinkingConfig? get thinking;
+
+  /// Anthropic-specific output behavior configuration.
+  $AnthropicOutputConfig? get outputConfig;
 }
 
 /// Configuration for Anthropic's extended thinking mode.
@@ -82,4 +85,16 @@ abstract class $ThinkingConfig {
         'The budget must be at least 1024 tokens and cannot exceed the model\'s max_tokens limit.',
   )
   int? get budgetTokens;
+}
+
+/// Configuration for Anthropic output behavior.
+@Schema()
+abstract class $AnthropicOutputConfig {
+  @StringField(
+    enumValues: ['low', 'medium', 'high', 'xhigh', 'max'],
+    description:
+        'Controls the effort Claude spends on the response, trading off '
+        'response depth against latency and token usage.',
+  )
+  String? get effort;
 }

--- a/packages/genkit_anthropic/lib/src/model.g.dart
+++ b/packages/genkit_anthropic/lib/src/model.g.dart
@@ -36,6 +36,7 @@ base class AnthropicOptions {
     int? topK,
     List<String>? stopSequences,
     ThinkingConfig? thinking,
+    AnthropicOutputConfig? outputConfig,
   }) {
     _json = {
       'apiKey': ?apiKey,
@@ -45,6 +46,7 @@ base class AnthropicOptions {
       'topK': ?topK,
       'stopSequences': ?stopSequences,
       'thinking': ?thinking?.toJson(),
+      'outputConfig': ?outputConfig?.toJson(),
     };
   }
 
@@ -146,6 +148,24 @@ base class AnthropicOptions {
     }
   }
 
+  /// Anthropic-specific output behavior configuration.
+  AnthropicOutputConfig? get outputConfig {
+    return _json['outputConfig'] == null
+        ? null
+        : AnthropicOutputConfig.fromJson(
+            _json['outputConfig'] as Map<String, dynamic>,
+          );
+  }
+
+  /// Anthropic-specific output behavior configuration.
+  set outputConfig(AnthropicOutputConfig? value) {
+    if (value == null) {
+      _json.remove('outputConfig');
+    } else {
+      _json['outputConfig'] = value.toJson();
+    }
+  }
+
   @override
   String toString() {
     return _json.toString();
@@ -197,10 +217,13 @@ base class _AnthropicOptionsTypeFactory
             ),
             'stopSequences': $Schema.list(items: $Schema.string()),
             'thinking': $Schema.fromMap({'\$ref': r'#/$defs/ThinkingConfig'}),
+            'outputConfig': $Schema.fromMap({
+              '\$ref': r'#/$defs/AnthropicOutputConfig',
+            }),
           },
         )
         .value,
-    dependencies: [ThinkingConfig.$schema],
+    dependencies: [ThinkingConfig.$schema, AnthropicOutputConfig.$schema],
   );
 }
 
@@ -280,6 +303,74 @@ base class _ThinkingConfigTypeFactory extends SchemanticType<ThinkingConfig> {
               description:
                   'Determines how many tokens Claude can use for its internal reasoning process. Larger budgets allow for more extensive thought but increase latency and cost. The budget must be at least 1024 tokens and cannot exceed the model\'s max_tokens limit.',
               minimum: 1024,
+            ),
+          },
+        )
+        .value,
+    dependencies: [],
+  );
+}
+
+/// Configuration for Anthropic output behavior.
+base class AnthropicOutputConfig {
+  /// Creates a [AnthropicOutputConfig] from a JSON map.
+  factory AnthropicOutputConfig.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  AnthropicOutputConfig._(this._json);
+
+  AnthropicOutputConfig({String? effort}) {
+    _json = {'effort': ?effort};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [AnthropicOutputConfig].
+  static const SchemanticType<AnthropicOutputConfig> $schema =
+      _AnthropicOutputConfigTypeFactory();
+
+  String? get effort {
+    return _json['effort'] as String?;
+  }
+
+  set effort(String? value) {
+    if (value == null) {
+      _json.remove('effort');
+    } else {
+      _json['effort'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [AnthropicOutputConfig] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _AnthropicOutputConfigTypeFactory
+    extends SchemanticType<AnthropicOutputConfig> {
+  const _AnthropicOutputConfigTypeFactory();
+
+  @override
+  AnthropicOutputConfig parse(Object? json) {
+    return AnthropicOutputConfig._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'AnthropicOutputConfig',
+    definition: $Schema
+        .object(
+          properties: {
+            'effort': $Schema.string(
+              description:
+                  'Controls the effort Claude spends on the response, trading off response depth against latency and token usage.',
+              enumValues: ['low', 'medium', 'high', 'xhigh', 'max'],
             ),
           },
         )

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -70,13 +70,10 @@ class AnthropicPluginImpl extends GenkitPlugin {
     knownClaudeModels,
   );
 
-  static final _datedSuffixRegExp = RegExp(r'-\d{8}$');
-
   /// Strips a trailing dated-snapshot suffix (e.g.
   /// `claude-haiku-4-5-20251001` -> `claude-haiku-4-5`) so dated ids returned
   /// by the models endpoint map onto the curated aliases.
-  static String _aliasOf(String modelName) =>
-      modelName.replaceFirst(_datedSuffixRegExp, '');
+  static String _aliasOf(String modelName) => claudeModelAlias(modelName);
 
   /// Returns the capability metadata for [modelName], matching by exact name
   /// first and then by dated-snapshot alias, falling back to [commonModelInfo]
@@ -269,7 +266,8 @@ class AnthropicPluginImpl extends GenkitPlugin {
       };
     }
 
-    final thinking = _mapThinkingConfig(options.thinking);
+    final thinking = _mapThinkingConfig(options.thinking, modelName);
+    final outputConfig = _mapOutputConfig(options.outputConfig);
 
     return sdk.MessageCreateRequest(
       model: modelName,
@@ -283,6 +281,7 @@ class AnthropicPluginImpl extends GenkitPlugin {
       tools: tools.isNotEmpty ? tools : null,
       toolChoice: toolChoice,
       thinking: thinking,
+      outputConfig: outputConfig,
     );
   }
 
@@ -471,14 +470,52 @@ Map<String, dynamic> _extractOutput(Map<String, dynamic> input) {
   return input;
 }
 
-sdk.ThinkingConfig? _mapThinkingConfig(ThinkingConfig? config) {
+sdk.ThinkingConfig? _mapThinkingConfig(
+  ThinkingConfig? config,
+  String modelName,
+) {
   if (config == null) return null;
-  return switch (config.type ?? 'enabled') {
+
+  final type =
+      config.type ?? knownClaudeModelFor(modelName)?.defaultThinkingMode.name;
+  if (type == null) {
+    throw GenkitException(
+      'Set thinking.type explicitly for unknown Anthropic model "$modelName".',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+
+  return switch (type) {
     'disabled' => sdk.ThinkingConfig.disabled(),
     'adaptive' => sdk.ThinkingConfig.adaptive(),
     // 1024 is the minimum budget_tokens required by the Anthropic API.
-    _ => sdk.ThinkingConfig.enabled(budgetTokens: config.budgetTokens ?? 1024),
+    'enabled' => sdk.ThinkingConfig.enabled(
+      budgetTokens: config.budgetTokens ?? 1024,
+    ),
+    _ => throw GenkitException(
+      'Unsupported Anthropic thinking type "$type".',
+      status: StatusCodes.INVALID_ARGUMENT,
+    ),
   };
+}
+
+sdk.OutputConfig? _mapOutputConfig(AnthropicOutputConfig? config) {
+  final effort = config?.effort;
+  if (effort == null) return null;
+
+  return sdk.OutputConfig(
+    effort: switch (effort) {
+      'low' => sdk.EffortLevel.low,
+      'medium' => sdk.EffortLevel.medium,
+      'high' => sdk.EffortLevel.high,
+      'xhigh' => sdk.EffortLevel.xhigh,
+      'max' => sdk.EffortLevel.max,
+      _ => throw GenkitException(
+        'Unsupported Anthropic output effort "$effort".',
+        status: StatusCodes.INVALID_ARGUMENT,
+      ),
+    },
+  );
 }
 
 /// Emits streaming chunks for content deltas and throws on error events.

--- a/packages/genkit_anthropic/test/test_live.dart
+++ b/packages/genkit_anthropic/test/test_live.dart
@@ -77,7 +77,7 @@ void main() {
       );
 
       final chunks = await response.toList();
-      expect(chunks.length, greaterThan(1));
+      expect(chunks, isNotEmpty);
       final fullText = chunks.map((c) => c.text).join();
       expect(fullText, contains('5'));
 
@@ -139,14 +139,26 @@ void main() {
         model: anthropic.model('claude-sonnet-4-5'),
         prompt: 'Solve this 24 game: 2, 3, 10, 10',
         config: AnthropicOptions(
-          // Thinking requires budget if supported
-          thinking: ThinkingConfig(budgetTokens: 1024),
+          thinking: ThinkingConfig(type: 'enabled', budgetTokens: 1024),
         ),
       );
       expect(
         response.message?.content.where((p) => p.isReasoning).length,
         greaterThanOrEqualTo(1),
       );
+    }, timeout: Timeout(Duration(minutes: 2)));
+
+    test('should use adaptive thinking for newer models', () async {
+      final response = await ai.generate(
+        model: anthropic.model('claude-sonnet-5'),
+        prompt: 'What is 17 * 19? Answer briefly.',
+        config: AnthropicOptions(
+          maxTokens: 512,
+          thinking: ThinkingConfig(),
+          outputConfig: AnthropicOutputConfig(effort: 'low'),
+        ),
+      );
+      expect(response.text, isNotEmpty);
     }, timeout: Timeout(Duration(minutes: 2)));
   });
 }

--- a/packages/genkit_anthropic/test/thinking_config_wire_test.dart
+++ b/packages/genkit_anthropic/test/thinking_config_wire_test.dart
@@ -1,0 +1,184 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_anthropic/genkit_anthropic.dart';
+import 'package:genkit_anthropic/src/plugin_impl.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+Future<Map<String, dynamic>> _requestOnTheWire({
+  required String model,
+  ThinkingConfig? thinking,
+  AnthropicOutputConfig? outputConfig,
+}) async {
+  Map<String, dynamic>? captured;
+  final client = MockClient((request) async {
+    if (request.url.path != '/v1/messages') {
+      return http.Response('not found', 404);
+    }
+    captured = (jsonDecode(request.body) as Map).cast<String, dynamic>();
+    return http.Response(
+      jsonEncode({
+        'id': 'msg_test',
+        'type': 'message',
+        'role': 'assistant',
+        'model': model,
+        'content': [
+          {'type': 'text', 'text': 'ok'},
+        ],
+        'stop_reason': 'end_turn',
+        'stop_sequence': null,
+        'usage': {'input_tokens': 1, 'output_tokens': 1},
+      }),
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  });
+  final plugin = AnthropicPluginImpl(apiKey: 'test-key', httpClient: client);
+  addTearDown(plugin.close);
+  final action = plugin.resolve('model', model) as Model;
+
+  await action(
+    ModelRequest(
+      messages: [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hello')],
+        ),
+      ],
+      config: AnthropicOptions(
+        thinking: thinking,
+        outputConfig: outputConfig,
+      ).toJson(),
+    ),
+  );
+
+  return captured!;
+}
+
+void main() {
+  group('thinking config on the wire', () {
+    const adaptiveModels = [
+      'claude-fable-5',
+      'claude-opus-5',
+      'claude-opus-4-8',
+      'claude-opus-4-7',
+      'claude-opus-4-6',
+      'claude-sonnet-5',
+      'claude-sonnet-4-6',
+    ];
+
+    for (final model in adaptiveModels) {
+      test('$model defaults to adaptive', () async {
+        final body = await _requestOnTheWire(
+          model: model,
+          thinking: ThinkingConfig(),
+        );
+        expect(body['thinking'], {'type': 'adaptive'});
+      });
+    }
+
+    test('dated adaptive snapshot uses its curated alias', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-opus-4-7-20260205',
+        thinking: ThinkingConfig(),
+      );
+      expect(body['thinking'], {'type': 'adaptive'});
+    });
+
+    test('Claude 4.5 models default to manual thinking', () async {
+      final sonnet = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        thinking: ThinkingConfig(),
+      );
+      final haiku = await _requestOnTheWire(
+        model: 'claude-haiku-4-5-20251001',
+        thinking: ThinkingConfig(budgetTokens: 2048),
+      );
+      final opus = await _requestOnTheWire(
+        model: 'claude-opus-4-5',
+        thinking: ThinkingConfig(),
+      );
+
+      expect(sonnet['thinking'], {'type': 'enabled', 'budget_tokens': 1024});
+      expect(haiku['thinking'], {'type': 'enabled', 'budget_tokens': 2048});
+      expect(opus['thinking'], {'type': 'enabled', 'budget_tokens': 1024});
+    });
+
+    test('explicit types override curated defaults', () async {
+      final manual = await _requestOnTheWire(
+        model: 'claude-opus-4-7',
+        thinking: ThinkingConfig(type: 'enabled', budgetTokens: 2048),
+      );
+      final adaptive = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        thinking: ThinkingConfig(type: 'adaptive', budgetTokens: 2048),
+      );
+
+      expect(manual['thinking'], {'type': 'enabled', 'budget_tokens': 2048});
+      expect(adaptive['thinking'], {'type': 'adaptive'});
+    });
+
+    test('explicit type works for an unknown model', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-future-model',
+        thinking: ThinkingConfig(type: 'disabled'),
+      );
+      expect(body['thinking'], {'type': 'disabled'});
+    });
+
+    test('unknown model requires an explicit type', () async {
+      await expectLater(
+        _requestOnTheWire(
+          model: 'claude-future-model',
+          thinking: ThinkingConfig(),
+        ),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having((e) => e.message, 'message', contains('thinking.type')),
+        ),
+      );
+    });
+
+    test('omits thinking when no config is provided', () async {
+      final body = await _requestOnTheWire(model: 'claude-opus-4-7');
+      expect(body, isNot(contains('thinking')));
+    });
+  });
+
+  group('output config on the wire', () {
+    for (final effort in ['low', 'medium', 'high', 'xhigh', 'max']) {
+      test('maps $effort effort', () async {
+        final body = await _requestOnTheWire(
+          model: 'claude-sonnet-5',
+          outputConfig: AnthropicOutputConfig(effort: effort),
+        );
+        expect(body['output_config'], {'effort': effort});
+      });
+    }
+
+    test('omits output_config when no effort is provided', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-5',
+        outputConfig: AnthropicOutputConfig(),
+      );
+      expect(body, isNot(contains('output_config')));
+    });
+  });
+}


### PR DESCRIPTION
This PR handles model-specific thinking defaults. It resolve default thinking mode per model; expose output_config.effort for the adaptive path.

"Tracked" = present in the curated KnownClaudeModel enum (10 models). Lookup is by exact bare name, then by dated-snapshot alias — claude-haiku-4-5-20251001 strips to claude-haiku-4-5, so dated ids from the models endpoint hit the same entry.

Capability metadata — graceful fallback. modelInfoFor() returns curated ModelInfo (typed label, stable stage, tiered supports) for tracked names, and falls back to commonModelInfo for anything else. Untracked names always resolve; you can call any model string the API accepts, tracked or not. Tracking only enriches — it adds the label/stage and guarantees the model shows up in listings even when discovery fails or omits it.

Thinking mode — explicit failure. When thinking is supplied without a type, tracked models fill in their defaultThinkingMode (adaptive for 4.6-and-newer, enabled for 4.5). Untracked models throw INVALID_ARGUMENT asking for an explicit type rather than guessing. An explicit type always works for any model, tracked or not — the catalog is consulted only to fill the blank.

The asymmetry is intentional: a wrong capability guess is cheap and self-correcting, whereas a wrong thinking mode is a hard API rejection at request time, so that one refuses to guess.

Closes: #354 

