### PR TITLE
feat!: add cancellation support for action calls and generate API

### DIFF
--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -291,11 +291,10 @@ final aborted = await ai.generate(
 if (aborted.finishReason == FinishReason.aborted) {
   print('Cancelled: ${aborted.finishMessage}');
 
-  // Resume: reuse the preserved history with a brand-new token.
+  // Resume: reuse the preserved history.
   final resumed = await ai.generate(
     model: googleAI.gemini('gemini-flash-latest'),
     messages: aborted.messages, // last-good conversation state
-    cancel: CancellationController().token,
   );
   print(resumed.text);
 }

--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -272,7 +272,10 @@ if (response.finishReason == FinishReason.interrupted) {
 
 Cancel an in-flight `generate` or `generateStream` call. You create a `CancellationController`, pass its `token` into `generate`, and call `cancel()` when you want to stop (e.g. the user hits "stop").
 
-Rather than throwing, a cancelled call resolves with a response whose `finishReason` is `FinishReason.aborted`. The response has no model message, but `response.messages` carries the last-good conversation history, so you can resume from where you left off by passing it back into a fresh `generate` with a new token:
+Cancellation is **cooperative and best-effort**: it prevents further work — additional turns, the tool loop, and (where the plugin supports it) aborting the in-flight model call. When work is actually interrupted, the call resolves — rather than throwing — with a response whose `finishReason` is `FinishReason.aborted`. That aborted response has no model message, but `response.messages` carries the last-good conversation history, so you can resume from where you left off by passing it back into a fresh `generate` with a new token.
+
+If the model call happens to complete before the cancellation takes effect, its result is returned normally (e.g. `finishReason: stop` with the full message) — the completed work is not discarded. Whether a mid-flight cancel yields `aborted` or a completed result therefore depends on the plugin: plugins that tear down their transport on cancel (e.g. `genkit_google_genai`) surface `aborted` promptly, while others may run the request to completion.
+
 
 ```dart
 // Kick off a generation we can interrupt.

--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -268,6 +268,41 @@ if (response.finishReason == FinishReason.interrupted) {
 }
 ```
 
+### Cancellation
+
+Cancel an in-flight `generate` or `generateStream` call. You create a `CancellationController`, pass its `token` into `generate`, and call `cancel()` when you want to stop (e.g. the user hits "stop").
+
+Rather than throwing, a cancelled call resolves with a response whose `finishReason` is `FinishReason.aborted`. The response has no model message, but `response.messages` carries the last-good conversation history, so you can resume from where you left off by passing it back into a fresh `generate` with a new token:
+
+```dart
+// Kick off a generation we can interrupt.
+final controller = CancellationController();
+// Simulate the user pressing "stop" mid-flight.
+Timer(const Duration(milliseconds: 200), () {
+  controller.cancel('user pressed stop');
+});
+
+final aborted = await ai.generate(
+  model: googleAI.gemini('gemini-flash-latest'),
+  prompt: 'Explain quantum computing in detail.',
+  cancel: controller.token,
+);
+
+if (aborted.finishReason == FinishReason.aborted) {
+  print('Cancelled: ${aborted.finishMessage}');
+
+  // Resume: reuse the preserved history with a brand-new token.
+  final resumed = await ai.generate(
+    model: googleAI.gemini('gemini-flash-latest'),
+    messages: aborted.messages, // last-good conversation state
+    cancel: CancellationController().token,
+  );
+  print(resumed.text);
+}
+```
+
+The same aborted-response path is used when a generation exceeds its `maxTurns` limit (`finishMessage` contains "max turns"), so the same resume pattern applies after bumping `maxTurns`.
+
 ### Middleware
 
 Intercept and modify requests and responses with middleware. Genkit provides built-in middleware like `retry` for robust error handling. Check out the [genkit_middleware](https://pub.dev/packages/genkit_middleware) package for more specialized middleware like tool approval, filesystem access, and skills.

--- a/packages/genkit/lib/client.dart
+++ b/packages/genkit/lib/client.dart
@@ -30,6 +30,7 @@ export 'src/ai/agents/agent_core.dart'
         AgentSnapshot,
         AgentTransport,
         AgentTurn,
+        CancellationController,
         CancellationToken,
         DetachedTask,
         TurnStream;

--- a/packages/genkit/lib/genkit.dart
+++ b/packages/genkit/lib/genkit.dart
@@ -43,6 +43,7 @@ export 'src/ai/agents/agent_core.dart'
         AgentSnapshot,
         AgentTransport,
         AgentTurn,
+        CancellationController,
         CancellationToken,
         DetachedTask,
         TurnStream;
@@ -106,10 +107,10 @@ export 'src/ai/tool.dart'
         ToolInterruptResult,
         ToolResponseResult,
         ToolResult;
-
 export 'src/core/action.dart'
     show Action, ActionFnArg, ActionMetadata, ActionType;
-
+export 'src/core/cancellation.dart'
+    show CancellationController, CancellationToken, CancelledException;
 export 'src/core/dynamic_action_provider.dart' show DynamicActionProvider;
 export 'src/core/flow.dart';
 export 'src/exception.dart' show GenkitException, StatusCodes;

--- a/packages/genkit/lib/lite.dart
+++ b/packages/genkit/lib/lite.dart
@@ -32,10 +32,13 @@ import 'src/ai/generate_types.dart';
 import 'src/ai/model.dart';
 import 'src/ai/tool.dart';
 import 'src/core/action.dart';
+import 'src/core/cancellation.dart';
 import 'src/core/registry.dart';
 import 'src/types.dart';
 
 export 'src/ai/remote_model.dart' show remoteModel;
+export 'src/core/cancellation.dart'
+    show CancellationController, CancellationToken;
 export 'src/schema_extensions.dart';
 export 'src/types.dart';
 
@@ -60,6 +63,10 @@ Future<GenerateResponseHelper> generate<C>({
   Map<String, dynamic>? context,
   StreamingCallback<GenerateResponseChunk>? onChunk,
   List<GenerateMiddleware>? use,
+
+  /// Cooperative cancellation token, observed by the model call, tools, and
+  /// middleware to abort generation.
+  CancellationToken? cancel,
 
   /// Optional data to resume an interrupted generation session.
   ///
@@ -123,6 +130,7 @@ Future<GenerateResponseHelper> generate<C>({
     maxTurns: maxTurns,
     output: outputConfig,
     context: context,
+    cancel: cancel,
     onChunk: onChunk,
     middleware: use
         ?.map((mw) => (middlewareInstance: mw, middlewareRef: null))
@@ -152,6 +160,7 @@ ActionStream<GenerateResponseChunk, GenerateResponseHelper> generateStream<C>({
   String? outputContentType,
   Map<String, dynamic>? context,
   List<GenerateMiddleware>? use,
+  CancellationToken? cancel,
   List<InterruptResponse>? interruptRespond,
   List<ToolRequestPart>? interruptRestart,
 }) {
@@ -180,6 +189,7 @@ ActionStream<GenerateResponseChunk, GenerateResponseHelper> generateStream<C>({
         outputNoInstructions: outputNoInstructions,
         outputContentType: outputContentType,
         context: context,
+        cancel: cancel,
         onChunk: (chunk) {
           if (streamController.isClosed) return;
           streamController.add(chunk);

--- a/packages/genkit/lib/plugin.dart
+++ b/packages/genkit/lib/plugin.dart
@@ -46,6 +46,8 @@ export 'package:genkit/src/ai/tool.dart'
         ToolResult;
 export 'package:genkit/src/core/action.dart'
     show Action, ActionFnArg, ActionMetadata, ActionType;
+export 'package:genkit/src/core/cancellation.dart'
+    show CancellationController, CancellationToken, CancelledException;
 export 'package:genkit/src/core/plugin.dart' show GenkitPlugin;
 export 'package:genkit/src/core/registry.dart' show Registry;
 export 'package:genkit/src/exception.dart' show GenkitException, StatusCodes;

--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -47,9 +47,16 @@ import 'session.dart';
 /// ended (e.g. `interrupted`, `length`). When omitted, no per-turn reason is
 /// reported.
 class TurnResult {
-  TurnResult({this.finishReason});
+  TurnResult({this.finishReason, this.finishMessage});
 
   final AgentFinishReason? finishReason;
+
+  /// An optional human-readable message describing why the turn ended.
+  ///
+  /// Carries, for example, the "Reached max turns of N" text from a generation
+  /// that overran its turn limit, so the [SessionRunner] can surface it rather
+  /// than dropping it.
+  final String? finishMessage;
 }
 
 /// Per-turn context handed to the handler passed to [SessionRunner.run].
@@ -404,14 +411,50 @@ class SessionRunner<State> {
           if (cancel?.isCancelled ?? false) {
             lastTurnFinishReason = AgentFinishReason.aborted;
             lastTurnError = null;
+            // Persist the turn as `aborted`. The detached route already wrote
+            // `aborted` via `_abortSnapshotInStore`, in which case the
+            // abort-aware mutator makes this a no-op; but the attached route
+            // (`AgentTurn.abort()` -> token cancel) has written nothing, so
+            // without this the trailing `invocationEnd` snapshot would persist a
+            // half-finished turn as `completed` and later be picked as a resume
+            // point.
+            final snapshotId = await maybeSnapshot(
+              status: 'aborted',
+              snapshotId: turnSnapshotId,
+              finishReason: AgentFinishReason.aborted,
+            );
             _notifyEndTurn(
-              _lastSnapshot?.snapshotId,
+              snapshotId ?? _lastSnapshot?.snapshotId,
               AgentFinishReason.aborted,
             );
             return true;
           }
 
           final finishReason = turnResult?.finishReason;
+
+          // A turn that resolved `aborted` *without* the token being cancelled
+          // is not a cooperative cancel: it is an overrun (e.g. the generate
+          // loop hit `maxTurns`). Route it to the failure path so the reason
+          // (e.g. "Reached max turns of N") surfaces as an error instead of
+          // being silently dropped as a success with a null message.
+          if (finishReason == AgentFinishReason.aborted) {
+            lastTurnFinishReason = AgentFinishReason.failed;
+            lastTurnError = toErrorDetails(
+              GenkitException(
+                turnResult?.finishMessage ?? 'Turn aborted.',
+                status: StatusCodes.ABORTED,
+              ),
+            );
+            final snapshotId = await maybeSnapshot(
+              status: 'failed',
+              error: lastTurnError,
+              snapshotId: turnSnapshotId,
+              finishReason: AgentFinishReason.failed,
+            );
+            _notifyEndTurn(snapshotId, AgentFinishReason.failed);
+            return true;
+          }
+
           lastTurnFinishReason = finishReason;
           lastTurnError = null;
 
@@ -898,7 +941,7 @@ final class _InProcessTransport extends AgentTransport {
   TurnStream runTurn(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     final bidi = _startBidi(input, init, context: context, cancel: cancel);
@@ -909,7 +952,7 @@ final class _InProcessTransport extends AgentTransport {
   Future<AgentOutput>? run(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     return _startBidi(input, init, context: context, cancel: cancel).onResult;
@@ -1137,7 +1180,9 @@ Agent<State> defineCustomAgent<State>(
           // Capture the disposer so a reused, long-lived `ctx.cancel` token
           // doesn't accumulate one stranded listener (pinning this turn's
           // controller and closure) per turn. Disposed when the flow settles.
-          final unlinkCancel = ctx.cancel.onCancel(cancelController.cancel);
+          // `link` forwards the cancellation reason so a caller-supplied
+          // `controller.cancel('...')` survives the hop into this turn's token.
+          final unlinkCancel = ctx.cancel?.link(cancelController);
           final cancelToken = cancelController.token;
           void Function()? unsubscribe;
           // Background heartbeat timer for the detached snapshot. Started in
@@ -1302,7 +1347,7 @@ Agent<State> defineCustomAgent<State>(
               // The turn has settled (the snapshot reached a terminal status),
               // so stop refreshing its heartbeat.
               stopHeartbeat();
-              unlinkCancel();
+              unlinkCancel?.call();
               unsubscribe?.call();
               offArtifactAdded();
               offArtifactUpdated();
@@ -1597,10 +1642,16 @@ Agent<State> definePromptAgent<State>(
         context: options.context,
         inputStream: null,
         init: null,
-        cancel: options.cancel ?? CancellationToken.none,
+        cancel: options.cancel,
       ));
 
-      // Keep everything that is NOT a prompt-template message.
+      final aborted = res.finishReason == FinishReason.aborted;
+
+      // Keep everything that is NOT a prompt-template message. On an aborted
+      // turn `res.message` is null; the abort path already carries the last-good
+      // history in `res.modelRequest`, so leaving `keep` without a trailing
+      // model message preserves the user turn as the resume point rather than
+      // treating the user's own message as the model reply.
       final reqMessages = res.modelRequest?.messages;
       if (reqMessages != null) {
         final keep = reqMessages
@@ -1628,13 +1679,18 @@ Agent<State> definePromptAgent<State>(
       final reason = res.finishReason;
       return TurnResult(
         finishReason: reason != null ? AgentFinishReason(reason.value) : null,
+        finishMessage: aborted ? res.finishMessage : null,
       );
     });
 
     final msgs = sess.getMessages();
+    // Only surface the last message as the agent's reply when it is actually a
+    // model turn. An aborted turn leaves the user message last (see above), so
+    // returning it would echo the user's prompt back as the agent's reply.
+    final lastMessage = msgs.isNotEmpty ? msgs.last : null;
     return AgentResult(
       artifacts: sess.getArtifacts(),
-      message: msgs.isNotEmpty ? msgs.last : null,
+      message: lastMessage?.role == Role.model ? lastMessage : null,
       finishReason: sess.lastTurnFinishReason,
     );
   }

--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -1134,7 +1134,10 @@ Agent<State> defineCustomAgent<State>(
           // transport token to it, so an attached `runTurn(cancel:)` also
           // cooperatively stops this turn's `generate`.
           final cancelController = CancellationController();
-          ctx.cancel.onCancel(cancelController.cancel);
+          // Capture the disposer so a reused, long-lived `ctx.cancel` token
+          // doesn't accumulate one stranded listener (pinning this turn's
+          // controller and closure) per turn. Disposed when the flow settles.
+          final unlinkCancel = ctx.cancel.onCancel(cancelController.cancel);
           final cancelToken = cancelController.token;
           void Function()? unsubscribe;
           // Background heartbeat timer for the detached snapshot. Started in
@@ -1299,6 +1302,7 @@ Agent<State> defineCustomAgent<State>(
               // The turn has settled (the snapshot reached a terminal status),
               // so stop refreshing its heartbeat.
               stopHeartbeat();
+              unlinkCancel();
               unsubscribe?.call();
               offArtifactAdded();
               offArtifactUpdated();

--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -390,8 +390,26 @@ class SessionRunner<State> {
       );
 
       try {
-        await runInNewSpan('runTurn-${turnIndex + 1}', (_) async {
+        final aborted = await runInNewSpan('runTurn-${turnIndex + 1}', (
+          _,
+        ) async {
           final turnResult = await fn(input, turnContext);
+
+          // The generate loop now resolves (rather than throws) on a
+          // cooperative cancel, so a returned turn can still be an abort. Mirror
+          // the catch-path handling: record `aborted`, skip the `completed`
+          // snapshot (the abort path already persisted `aborted`, and the
+          // abort-aware mutator would skip a late `completed` write anyway), and
+          // stop processing further inputs.
+          if (cancel?.isCancelled ?? false) {
+            lastTurnFinishReason = AgentFinishReason.aborted;
+            lastTurnError = null;
+            _notifyEndTurn(
+              _lastSnapshot?.snapshotId,
+              AgentFinishReason.aborted,
+            );
+            return true;
+          }
 
           final finishReason = turnResult?.finishReason;
           lastTurnFinishReason = finishReason;
@@ -408,8 +426,9 @@ class SessionRunner<State> {
           _lastGoodFinishReason = finishReason;
 
           _notifyEndTurn(snapshotId, finishReason);
-          return 0;
+          return false;
         }, input: input);
+        if (aborted) break;
         turnIndex++;
       } catch (e) {
         // An aborted turn rejects out of `generate` and lands here. Treat it as
@@ -857,23 +876,24 @@ final class _InProcessTransport extends AgentTransport {
 
   BidiActionStream<AgentStreamChunk, AgentOutput, AgentInput> _startBidi(
     AgentInput input,
-    AgentInit init, [
+    AgentInit init, {
     Map<String, dynamic>? context,
-  ]) {
-    final bidi = primaryAction.streamBidi(init: init, context: context);
+    CancellationToken? cancel,
+  }) {
+    final bidi = primaryAction.streamBidi(
+      init: init,
+      context: context,
+      cancel: cancel,
+    );
     bidi.send(input);
     bidi.close();
     return bidi;
   }
 
-  // NOTE: [cancel] is accepted to satisfy the [AgentTransport] contract but is
-  // not threaded into `generate` on the in-process transport today, so it does
-  // not stop an in-flight model call for an *attached* turn. Cooperative
-  // cancellation currently only takes effect on the detached path: `abort`
-  // flips the persisted snapshot to `aborted`, and a detached worker observing
-  // that (via `SnapshotChangeNotifier`) cancels its own turn. Aborting an
-  // attached in-process turn is therefore effectively persist-only. Threading
-  // cancellation through `generate` to cancel attached turns is future work.
+  // [cancel] is threaded into the agent action's `generate` call (via
+  // `streamBidi`), so aborting an attached in-process turn cooperatively stops
+  // the in-flight model call. The detached path additionally observes the
+  // persisted `aborted` status via `SnapshotChangeNotifier`.
   @override
   TurnStream runTurn(
     AgentInput input,
@@ -881,12 +901,10 @@ final class _InProcessTransport extends AgentTransport {
     required CancellationToken cancel,
     Map<String, dynamic>? context,
   }) {
-    final bidi = _startBidi(input, init, context);
+    final bidi = _startBidi(input, init, context: context, cancel: cancel);
     return (stream: bidi, output: bidi.onResult);
   }
 
-  // See [runTurn]: [cancel] is not wired into `generate` here, so aborting an
-  // attached in-process turn is persist-only (does not stop the model).
   @override
   Future<AgentOutput>? run(
     AgentInput input,
@@ -894,7 +912,7 @@ final class _InProcessTransport extends AgentTransport {
     required CancellationToken cancel,
     Map<String, dynamic>? context,
   }) {
-    return _startBidi(input, init, context).onResult;
+    return _startBidi(input, init, context: context, cancel: cancel).onResult;
   }
 
   @override
@@ -1111,7 +1129,13 @@ Agent<State> defineCustomAgent<State>(
 
           String? detachedSnapshotId;
           final detachCompleter = Completer<void>();
-          final cancelToken = CancellationToken();
+          // Own a controller for this turn (cancelled on detach-abort or when
+          // the persisted snapshot flips to `aborted`) and link the ambient
+          // transport token to it, so an attached `runTurn(cancel:)` also
+          // cooperatively stops this turn's `generate`.
+          final cancelController = CancellationController();
+          ctx.cancel.onCancel(cancelController.cancel);
+          final cancelToken = cancelController.token;
           void Function()? unsubscribe;
           // Background heartbeat timer for the detached snapshot. Started in
           // `onDetach`, cleared when the flow settles (or on abort).
@@ -1190,7 +1214,7 @@ Agent<State> defineCustomAgent<State>(
                     .onSnapshotStateChange(snapshotId, (snap) {
                       if (snap.status?.value == 'aborted') {
                         stopHeartbeat();
-                        cancelToken.cancel();
+                        cancelController.cancel();
                         localUnsubscribe?.call();
                       }
                     }, context: ctx.context);
@@ -1569,6 +1593,7 @@ Agent<State> definePromptAgent<State>(
         context: options.context,
         inputStream: null,
         init: null,
+        cancel: options.cancel ?? CancellationToken.none,
       ));
 
       // Keep everything that is NOT a prompt-template message.

--- a/packages/genkit/lib/src/ai/agents/agent_core.dart
+++ b/packages/genkit/lib/src/ai/agents/agent_core.dart
@@ -78,7 +78,7 @@ abstract base class AgentTransport {
   TurnStream runTurn(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   });
 
@@ -90,7 +90,7 @@ abstract base class AgentTransport {
   Future<AgentOutput>? run(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) => null;
 
@@ -678,14 +678,14 @@ final class AgentChat<State> {
   /// turns resolve to a synthetic `aborted` response.
   Future<AgentResponse<State>> _buildResponse(
     Future<AgentOutput> output,
-    CancellationToken cancel,
+    CancellationToken? cancel,
     int messageCountBeforeTurn,
   ) async {
     AgentOutput raw;
     try {
       raw = await output;
     } catch (e) {
-      if (cancel.isCancelled) {
+      if (cancel?.isCancelled ?? false) {
         raw = AgentOutput(finishReason: AgentFinishReason.aborted);
       } else {
         // A thrown transport error / non-200 rejects before reaching the
@@ -772,13 +772,13 @@ final class AgentChat<State> {
     Map<String, dynamic>? context,
   }) async {
     // In `_send` the token is observed and forwarded only (never cancelled
-    // here), so a caller token flows straight through; absent one, the
-    // never-cancelled sentinel is fine.
-    final token = cancel ?? CancellationToken.none;
+    // here), so a caller token flows straight through; absent one (`null`),
+    // there is no cancellation to observe.
+    final token = cancel;
     // Bail before pushing the message or dispatching the turn if the caller's
     // token is already cancelled: there's no point starting work, and we must
     // not leave an orphaned user message in `messages`.
-    if (token.isCancelled) {
+    if (token?.isCancelled ?? false) {
       return _abortedResponse();
     }
     final runFuture = _transport.run(
@@ -859,8 +859,10 @@ final class AgentChat<State> {
   }) {
     // Own a controller for this turn so `AgentTurn.abort()` can cancel it, and
     // link it to the caller's token (if any) so an external cancel also aborts.
+    // `link` forwards the cancellation reason so a caller-supplied
+    // `controller.cancel('...')` survives the hop into this turn's token.
     final controller = CancellationController();
-    final unlink = cancel?.onCancel(controller.cancel);
+    final unlink = cancel?.link(controller);
     final token = controller.token;
     // Bail before pushing the message or dispatching the turn if the caller's
     // token is already cancelled: return an empty stream and a synthetic
@@ -901,8 +903,11 @@ final class AgentChat<State> {
       (_) => AgentResponse<State>._(AgentOutput(), messages),
     );
     // Detach the caller-token listener once the turn settles so a reused
-    // caller token does not accumulate one handler per turn.
-    if (unlink != null) responsePromise.whenComplete(unlink);
+    // caller token does not accumulate one handler per turn. `whenComplete`
+    // returns a *new* future that re-completes with the same error; `ignore()`
+    // it so a rejecting turn does not reach `Zone.handleUncaughtError` (the
+    // `catchError` above handles the original future, not this derived one).
+    if (unlink != null) responsePromise.whenComplete(unlink).ignore();
 
     Stream<AgentChunk<State>> buildStream() async* {
       var previousText = '';

--- a/packages/genkit/lib/src/ai/agents/agent_core.dart
+++ b/packages/genkit/lib/src/ai/agents/agent_core.dart
@@ -32,55 +32,14 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:schemantic/schemantic.dart';
 
+import '../../core/cancellation.dart';
 import '../../schema_extensions.dart';
 import '../../types.dart';
 import 'json_patch.dart';
 import 'state_codec.dart';
 
-// ---------------------------------------------------------------------------
-// Cancellation (Dart has no AbortSignal/AbortController).
-// ---------------------------------------------------------------------------
-
-/// A minimal cooperative cancellation primitive, the Dart stand-in for the
-/// Web's `AbortSignal`/`AbortController`.
-final class CancellationToken {
-  final Completer<void> _completer = Completer<void>();
-  final List<void Function()> _listeners = [];
-
-  /// Whether cancellation has been requested.
-  bool get isCancelled => _completer.isCompleted;
-
-  /// Completes when [cancel] is called.
-  Future<void> get whenCancelled => _completer.future;
-
-  /// Registers [callback] to run when this token is cancelled, and returns a
-  /// disposer that unregisters it. Unlike [whenCancelled] (a one-shot future
-  /// that can never be detached), this lets a caller-supplied token be reused
-  /// across turns without leaking per-turn handlers. If the token is already
-  /// cancelled, [callback] runs synchronously and the returned disposer is a
-  /// no-op.
-  void Function() onCancel(void Function() callback) {
-    if (_completer.isCompleted) {
-      callback();
-      return () {};
-    }
-    _listeners.add(callback);
-    return () => _listeners.remove(callback);
-  }
-
-  /// Requests cancellation (idempotent).
-  void cancel() {
-    if (_completer.isCompleted) return;
-    _completer.complete();
-    // Snapshot then clear so listeners that (re)register during fan-out don't
-    // fire twice and can't be stranded in the list.
-    final listeners = [..._listeners];
-    _listeners.clear();
-    for (final listener in listeners) {
-      listener();
-    }
-  }
-}
+export '../../core/cancellation.dart'
+    show CancellationController, CancellationToken;
 
 // ---------------------------------------------------------------------------
 // Transport
@@ -812,7 +771,10 @@ final class AgentChat<State> {
     CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) async {
-    final token = cancel ?? CancellationToken();
+    // In `_send` the token is observed and forwarded only (never cancelled
+    // here), so a caller token flows straight through; absent one, the
+    // never-cancelled sentinel is fine.
+    final token = cancel ?? CancellationToken.none;
     // Bail before pushing the message or dispatching the turn if the caller's
     // token is already cancelled: there's no point starting work, and we must
     // not leave an orphaned user message in `messages`.
@@ -895,12 +857,17 @@ final class AgentChat<State> {
     CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
-    final token = cancel ?? CancellationToken();
+    // Own a controller for this turn so `AgentTurn.abort()` can cancel it, and
+    // link it to the caller's token (if any) so an external cancel also aborts.
+    final controller = CancellationController();
+    final unlink = cancel?.onCancel(controller.cancel);
+    final token = controller.token;
     // Bail before pushing the message or dispatching the turn if the caller's
     // token is already cancelled: return an empty stream and a synthetic
     // `aborted` response, and leave `messages` untouched. Mirrors the JS
     // core's pre-aborted short-circuit.
     if (token.isCancelled) {
+      unlink?.call();
       return AgentTurn<State>._(
         stream: const Stream.empty(),
         response: Future.value(_abortedResponse()),
@@ -933,6 +900,9 @@ final class AgentChat<State> {
     responsePromise.catchError(
       (_) => AgentResponse<State>._(AgentOutput(), messages),
     );
+    // Detach the caller-token listener once the turn settles so a reused
+    // caller token does not accumulate one handler per turn.
+    if (unlink != null) responsePromise.whenComplete(unlink);
 
     Stream<AgentChunk<State>> buildStream() async* {
       var previousText = '';
@@ -977,7 +947,7 @@ final class AgentChat<State> {
     return AgentTurn<State>._(
       stream: buildStream(),
       response: responsePromise,
-      onAbort: token.cancel,
+      onAbort: controller.cancel,
     );
   }
 
@@ -1066,11 +1036,11 @@ final class AgentChat<State> {
     }
     final init = _buildInit();
 
-    final token = CancellationToken();
+    final controller = CancellationController();
     final turn = _transport.runTurn(
       agentInput,
       init,
-      cancel: token,
+      cancel: controller.token,
       context: context,
     );
     final raw = await turn.output;

--- a/packages/genkit/lib/src/ai/agents/remote_agent.dart
+++ b/packages/genkit/lib/src/ai/agents/remote_agent.dart
@@ -162,10 +162,11 @@ final class _HttpAgentTransport extends AgentTransport {
   TurnStream runTurn(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     _rejectContext(context);
+
     final controller = StreamController<AgentStreamChunk>();
     final outputCompleter = Completer<AgentOutput>();
 
@@ -180,12 +181,14 @@ final class _HttpAgentTransport extends AgentTransport {
         );
 
         // Abort cooperatively when the caller cancels.
-        unawaited(
-          cancel.whenCancelled.then((_) {
-            sub?.cancel();
-            if (!controller.isClosed) controller.close();
-          }),
-        );
+        if (cancel != null) {
+          unawaited(
+            cancel.whenCancelled.then((_) {
+              sub?.cancel();
+              if (!controller.isClosed) controller.close();
+            }),
+          );
+        }
 
         sub = actionStream.listen(
           (chunk) {
@@ -222,10 +225,11 @@ final class _HttpAgentTransport extends AgentTransport {
   Future<AgentOutput>? run(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     _rejectContext(context);
+
     // Opt out of the non-streaming fast path: `send()` should always run the
     // turn over the streaming transport and drain the stream so a server-managed
     // agent's `customPatch` chunks are applied to the chat's tracked state. The

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -1148,6 +1148,13 @@ _executeTools(
       // response (which would let the loop continue as if the tool "failed").
       rethrow;
     } catch (e) {
+      if (cancelToken.isCancelled) {
+        // A generic failure (e.g. a closed HTTP client throwing
+        // SocketException) raised during cancellation must still propagate as a
+        // cancellation rather than be recorded as a tool error that lets the
+        // loop continue.
+        throw CancelledException(reason: cancelToken.reason);
+      }
       toolResponses.add(
         ToolResponsePart(
           toolResponse: ToolResponse(

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -236,16 +236,68 @@ GenerateResponseHelper _abortedResponse({
   Map<String, dynamic>? config,
   Object? reason,
 }) {
+  final request = ModelRequest(messages: history, config: config);
   return GenerateResponseHelper(
     ModelResponse(
       finishReason: FinishReason.aborted,
       finishMessage: reason is String
           ? reason
           : (reason?.toString() ?? 'Generation was cancelled'),
+      // Stamp the request onto the ModelResponse too, not just the helper, so
+      // the resumable history survives the reflection boundary (the registered
+      // `generate` util action returns `response.modelResponse`, dropping the
+      // helper's own `_request`).
+      request: GenerateRequest(messages: history, config: config),
     ),
-    request: ModelRequest(messages: history, config: config),
+    request: request,
     output: null,
   );
+}
+
+/// Decides whether an exception [e] raised during a generation turn should be
+/// converted into an aborted response, or rethrown.
+///
+/// Returns a [GenerateResponseHelper] (the abort) when:
+/// - [e] is a [CancelledException] produced by *this* turn's [cancel] token
+///   (matched by identity, or by the token being cancelled), or
+/// - [cancel] is cancelled and [e] is a generic failure surfaced because the
+///   plugin honored cancellation by tearing down its transport (e.g. a
+///   `SocketException` from a closed HTTP client). In that case the original
+///   error is preserved as the finish reason so a genuine failure that merely
+///   raced the cancel is not silently masked.
+///
+/// Returns `null` when the caller should rethrow: a [CancelledException] from an
+/// unrelated token (e.g. a tool's own internal timeout) is a real failure, not
+/// an abort of this generation.
+///
+/// All abort sites pass the same [history] shape (the turn's accumulated,
+/// pre-format-injection `options.messages`) so the resumable state a caller
+/// feeds back does not depend on *when* the cancel fired.
+GenerateResponseHelper? _abortResponseIfCancelled(
+  Object e,
+  CancellationToken? cancel, {
+  required List<Message> history,
+  Map<String, dynamic>? config,
+}) {
+  if (cancel == null) return null;
+  if (e is CancelledException) {
+    if (identical(e.token, cancel) || cancel.isCancelled) {
+      return _abortedResponse(
+        history: history,
+        config: config,
+        reason: cancel.reason,
+      );
+    }
+    return null;
+  }
+  if (cancel.isCancelled) {
+    return _abortedResponse(
+      history: history,
+      config: config,
+      reason: cancel.reason ?? e,
+    );
+  }
+  return null;
 }
 
 Future<GenerateResponseHelper> _runGenerateLoop(
@@ -261,11 +313,11 @@ Future<GenerateResponseHelper> _runGenerateLoop(
   // Cooperative checkpoint at the start of every turn so a cancel between turns
   // resolves with an aborted response carrying the last-good history (rather
   // than throwing), letting the caller resume from `response.messages`.
-  if (ctx.cancel.isCancelled) {
+  if (ctx.cancel?.isCancelled ?? false) {
     return _abortedResponse(
       history: options.messages,
       config: options.config,
-      reason: ctx.cancel.reason,
+      reason: ctx.cancel?.reason,
     );
   }
   if (options.model == null) {
@@ -334,7 +386,8 @@ Future<GenerateResponseHelper> _runGenerateLoop(
     // Cooperative checkpoint right before the (potentially expensive) model
     // call. Middleware wrapping `model` runs before this and can observe
     // `c.cancel` itself.
-    c.cancel.throwIfCancelled();
+    c.cancel?.throwIfCancelled();
+
     return model(
       req,
       onChunk: c.streamingRequested ? c.sendChunk : null,
@@ -406,13 +459,16 @@ Future<GenerateResponseHelper> _runGenerateLoop(
       cancel: ctx.cancel,
     ));
   } catch (e) {
-    if (ctx.cancel.isCancelled) {
-      return _abortedResponse(
-        history: currentRequest.messages,
-        config: options.config,
-        reason: ctx.cancel.reason,
-      );
-    }
+    // A cancel of this turn's token resolves to an aborted response carrying
+    // the last-good history; a genuine failure (even one racing a cancel of an
+    // unrelated token) rethrows with its cause intact.
+    final aborted = _abortResponseIfCancelled(
+      e,
+      ctx.cancel,
+      history: options.messages,
+      config: options.config,
+    );
+    if (aborted != null) return aborted;
     rethrow;
   }
 
@@ -458,14 +514,16 @@ Future<GenerateResponseHelper> _runGenerateLoop(
   } catch (e) {
     // A tool cancelled mid-execution: resolve with the last-good history (this
     // turn's input), discarding the model message whose tool requests were left
-    // unanswered so the history stays a clean resume point.
-    if (ctx.cancel.isCancelled) {
-      return _abortedResponse(
-        history: currentRequest.messages,
-        config: options.config,
-        reason: ctx.cancel.reason,
-      );
-    }
+    // unanswered so the history stays a clean resume point. A `CancelledException`
+    // from an unrelated token (e.g. a tool's own internal timeout) is a real
+    // failure and rethrows.
+    final aborted = _abortResponseIfCancelled(
+      e,
+      ctx.cancel,
+      history: options.messages,
+      config: options.config,
+    );
+    if (aborted != null) return aborted;
     rethrow;
   }
   final toolResponses = execution.toolResponses;
@@ -607,13 +665,35 @@ Future<GenerateResponseHelper> _runGenerateAction(
     final toolStatus = <String, _ToolStatus>{};
 
     if (resumeRestart.isNotEmpty) {
-      final execution = await _executeTools(
-        generateRegistry,
-        resumeRestart.cast<ToolRequestPart>().toList(),
-        c.context,
-        cancel: c.cancel,
-        middleware: resolvedMiddleware,
-      );
+      final ({
+        List<Part> toolResponses,
+        bool interrupted,
+        Map<String, _ToolStatus> toolStatus,
+      })
+      execution;
+      try {
+        execution = await _executeTools(
+          generateRegistry,
+          resumeRestart.cast<ToolRequestPart>().toList(),
+          c.context,
+          cancel: c.cancel,
+          middleware: resolvedMiddleware,
+        );
+      } catch (e) {
+        // A cancel during the restart tool execution resolves to an aborted
+        // response (like the two sites inside `_runGenerateLoop`) rather than
+        // escaping `generate()` as a throw. `coreGenerate` runs before the
+        // loop's own entry checkpoint, so without this guard an already-cancelled
+        // restart would surface a `CancelledException` to the caller.
+        final aborted = _abortResponseIfCancelled(
+          e,
+          c.cancel,
+          history: opts.messages,
+          config: opts.config,
+        );
+        if (aborted != null) return aborted;
+        rethrow;
+      }
       toolStatus.addAll(execution.toolStatus);
 
       if (execution.interrupted) {
@@ -849,7 +929,7 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
       context: context,
       inputStream: null,
       init: null,
-      cancel: cancel ?? CancellationToken.none,
+      cancel: cancel,
     ),
     middleware: middleware,
   );
@@ -1064,7 +1144,7 @@ _executeTools(
   CancellationToken? cancel,
   List<GenerateMiddleware>? middleware,
 }) async {
-  final cancelToken = cancel ?? CancellationToken.none;
+  final cancelToken = cancel;
   final toolResponses = <ToolResponsePart>[];
   final toolStatus = <String, _ToolStatus>{};
   var interrupted = false;
@@ -1086,7 +1166,7 @@ _executeTools(
       ActionFnArg<void, dynamic, void> c,
     ) async {
       _recordResumedMetadata(c.context);
-      c.cancel.throwIfCancelled();
+      c.cancel?.throwIfCancelled();
       final result = (await tool.runRaw(
         req.toolRequest.input,
         context: c.context,
@@ -1143,17 +1223,36 @@ _executeTools(
       interrupted = true;
       toolStatus[toolRequest.toolRequest.ref ?? toolRequest.toolRequest.name] =
           (output: null, content: null, metadata: null, interrupt: e);
-    } on CancelledException {
-      // Cancellation must propagate, not be swallowed into an error tool
-      // response (which would let the loop continue as if the tool "failed").
-      rethrow;
+    } on CancelledException catch (e) {
+      // A cancellation of *the caller's* token must propagate, not be swallowed
+      // into an error tool response (which would let the loop continue as if the
+      // tool "failed"). But a `CancelledException` from an unrelated token (e.g.
+      // a tool's own internal timeout) is just a tool failure like any other and
+      // is recorded as an error response so the loop can continue.
+      if (cancelToken != null &&
+          (identical(e.token, cancelToken) || cancelToken.isCancelled)) {
+        rethrow;
+      }
+
+      toolResponses.add(
+        ToolResponsePart(
+          toolResponse: ToolResponse(
+            ref: toolRequest.toolRequest.ref,
+            name: toolRequest.toolRequest.name,
+            output: 'Error: $e',
+          ),
+        ),
+      );
     } catch (e) {
-      if (cancelToken.isCancelled) {
+      if (cancelToken?.isCancelled ?? false) {
         // A generic failure (e.g. a closed HTTP client throwing
         // SocketException) raised during cancellation must still propagate as a
         // cancellation rather than be recorded as a tool error that lets the
         // loop continue.
-        throw CancelledException(reason: cancelToken.reason);
+        throw CancelledException(
+          reason: cancelToken!.reason,
+          token: cancelToken,
+        );
       }
       toolResponses.add(
         ToolResponsePart(

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import '../core/action.dart';
+import '../core/cancellation.dart';
 import '../core/dynamic_action_provider.dart';
 import '../core/registry.dart';
 import '../exception.dart';
@@ -224,6 +225,29 @@ _resolveTools(
   );
 }
 
+/// Builds an aborted [GenerateResponseHelper] carrying [history] as the
+/// resumable message list. Used when a generation turn is cancelled (or exceeds
+/// its turn limit): rather than throwing, the loop resolves with a response
+/// whose `finishReason` is [FinishReason.aborted] and no message, so the caller
+/// can inspect `response.messages` and attempt to resume from the last good
+/// state.
+GenerateResponseHelper _abortedResponse({
+  required List<Message> history,
+  Map<String, dynamic>? config,
+  Object? reason,
+}) {
+  return GenerateResponseHelper(
+    ModelResponse(
+      finishReason: FinishReason.aborted,
+      finishMessage: reason is String
+          ? reason
+          : (reason?.toString() ?? 'Generation was cancelled'),
+    ),
+    request: ModelRequest(messages: history, config: config),
+    output: null,
+  );
+}
+
 Future<GenerateResponseHelper> _runGenerateLoop(
   Registry registry,
   GenerateActionOptions options,
@@ -234,6 +258,16 @@ Future<GenerateResponseHelper> _runGenerateLoop(
   int currentTurn = 0,
   int messageIndex = 0,
 }) async {
+  // Cooperative checkpoint at the start of every turn so a cancel between turns
+  // resolves with an aborted response carrying the last-good history (rather
+  // than throwing), letting the caller resume from `response.messages`.
+  if (ctx.cancel.isCancelled) {
+    return _abortedResponse(
+      history: options.messages,
+      config: options.config,
+      reason: ctx.cancel.reason,
+    );
+  }
   if (options.model == null) {
     throw GenkitException(
       'Model must be provided',
@@ -241,12 +275,17 @@ Future<GenerateResponseHelper> _runGenerateLoop(
     );
   }
 
-  // Check turn limits
+  // Check turn limits. Treat exceeding the limit like a cooperative abort:
+  // resolve with an aborted response carrying the history so far, so the caller
+  // can inspect/resume rather than catching an exception.
   final maxTurns = options.maxTurns ?? _defaultMaxTurns;
   if (currentTurn >= maxTurns) {
-    throw GenkitException(
-      'Reached max turns of $maxTurns. Adjust maxTurns option to increase the max number of turns.',
-      status: StatusCodes.ABORTED,
+    return _abortedResponse(
+      history: options.messages,
+      config: options.config,
+      reason:
+          'Reached max turns of $maxTurns. Adjust maxTurns option to increase '
+          'the max number of turns.',
     );
   }
 
@@ -292,10 +331,15 @@ Future<GenerateResponseHelper> _runGenerateLoop(
     ModelRequest req,
     ActionFnArg<ModelResponseChunk, ModelRequest, void> c,
   ) {
+    // Cooperative checkpoint right before the (potentially expensive) model
+    // call. Middleware wrapping `model` runs before this and can observe
+    // `c.cancel` itself.
+    c.cancel.throwIfCancelled();
     return model(
       req,
       onChunk: c.streamingRequested ? c.sendChunk : null,
       context: c.context,
+      cancel: c.cancel,
     );
   }
 
@@ -327,29 +371,50 @@ Future<GenerateResponseHelper> _runGenerateLoop(
   var currentChunkRole = Role.model;
   var modelHasSentChunks = false;
 
-  // Execute model with middleware
-  var response = await composedModel(currentRequest, (
-    streamingRequested: ctx.streamingRequested,
-    sendChunk: (chunk) {
-      final currentRole = chunk.role ?? Role.model;
-      if (currentRole != currentChunkRole && modelHasSentChunks) messageIndex++;
-      currentChunkRole = currentRole;
-      modelHasSentChunks = true;
+  // Execute model with middleware. If the turn is cancelled mid-call, resolve
+  // with an aborted response carrying this turn's input history (the partial
+  // model output already went out as stream chunks and is intentionally not
+  // part of the resumable history). We catch broadly because a plugin that
+  // honors cancellation by tearing down its transport (e.g. closing the HTTP
+  // client) may surface a transport error rather than a `CancelledException`;
+  // we only convert when the token is actually cancelled, otherwise rethrow.
+  final ModelResponse response;
+  try {
+    response = await composedModel(currentRequest, (
+      streamingRequested: ctx.streamingRequested,
+      sendChunk: (chunk) {
+        final currentRole = chunk.role ?? Role.model;
+        if (currentRole != currentChunkRole && modelHasSentChunks) {
+          messageIndex++;
+        }
+        currentChunkRole = currentRole;
+        modelHasSentChunks = true;
 
-      ctx.sendChunk(
-        ModelResponseChunk(
-          index: chunk.index ?? messageIndex,
-          content: chunk.content,
-          role: currentChunkRole,
-          custom: chunk.custom,
-          aggregated: chunk.aggregated,
-        ),
+        ctx.sendChunk(
+          ModelResponseChunk(
+            index: chunk.index ?? messageIndex,
+            content: chunk.content,
+            role: currentChunkRole,
+            custom: chunk.custom,
+            aggregated: chunk.aggregated,
+          ),
+        );
+      },
+      context: ctx.context,
+      inputStream: null,
+      init: null,
+      cancel: ctx.cancel,
+    ));
+  } catch (e) {
+    if (ctx.cancel.isCancelled) {
+      return _abortedResponse(
+        history: currentRequest.messages,
+        config: options.config,
+        reason: ctx.cancel.reason,
       );
-    },
-    context: ctx.context,
-    inputStream: null,
-    init: null,
-  ));
+    }
+    rethrow;
+  }
 
   final parser = format
       ?.handler(requestOptions.output?.jsonSchema)
@@ -376,12 +441,33 @@ Future<GenerateResponseHelper> _runGenerateLoop(
     );
   }
 
-  final execution = await _executeTools(
-    registry,
-    toolRequests,
-    ctx.context,
-    middleware: resolvedMiddleware,
-  );
+  final ({
+    List<Part> toolResponses,
+    bool interrupted,
+    Map<String, _ToolStatus> toolStatus,
+  })
+  execution;
+  try {
+    execution = await _executeTools(
+      registry,
+      toolRequests,
+      ctx.context,
+      cancel: ctx.cancel,
+      middleware: resolvedMiddleware,
+    );
+  } catch (e) {
+    // A tool cancelled mid-execution: resolve with the last-good history (this
+    // turn's input), discarding the model message whose tool requests were left
+    // unanswered so the history stays a clean resume point.
+    if (ctx.cancel.isCancelled) {
+      return _abortedResponse(
+        history: currentRequest.messages,
+        config: options.config,
+        reason: ctx.cancel.reason,
+      );
+    }
+    rethrow;
+  }
   final toolResponses = execution.toolResponses;
   final toolStatus = execution.toolStatus;
   final interrupted = execution.interrupted;
@@ -525,6 +611,7 @@ Future<GenerateResponseHelper> _runGenerateAction(
         generateRegistry,
         resumeRestart.cast<ToolRequestPart>().toList(),
         c.context,
+        cancel: c.cancel,
         middleware: resolvedMiddleware,
       );
       toolStatus.addAll(execution.toolStatus);
@@ -635,6 +722,10 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
   Map<String, dynamic>? context,
   StreamingCallback<GenerateResponseChunk>? onChunk,
   List<GenerateMiddlewareOneof>? middleware,
+
+  /// Cooperative cancellation token, observed by the model call, tools, and
+  /// middleware to abort generation.
+  CancellationToken? cancel,
 
   /// List of interrupt responses to resolve interrupts.
   List<InterruptResponse>? resume,
@@ -758,6 +849,7 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
       context: context,
       inputStream: null,
       init: null,
+      cancel: cancel ?? CancellationToken.none,
     ),
     middleware: middleware,
   );
@@ -969,8 +1061,10 @@ _executeTools(
   Registry registry,
   List<ToolRequestPart> toolRequests,
   Map<String, dynamic>? context, {
+  CancellationToken? cancel,
   List<GenerateMiddleware>? middleware,
 }) async {
+  final cancelToken = cancel ?? CancellationToken.none;
   final toolResponses = <ToolResponsePart>[];
   final toolStatus = <String, _ToolStatus>{};
   var interrupted = false;
@@ -992,9 +1086,11 @@ _executeTools(
       ActionFnArg<void, dynamic, void> c,
     ) async {
       _recordResumedMetadata(c.context);
+      c.cancel.throwIfCancelled();
       final result = (await tool.runRaw(
         req.toolRequest.input,
         context: c.context,
+        cancel: c.cancel,
       )).result;
 
       switch (result) {
@@ -1031,6 +1127,7 @@ _executeTools(
           context: context,
           inputStream: null,
           init: null,
+          cancel: cancelToken,
         )),
         zoneValues: {ToolRequestPart: toolRequest},
       );
@@ -1046,6 +1143,10 @@ _executeTools(
       interrupted = true;
       toolStatus[toolRequest.toolRequest.ref ?? toolRequest.toolRequest.name] =
           (output: null, content: null, metadata: null, interrupt: e);
+    } on CancelledException {
+      // Cancellation must propagate, not be swallowed into an error tool
+      // response (which would let the loop continue as if the tool "failed").
+      rethrow;
     } catch (e) {
       toolResponses.add(
         ToolResponsePart(

--- a/packages/genkit/lib/src/ai/generate_bidi.dart
+++ b/packages/genkit/lib/src/ai/generate_bidi.dart
@@ -114,8 +114,13 @@ Future<GenerateBidiSession> runGenerateBidi(
   final session = model.streamBidi(init: initRequest, cancel: cancel);
   // Close the input side of the session when cancellation is requested so no
   // further turns can be sent; the model's own `cancel` handling stops the
-  // in-flight turn.
-  cancel?.onCancel(() => unawaited(session.close()));
+  // in-flight turn. Capture the disposer and drop it once the session settles
+  // so a reused, long-lived `cancel` token doesn't leak this closure (and the
+  // session it pins) across sessions.
+  final unsubscribe = cancel?.onCancel(() => unawaited(session.close()));
+  if (unsubscribe != null) {
+    unawaited(session.onResult.whenComplete(unsubscribe));
+  }
 
   final outputController = StreamController<GenerateResponseChunk>();
   final previousChunks = <ModelResponseChunk>[];

--- a/packages/genkit/lib/src/ai/generate_bidi.dart
+++ b/packages/genkit/lib/src/ai/generate_bidi.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 
 import '../core/action.dart';
+import '../core/cancellation.dart';
 import '../core/registry.dart';
 import '../exception.dart';
 import '../schema_extensions.dart';
@@ -72,6 +73,7 @@ Future<GenerateBidiSession> runGenerateBidi(
   dynamic config,
   List<String>? tools,
   String? system,
+  CancellationToken? cancel,
 }) async {
   final model =
       await registry.lookupAction(.bidiModel, modelName) as BidiModel?;
@@ -109,7 +111,11 @@ Future<GenerateBidiSession> runGenerateBidi(
     tools: toolDefs,
   );
 
-  final session = model.streamBidi(init: initRequest);
+  final session = model.streamBidi(init: initRequest, cancel: cancel);
+  // Close the input side of the session when cancellation is requested so no
+  // further turns can be sent; the model's own `cancel` handling stops the
+  // in-flight turn.
+  cancel?.onCancel(() => unawaited(session.close()));
 
   final outputController = StreamController<GenerateResponseChunk>();
   final previousChunks = <ModelResponseChunk>[];
@@ -164,6 +170,7 @@ Future<GenerateBidiSession> runGenerateBidi(
             try {
               result = (await tool.runRaw(
                 toolRequest.toolRequest.input,
+                cancel: cancel,
               )).result;
             } on ToolInterruptException {
               // Deprecated throwing interrupt form.

--- a/packages/genkit/lib/src/ai/generate_bidi.dart
+++ b/packages/genkit/lib/src/ai/generate_bidi.dart
@@ -119,7 +119,11 @@ Future<GenerateBidiSession> runGenerateBidi(
   // session it pins) across sessions.
   final unsubscribe = cancel?.onCancel(() => unawaited(session.close()));
   if (unsubscribe != null) {
-    unawaited(session.onResult.whenComplete(unsubscribe));
+    // `whenComplete` returns a *new* future that re-completes with the same
+    // error; `ignore()` it so a session that settles with an error (e.g. a
+    // transport failure) does not surface a duplicate unhandled async error via
+    // this cleanup hook (the caller already sees it through `outputController`).
+    session.onResult.whenComplete(unsubscribe).ignore();
   }
 
   final outputController = StreamController<GenerateResponseChunk>();
@@ -180,6 +184,12 @@ Future<GenerateBidiSession> runGenerateBidi(
             } on ToolInterruptException {
               // Deprecated throwing interrupt form.
               throw bidiInterruptUnsupported();
+            } on CancelledException {
+              // A cooperative cancel tears the session down (the cancel hook
+              // above calls `session.close()`). Propagate it rather than turn it
+              // into a fabricated `Error: ...cancelled` tool answer that would
+              // be sent back to the model on an already-closed input sink.
+              rethrow;
             } catch (e) {
               toolResponses.add(
                 ToolResponsePart(

--- a/packages/genkit/lib/src/ai/generate_types.dart
+++ b/packages/genkit/lib/src/ai/generate_types.dart
@@ -90,25 +90,33 @@ final class GenerateResponseHelper<Output> extends GenerateResponse {
         raw: _response.raw,
         request: _response.request, // This uses ModelResponse.request
         operation: _response.operation,
-        candidates: [
-          Candidate(
-            index: 0,
-            message: _response.message!,
-            finishReason: _response.finishReason,
-            finishMessage: _response.finishMessage,
-            usage: _response.usage,
-            custom: _response.custom,
-          ),
-        ],
+        // Only build a candidate when a message is present. An aborted response
+        // (`finishReason: aborted`) carries no message, so there is no candidate
+        // to report.
+        candidates: _response.message == null
+            ? null
+            : [
+                Candidate(
+                  index: 0,
+                  message: _response.message!,
+                  finishReason: _response.finishReason,
+                  finishMessage: _response.finishMessage,
+                  usage: _response.usage,
+                  custom: _response.custom,
+                ),
+              ],
       );
 
   /// The full history of the conversation, including the request messages and
   /// the final model response.
   ///
   /// This is useful for continuing the conversation in multi-turn scenarios.
+  /// When the response has no message (e.g. an aborted turn), only the request
+  /// history is returned, so callers can attempt to resume from the last good
+  /// state.
   List<Message> get messages => [
     ...(_request?.messages ?? _response.request?.messages ?? []),
-    _response.message!,
+    if (_response.message != null) _response.message!,
   ];
 
   ModelResponse get modelResponse => _response;

--- a/packages/genkit/lib/src/ai/generate_types.dart
+++ b/packages/genkit/lib/src/ai/generate_types.dart
@@ -150,9 +150,17 @@ final class GenerateResponseHelper<Output> extends GenerateResponse {
   ///
   /// This will be populated if the output format is JSON, or if the output is
   /// arbitrarily parsed as JSON.
+  ///
+  /// Returns `null` for a message-less response (e.g. an aborted turn), where
+  /// `text` is empty and there is nothing to parse, rather than throwing a
+  /// `FormatException`. This mirrors how the other accessors degrade safely on
+  /// the abort path (`text` -> `''`, `media`/`toolRequests` -> null/`[]`).
   Output? get jsonOutput {
     if (output != null) return output;
-    return extractJson(text) as Output?;
+    if (_response.message == null) return null;
+    final source = text;
+    if (source.isEmpty) return null;
+    return extractJson(source) as Output?;
   }
 
   ModelResponse get rawResponse => _response;

--- a/packages/genkit/lib/src/ai/middleware/retry.dart
+++ b/packages/genkit/lib/src/ai/middleware/retry.dart
@@ -19,6 +19,7 @@ import 'package:logging/logging.dart';
 import 'package:schemantic/schemantic.dart';
 
 import '../../core/action.dart';
+import '../../core/cancellation.dart';
 import '../../core/plugin.dart';
 import '../../exception.dart';
 import '../../types.dart';
@@ -162,7 +163,7 @@ class RetryMiddleware extends GenerateMiddleware {
     if (!retryModel) {
       return next(request, ctx);
     }
-    return _retry(() => next(request, ctx));
+    return _retry(() => next(request, ctx), ctx.cancel);
   }
 
   @override
@@ -178,16 +179,26 @@ class RetryMiddleware extends GenerateMiddleware {
     if (!retryTools) {
       return next(request, ctx);
     }
-    return _retry(() => next(request, ctx));
+    return _retry(() => next(request, ctx), ctx.cancel);
   }
 
-  Future<T> _retry<T>(Future<T> Function() fn) async {
+  Future<T> _retry<T>(
+    Future<T> Function() fn, [
+    CancellationToken? cancel,
+  ]) async {
     var attempt = 0;
     while (true) {
+      // Don't start (or restart) work once the caller has cancelled.
+      cancel?.throwIfCancelled();
       try {
         return await fn();
       } catch (e) {
-        if (attempt >= maxRetries || !_shouldRetry(e)) {
+        if (attempt >= maxRetries ||
+            !_shouldRetry(e) ||
+            (cancel?.isCancelled ?? false)) {
+          // A cancel that surfaces as a transport error (e.g. the plugin closed
+          // its HTTP client) can look retryable; don't back off - let the
+          // downstream cancel checkpoint resolve it as an abort.
           rethrow;
         }
         attempt++;
@@ -199,7 +210,14 @@ class RetryMiddleware extends GenerateMiddleware {
         _logger.warning(
           'Retry attempt $attempt after ${delay.inMilliseconds}ms due to error: $e',
         );
-        await Future.delayed(delay);
+        // Race the backoff against cancellation so a cancel during the sleep
+        // resolves promptly instead of waiting out the full (possibly long)
+        // delay. When no token is wired up, just wait out the delay.
+        if (cancel == null) {
+          await Future<void>.delayed(delay);
+        } else {
+          await Future.any([Future<void>.delayed(delay), cancel.whenCancelled]);
+        }
       }
     }
   }

--- a/packages/genkit/lib/src/ai/prompt.dart
+++ b/packages/genkit/lib/src/ai/prompt.dart
@@ -18,6 +18,7 @@ import 'package:dotprompt/dotprompt.dart' as dp;
 import 'package:schemantic/schemantic.dart';
 
 import '../core/action.dart';
+import '../core/cancellation.dart';
 import '../core/registry.dart';
 import '../exception.dart';
 import '../o11y/instrumentation.dart';
@@ -136,6 +137,11 @@ class PromptGenerateOptions<CustomOptions> {
   final List<GenerateMiddlewareRef>? use;
   final List<Message>? messages;
 
+  /// Cooperative cancellation token, observed by the model call, tools, and
+  /// middleware to abort generation. A cancelled call resolves with a response
+  /// whose `finishReason` is `FinishReason.aborted` (rather than throwing).
+  final CancellationToken? cancel;
+
   PromptGenerateOptions({
     this.model,
     this.config,
@@ -148,6 +154,7 @@ class PromptGenerateOptions<CustomOptions> {
     this.context,
     this.use,
     this.messages,
+    this.cancel,
   });
 }
 
@@ -335,6 +342,7 @@ class ExecutablePrompt<Input> {
           maxTurns: options.maxTurns,
           output: options.output,
           context: opts?.context,
+          cancel: opts?.cancel,
           middleware: middleware.isNotEmpty ? middleware : null,
           onChunk: onChunk,
         );

--- a/packages/genkit/lib/src/ai/tool.dart
+++ b/packages/genkit/lib/src/ai/tool.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'package:schemantic/schemantic.dart';
 
 import '../core/action.dart';
+import '../core/cancellation.dart';
 import '../o11y/instrumentation.dart';
 import '../types.dart';
 import 'interrupt.dart';
@@ -29,6 +30,34 @@ class ToolFnArgs<Input> {
 
   /// The execution context.
   Map<String, dynamic>? get context => _base.context;
+
+  /// A read-only cancellation token the tool body should observe to abort
+  /// long-running work cooperatively, or `null` when the caller wired up no
+  /// cancellation.
+  ///
+  /// Poll [CancellationToken.isCancelled], call
+  /// [CancellationToken.throwIfCancelled] at checkpoints, or race
+  /// [CancellationToken.whenCancelled] against long awaits so a cancel can
+  /// interrupt work in progress:
+  ///
+  /// ```dart
+  /// ai.defineTool(
+  ///   name: 'search',
+  ///   description: 'Searches the web.',
+  ///   fn: (input, ctx) async {
+  ///     final cancel = ctx.cancel;
+  ///     if (cancel == null) return .response(await doWork(input));
+  ///     final result = await Future.any([
+  ///       doWork(input),
+  ///       cancel.whenCancelled.then(
+  ///         (_) => throw CancelledException(reason: cancel.reason),
+  ///       ),
+  ///     ]);
+  ///     return .response(result);
+  ///   },
+  /// );
+  /// ```
+  CancellationToken? get cancel => _base.cancel;
 
   /// The tool request that triggered this execution.
   ToolRequestPart? get toolRequest =>

--- a/packages/genkit/lib/src/core/action.dart
+++ b/packages/genkit/lib/src/core/action.dart
@@ -467,19 +467,30 @@ class ActionStream<Chunk, Response> extends StreamView<Chunk> {
 class BidiActionStream<Chunk, Response, Request>
     extends ActionStream<Chunk, Response> {
   final StreamSink<Request>? _inputSink;
+  bool _inputClosed = false;
 
   BidiActionStream(super.stream, this._inputSink);
 
+  /// Whether the input side of this stream has been closed via [close].
+  bool get isClosed => _inputClosed;
+
   /// Sends a chunk of data back to the action.
+  ///
+  /// No-op once the input side has been [close]d (e.g. after a cooperative
+  /// cancel tears the session down): adding to a closed [StreamSink] throws a
+  /// `StateError`, so a late send that races the close is silently dropped
+  /// rather than crashing the caller.
   void send(Request chunk) {
     if (_inputSink == null) {
       throw GenkitException('Cannot send to this stream (external input)');
     }
+    if (_inputClosed) return;
     _inputSink.add(chunk);
   }
 
   /// Closes the input sink.
   Future<void> close() async {
+    _inputClosed = true;
     await _inputSink?.close();
   }
 }

--- a/packages/genkit/lib/src/core/action.dart
+++ b/packages/genkit/lib/src/core/action.dart
@@ -100,9 +100,9 @@ typedef ActionFnArg<Chunk, Input, Init> = ({
   Init? init,
 
   /// A read-only cancellation token the action body should observe to abort
-  /// cooperatively. Always present; defaults to [CancellationToken.none] when
-  /// the caller supplied no token.
-  CancellationToken cancel,
+  /// cooperatively, or `null` when the caller wired up no cancellation. Observe
+  /// it with null-aware calls, e.g. `ctx.cancel?.throwIfCancelled()`.
+  CancellationToken? cancel,
 });
 
 typedef ActionFn<Input, Output, Chunk, Init> =
@@ -216,7 +216,13 @@ class Action<Input, Output, Chunk, Init>
       onChunk: onChunk,
       context: context,
       inputStream: inputStream,
-      init: init,
+      // Validate `init` against the schema, matching `runRaw`. The static type
+      // only guarantees shape; value-level constraints (enum membership,
+      // numeric ranges, required nested fields) still need the schema. Skip
+      // when either the schema or the value is absent, mirroring `runRaw`.
+      init: (initSchema != null && init != null)
+          ? initSchema!.parse(init)
+          : init,
       onTraceStart: onTraceStart,
       cancel: cancel,
     )).result;
@@ -258,9 +264,9 @@ class Action<Input, Output, Chunk, Init>
     TraceStartCallback? onTraceStart,
     CancellationToken? cancel,
   }) async {
-    final cancelToken = cancel ?? CancellationToken.none;
     // Bail before doing any work if the caller's token is already cancelled.
-    cancelToken.throwIfCancelled();
+    cancel?.throwIfCancelled();
+
     if (inputStream == null) {
       final internalInputController = StreamController<Input>();
       inputStream = internalInputController.stream;
@@ -288,7 +294,7 @@ class Action<Input, Output, Chunk, Init>
             context: executionContext,
             inputStream: inputStream,
             init: init,
-            cancel: cancelToken,
+            cancel: cancel,
           ));
         },
         actionType: actionType.value,

--- a/packages/genkit/lib/src/core/action.dart
+++ b/packages/genkit/lib/src/core/action.dart
@@ -18,6 +18,7 @@ import 'package:schemantic/schemantic.dart';
 
 import '../exception.dart';
 import '../o11y/instrumentation.dart';
+import 'cancellation.dart';
 
 const _genkitContextKey = #genkitContext;
 
@@ -97,6 +98,11 @@ typedef ActionFnArg<Chunk, Input, Init> = ({
   Map<String, dynamic>? context,
   Stream<Input>? inputStream,
   Init? init,
+
+  /// A read-only cancellation token the action body should observe to abort
+  /// cooperatively. Always present; defaults to [CancellationToken.none] when
+  /// the caller supplied no token.
+  CancellationToken cancel,
 });
 
 typedef ActionFn<Input, Output, Chunk, Init> =
@@ -203,12 +209,16 @@ class Action<Input, Output, Chunk, Init>
     Stream<Input>? inputStream,
     Init? init,
     TraceStartCallback? onTraceStart,
+    CancellationToken? cancel,
   }) async {
     return (await run(
       input,
       onChunk: onChunk,
       context: context,
+      inputStream: inputStream,
+      init: init,
       onTraceStart: onTraceStart,
+      cancel: cancel,
     )).result;
   }
 
@@ -219,12 +229,14 @@ class Action<Input, Output, Chunk, Init>
     Stream<Input>? inputStream,
     dynamic init,
     TraceStartCallback? onTraceStart,
+    CancellationToken? cancel,
   }) async {
     return await run(
       inputSchema != null ? inputSchema!.parse(input) : input as Input?,
       onChunk: onChunk,
       context: context,
       inputStream: inputStream,
+      cancel: cancel,
       // Skip validation when no init was supplied. `init` is optional on the
       // first request (e.g. an agent's fresh session sends no init), so a null
       // value must pass through untouched rather than be validated against a
@@ -244,7 +256,11 @@ class Action<Input, Output, Chunk, Init>
     Stream<Input>? inputStream,
     Init? init,
     TraceStartCallback? onTraceStart,
+    CancellationToken? cancel,
   }) async {
+    final cancelToken = cancel ?? CancellationToken.none;
+    // Bail before doing any work if the caller's token is already cancelled.
+    cancelToken.throwIfCancelled();
     if (inputStream == null) {
       final internalInputController = StreamController<Input>();
       inputStream = internalInputController.stream;
@@ -272,6 +288,7 @@ class Action<Input, Output, Chunk, Init>
             context: executionContext,
             inputStream: inputStream,
             init: init,
+            cancel: cancelToken,
           ));
         },
         actionType: actionType.value,
@@ -296,6 +313,7 @@ class Action<Input, Output, Chunk, Init>
     Map<String, dynamic>? context,
     Stream<Input>? inputStream,
     Init? init,
+    CancellationToken? cancel,
   }) {
     final streamController = StreamController<Chunk>();
     final actionStream = ActionStream<Chunk, Output>(streamController.stream);
@@ -305,6 +323,7 @@ class Action<Input, Output, Chunk, Init>
           context: context,
           inputStream: inputStream,
           init: init,
+          cancel: cancel,
           onChunk: (chunk) {
             if (!streamController.isClosed) {
               streamController.add(chunk);
@@ -333,6 +352,7 @@ class Action<Input, Output, Chunk, Init>
     StreamingCallback<Chunk>? onChunk,
     Map<String, dynamic>? context,
     Init? init,
+    CancellationToken? cancel,
   }) {
     StreamController<Input>? internalInputController;
     if (inputStream == null) {
@@ -359,6 +379,7 @@ class Action<Input, Output, Chunk, Init>
           context: context,
           inputStream: inputStream,
           init: init,
+          cancel: cancel,
         )
         .then((result) {
           bidiStream.setResult(result.result);

--- a/packages/genkit/lib/src/core/cancellation.dart
+++ b/packages/genkit/lib/src/core/cancellation.dart
@@ -38,18 +38,11 @@ import '../exception.dart';
 /// expected to poll [isCancelled] / call [throwIfCancelled], await
 /// [whenCancelled], or register an [onCancel] callback to tear down eagerly
 /// (e.g. cancel a streaming HTTP subscription).
-///
-/// Use [CancellationToken.none] as a never-cancelled default where a token is
-/// required but no cancellation is wired up.
 final class CancellationToken {
   CancellationToken._();
 
-  /// A token that never cancels. Handy as a default when a [CancellationToken]
-  /// is required but the caller did not supply one.
-  static final CancellationToken none = CancellationToken._();
-
   final Completer<void> _completer = Completer<void>();
-  final List<void Function()> _listeners = [];
+  final List<void Function(Object? reason)> _listeners = [];
   Object? _reason;
 
   /// Whether cancellation has been requested.
@@ -58,8 +51,12 @@ final class CancellationToken {
   /// The optional reason passed to [CancellationController.cancel], or `null`.
   Object? get reason => _reason;
 
-  /// Completes when the owning controller is cancelled. For
-  /// [CancellationToken.none] this future never completes.
+  /// Completes when the owning controller is cancelled.
+  ///
+  /// Every token is per-operation and tied to a real [CancellationController],
+  /// so this future (and any awaiter) is released when the operation and its
+  /// controller become unreachable. It is therefore safe to race against, e.g.
+  /// `Future.any([work, token.whenCancelled])`.
   Future<void> get whenCancelled => _completer.future;
 
   /// Registers [callback] to run when this token is cancelled, and returns a
@@ -69,14 +66,29 @@ final class CancellationToken {
   /// this lets a caller-supplied token be reused across many operations without
   /// leaking per-operation handlers. If the token is already cancelled,
   /// [callback] runs synchronously and the returned disposer is a no-op.
-  void Function() onCancel(void Function() callback) {
-    // `none` never cancels, so its listener list would only ever grow. Return
-    // a no-op disposer immediately instead of stranding the callback.
-    if (identical(this, none)) {
-      return () {};
-    }
+  void Function() onCancel(void Function() callback) =>
+      _register((_) => callback());
+
+  /// Like [onCancel], but forwards the cancellation [reason] to [callback].
+  ///
+  /// Use this when relinking tokens so a caller-supplied reason (e.g.
+  /// `controller.cancel('user pressed stop')`) survives across the hop instead
+  /// of being dropped by a zero-arg tear-off.
+  void Function() onCancelWithReason(void Function(Object? reason) callback) =>
+      _register(callback);
+
+  /// Links [child] to this token so that cancelling this token also cancels
+  /// [child] with the same reason. Returns a disposer that unlinks.
+  ///
+  /// If this token is already cancelled, [child] is cancelled synchronously and
+  /// the returned disposer is a no-op. Prefer this over
+  /// `token.onCancel(child.cancel)`, which silently drops the reason.
+  void Function() link(CancellationController child) =>
+      onCancelWithReason(child.cancel);
+
+  void Function() _register(void Function(Object? reason) callback) {
     if (_completer.isCompleted) {
-      callback();
+      callback(_reason);
       return () {};
     }
     _listeners.add(callback);
@@ -89,7 +101,7 @@ final class CancellationToken {
   /// loop) to bail out promptly.
   void throwIfCancelled() {
     if (isCancelled) {
-      throw CancelledException(reason: _reason);
+      throw CancelledException(reason: _reason, token: this);
     }
   }
 
@@ -102,7 +114,15 @@ final class CancellationToken {
     final listeners = [..._listeners];
     _listeners.clear();
     for (final listener in listeners) {
-      listener();
+      // Isolate listeners: one throwing callback must not abort the fan-out
+      // (dropping the survivors, which were already cleared) nor escape
+      // `CancellationController.cancel`, which is documented as idempotent and
+      // non-throwing. Route failures to the ambient error handler instead.
+      try {
+        listener(reason);
+      } catch (e, s) {
+        Zone.current.handleUncaughtError(e, s);
+      }
     }
   }
 }
@@ -131,7 +151,13 @@ final class CancellationController {
 /// Maps to [StatusCodes.CANCELLED]. Catch this to distinguish a cooperative
 /// cancellation from other failures.
 class CancelledException extends GenkitException {
-  CancelledException({Object? reason})
+  /// The token that produced this cancellation, when known.
+  ///
+  /// Lets a caller distinguish a cancellation of *its own* token from one that
+  /// bubbled up from an unrelated token (e.g. a tool's internal timeout).
+  final CancellationToken? token;
+
+  CancelledException({Object? reason, this.token})
     : super(
         reason is String ? reason : 'Operation was cancelled',
         status: StatusCodes.CANCELLED,

--- a/packages/genkit/lib/src/core/cancellation.dart
+++ b/packages/genkit/lib/src/core/cancellation.dart
@@ -70,6 +70,11 @@ final class CancellationToken {
   /// leaking per-operation handlers. If the token is already cancelled,
   /// [callback] runs synchronously and the returned disposer is a no-op.
   void Function() onCancel(void Function() callback) {
+    // `none` never cancels, so its listener list would only ever grow. Return
+    // a no-op disposer immediately instead of stranding the callback.
+    if (identical(this, none)) {
+      return () {};
+    }
     if (_completer.isCompleted) {
       callback();
       return () {};

--- a/packages/genkit/lib/src/core/cancellation.dart
+++ b/packages/genkit/lib/src/core/cancellation.dart
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Cooperative cancellation for Genkit actions and generation.
+///
+/// This is the Dart analog of the Web's `AbortController` / `AbortSignal`
+/// split, expressed with Dart-idiomatic names: a [CancellationController] is
+/// the writable side (the caller holds it and calls [CancellationController.cancel]),
+/// while a [CancellationToken] is the read-only side that is threaded down
+/// through actions, middleware, and models so they can observe cancellation.
+///
+/// It is intentionally dependency-free and browser-safe (no `dart:io`, no
+/// `package:web`), built only on `Completer`.
+library;
+
+import 'dart:async';
+
+import '../exception.dart';
+
+/// A read-only view of a cancellation request.
+///
+/// A [CancellationToken] is what the framework hands to actions, middleware,
+/// and models. Holders can *observe* cancellation but cannot *trigger* it (that
+/// is the job of the [CancellationController] that created the token).
+///
+/// Cancellation is cooperative: nothing is force-killed. Long-running work is
+/// expected to poll [isCancelled] / call [throwIfCancelled], await
+/// [whenCancelled], or register an [onCancel] callback to tear down eagerly
+/// (e.g. cancel a streaming HTTP subscription).
+///
+/// Use [CancellationToken.none] as a never-cancelled default where a token is
+/// required but no cancellation is wired up.
+final class CancellationToken {
+  CancellationToken._();
+
+  /// A token that never cancels. Handy as a default when a [CancellationToken]
+  /// is required but the caller did not supply one.
+  static final CancellationToken none = CancellationToken._();
+
+  final Completer<void> _completer = Completer<void>();
+  final List<void Function()> _listeners = [];
+  Object? _reason;
+
+  /// Whether cancellation has been requested.
+  bool get isCancelled => _completer.isCompleted;
+
+  /// The optional reason passed to [CancellationController.cancel], or `null`.
+  Object? get reason => _reason;
+
+  /// Completes when the owning controller is cancelled. For
+  /// [CancellationToken.none] this future never completes.
+  Future<void> get whenCancelled => _completer.future;
+
+  /// Registers [callback] to run when this token is cancelled, and returns a
+  /// disposer that unregisters it.
+  ///
+  /// Unlike [whenCancelled] (a one-shot future that can never be detached),
+  /// this lets a caller-supplied token be reused across many operations without
+  /// leaking per-operation handlers. If the token is already cancelled,
+  /// [callback] runs synchronously and the returned disposer is a no-op.
+  void Function() onCancel(void Function() callback) {
+    if (_completer.isCompleted) {
+      callback();
+      return () {};
+    }
+    _listeners.add(callback);
+    return () => _listeners.remove(callback);
+  }
+
+  /// Throws a [CancelledException] if cancellation has been requested.
+  ///
+  /// Call this at cooperative checkpoints (e.g. between turns of a generation
+  /// loop) to bail out promptly.
+  void throwIfCancelled() {
+    if (isCancelled) {
+      throw CancelledException(reason: _reason);
+    }
+  }
+
+  void _cancel(Object? reason) {
+    if (_completer.isCompleted) return;
+    _reason = reason;
+    _completer.complete();
+    // Snapshot then clear so listeners that (re)register during fan-out don't
+    // fire twice and can't be stranded in the list.
+    final listeners = [..._listeners];
+    _listeners.clear();
+    for (final listener in listeners) {
+      listener();
+    }
+  }
+}
+
+/// The writable side of a cancellation.
+///
+/// A caller creates a controller, passes its [token] into an operation (e.g.
+/// `ai.generate(..., cancel: controller.token)`), and later calls [cancel] to
+/// request that the operation stop.
+///
+/// This is the Dart analog of the Web `AbortController`.
+final class CancellationController {
+  /// The read-only token to hand to the operation being controlled.
+  final CancellationToken token = CancellationToken._();
+
+  /// Whether [cancel] has already been called.
+  bool get isCancelled => token.isCancelled;
+
+  /// Requests cancellation (idempotent). An optional [reason] is surfaced on
+  /// [CancellationToken.reason] and the thrown `CancelledException`.
+  void cancel([Object? reason]) => token._cancel(reason);
+}
+
+/// Thrown when an operation is aborted via a [CancellationToken].
+///
+/// Maps to [StatusCodes.CANCELLED]. Catch this to distinguish a cooperative
+/// cancellation from other failures.
+class CancelledException extends GenkitException {
+  CancelledException({Object? reason})
+    : super(
+        reason is String ? reason : 'Operation was cancelled',
+        status: StatusCodes.CANCELLED,
+        underlyingException: reason is String ? null : reason,
+      );
+}

--- a/packages/genkit/lib/src/genkit_ai.dart
+++ b/packages/genkit/lib/src/genkit_ai.dart
@@ -24,6 +24,7 @@ import 'ai/generate_types.dart';
 import 'ai/model.dart';
 import 'ai/tool.dart';
 import 'core/action.dart';
+import 'core/cancellation.dart';
 import 'core/registry.dart';
 import 'exception.dart';
 import 'o11y/instrumentation.dart';
@@ -85,6 +86,7 @@ base class GenkitAI {
     List<Tool>? tools,
     List<String>? toolNames,
     String? system,
+    CancellationToken? cancel,
   }) {
     final resolved = _resolveTools(
       registry,
@@ -97,6 +99,7 @@ base class GenkitAI {
       config: config,
       tools: resolved.toolNames,
       system: system,
+      cancel: cancel,
     );
   }
 
@@ -122,6 +125,10 @@ base class GenkitAI {
     Map<String, dynamic>? context,
     StreamingCallback<GenerateResponseChunk<Output>>? onChunk,
     List<GenerateMiddlewareRef>? use,
+
+    /// Cooperative cancellation token, observed by the model call, tools, and
+    /// middleware to abort generation.
+    CancellationToken? cancel,
 
     /// Optional data to resume an interrupted generation session.
     ///
@@ -187,6 +194,7 @@ base class GenkitAI {
       maxTurns: maxTurns,
       output: outputConfig,
       context: context,
+      cancel: cancel,
       middleware: use
           ?.map<GenerateMiddlewareOneof>(
             (mw) => (middlewareRef: mw, middlewareInstance: null),
@@ -221,7 +229,13 @@ base class GenkitAI {
     if (outputSchema != null) {
       return GenerateResponseHelper(
         rawResponse.rawResponse,
-        output: outputSchema.parse(rawResponse.output),
+        request: rawResponse.modelRequest,
+        // An aborted response carries no output; guard the parse so the
+        // aborted response (with its resumable history) survives structured
+        // output calls too.
+        output: rawResponse.output == null
+            ? null
+            : outputSchema.parse(rawResponse.output),
       );
     } else {
       return GenerateResponseHelper(
@@ -254,6 +268,7 @@ base class GenkitAI {
     String? outputContentType,
     Map<String, dynamic>? context,
     List<GenerateMiddlewareRef>? use,
+    CancellationToken? cancel,
     List<InterruptResponse>? interruptRespond,
     List<ToolRequestPart>? interruptRestart,
   }) {
@@ -283,6 +298,7 @@ base class GenkitAI {
           outputNoInstructions: outputNoInstructions,
           outputContentType: outputContentType,
           use: use,
+          cancel: cancel,
           interruptRespond: interruptRespond,
           interruptRestart: interruptRestart,
           onChunk: (chunk) {

--- a/packages/genkit/lib/src/types.dart
+++ b/packages/genkit/lib/src/types.dart
@@ -289,6 +289,7 @@ extension type FinishReason(String value) {
   static FinishReason get stop => FinishReason('stop');
   static FinishReason get length => FinishReason('length');
   static FinishReason get blocked => FinishReason('blocked');
+  static FinishReason get aborted => FinishReason('aborted');
   static FinishReason get interrupted => FinishReason('interrupted');
   static FinishReason get other => FinishReason('other');
   static FinishReason get unknown => FinishReason('unknown');

--- a/packages/genkit/test/ai/agents/agent_core_test.dart
+++ b/packages/genkit/test/ai/agents/agent_core_test.dart
@@ -313,7 +313,7 @@ void main() {
       'send() bails before dispatching when the token is cancelled',
       () async {
         final transport = _FakeTransport([], supportsRun: true);
-        final token = CancellationToken()..cancel();
+        final token = (CancellationController()..cancel()).token;
         final chat = AgentApi(transport).chat();
         final res = await chat.send(text: 'hi', cancel: token);
         expect(res.finishReason, AgentFinishReason.aborted);
@@ -326,7 +326,7 @@ void main() {
       'sendStream() bails with an empty stream when the token is cancelled',
       () async {
         final transport = _FakeTransport([]);
-        final token = CancellationToken()..cancel();
+        final token = (CancellationController()..cancel()).token;
         final chat = AgentApi(transport).chat();
         final turn = chat.sendStream(text: 'hi', cancel: token);
         final chunks = <AgentChunk>[];
@@ -460,36 +460,37 @@ void main() {
 
   group('CancellationToken.onCancel', () {
     test('fires registered callbacks on cancel', () {
-      final token = CancellationToken();
+      final controller = CancellationController();
+      final token = controller.token;
       var fired = 0;
       token.onCancel(() => fired++);
       token.onCancel(() => fired++);
       expect(fired, 0);
-      token.cancel();
+      controller.cancel();
       expect(fired, 2);
     });
 
     test('only fires once even if cancel is called repeatedly', () {
-      final token = CancellationToken();
+      final controller = CancellationController();
       var fired = 0;
-      token.onCancel(() => fired++);
-      token
+      controller.token.onCancel(() => fired++);
+      controller
         ..cancel()
         ..cancel();
       expect(fired, 1);
     });
 
     test('the disposer unregisters the callback', () {
-      final token = CancellationToken();
+      final controller = CancellationController();
       var fired = 0;
-      final dispose = token.onCancel(() => fired++);
+      final dispose = controller.token.onCancel(() => fired++);
       dispose();
-      token.cancel();
+      controller.cancel();
       expect(fired, 0);
     });
 
     test('runs the callback synchronously if already cancelled', () {
-      final token = CancellationToken()..cancel();
+      final token = (CancellationController()..cancel()).token;
       var fired = 0;
       final dispose = token.onCancel(() => fired++);
       expect(fired, 1);

--- a/packages/genkit/test/ai/agents/agent_core_test.dart
+++ b/packages/genkit/test/ai/agents/agent_core_test.dart
@@ -54,7 +54,7 @@ final class _FakeTransport extends AgentTransport {
   TurnStream runTurn(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     final script = _next();
@@ -65,7 +65,7 @@ final class _FakeTransport extends AgentTransport {
   Future<AgentOutput>? run(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     if (!supportsRun) return null;
@@ -132,7 +132,7 @@ final class _StepTransport extends AgentTransport {
   TurnStream runTurn(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     final step = _next();
@@ -146,7 +146,7 @@ final class _StepTransport extends AgentTransport {
   Future<AgentOutput>? run(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     if (!supportsRun) return null;
@@ -937,7 +937,7 @@ final class _CaptureTransport extends AgentTransport {
   TurnStream runTurn(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) {
     final output = _handler(input);
@@ -951,7 +951,7 @@ final class _CaptureTransport extends AgentTransport {
   Future<AgentOutput>? run(
     AgentInput input,
     AgentInit init, {
-    required CancellationToken cancel,
+    CancellationToken? cancel,
     Map<String, dynamic>? context,
   }) => Future.value(_handler(input));
 

--- a/packages/genkit/test/ai/agents/agent_core_test.dart
+++ b/packages/genkit/test/ai/agents/agent_core_test.dart
@@ -306,6 +306,28 @@ void main() {
         ),
       );
     });
+
+    test('a failed turn on the streaming path throws AgentError without an '
+        'unhandled rejection', () async {
+      // `supportsRun: false` forces the streaming path (`_sendStream`), where
+      // the orphan `responsePromise` must be `.ignore()`d so a rejecting turn
+      // does not reach `Zone.handleUncaughtError` (which package:test would
+      // surface as a failure after the test body passes). The two other
+      // failed-turn tests take the `run()` fast path and never exercise this.
+      final transport = _FakeTransport([
+        _TurnScript(
+          output: AgentOutput(
+            finishReason: AgentFinishReason.failed,
+            error: AgentErrorInfo(status: 'INTERNAL', message: 'boom'),
+          ),
+        ),
+      ]);
+      final chat = AgentApi(transport).chat();
+      await expectLater(chat.send(text: 'hi'), throwsA(isA<AgentError>()));
+      // Let any stray unhandled async error settle onto the event loop; if the
+      // orphan future weren't ignored, this turn would fail the test here.
+      await Future<void>.delayed(Duration.zero);
+    });
   });
 
   group('AgentChat pre-aborted bail', () {

--- a/packages/genkit/test/ai/agents/agent_test.dart
+++ b/packages/genkit/test/ai/agents/agent_test.dart
@@ -478,6 +478,52 @@ void main() {
       expect(prior?.value, 'completed');
     });
 
+    test('an attached AgentTurn.abort() persists the turn as aborted, not '
+        'completed', () async {
+      // Regression: the attached abort route (`AgentTurn.abort()` -> token
+      // cancel) writes nothing to the store itself, so without the run loop's
+      // `status: 'aborted'` write the trailing `invocationEnd` snapshot would
+      // persist the half-finished turn as `completed` - and a later `loadChat`
+      // would then pick it as the last-good resume point.
+      final store = InMemorySessionStore();
+      final handlerRunning = Completer<void>();
+      final proceed = Completer<void>();
+      final agent = ai.defineCustomAgent(
+        name: 'attachedAbortable',
+        store: store,
+        fn: (sess, options) async {
+          await sess.run((input, ctx) async {
+            sess.updateCustom((_) => {'count': 1});
+            // Signal that the turn is in flight, then stay in flight until the
+            // test aborts the attached turn (cancelling this turn's token).
+            if (!handlerRunning.isCompleted) handlerRunning.complete();
+            await proceed.future;
+            return TurnResult(finishReason: AgentFinishReason.stop);
+          });
+          return AgentResult(finishReason: sess.lastTurnFinishReason);
+        },
+      );
+
+      final sessionId = generateUuidV4();
+      final chat = agent.chat(sessionId: sessionId);
+      final turn = chat.sendStream(text: 'go');
+      // Drain the stream so the turn progresses.
+      final drained = turn.stream.drain<void>();
+
+      await handlerRunning.future;
+      turn.abort(); // cancels this turn's token (attached route)
+      proceed.complete();
+
+      await turn.response;
+      await drained;
+
+      // The latest snapshot for the session must be `aborted`, never the
+      // `completed` a stray `invocationEnd` write would have produced.
+      final snapshot = await agent.getSnapshot(sessionId: sessionId);
+      expect(snapshot, isNotNull);
+      expect(snapshot!.status?.value, 'aborted');
+    });
+
     test('abortAgentAction round-trips typed request/response', () async {
       final store = InMemorySessionStore();
       final agent = ai.defineCustomAgent(

--- a/packages/genkit/test/ai/generate_bidi_test.dart
+++ b/packages/genkit/test/ai/generate_bidi_test.dart
@@ -155,7 +155,92 @@ void main() {
       expect(chunks.first.text, 'SYS V');
     });
 
+    // A cooperative cancel during a pending bidi tool call must propagate as a
+    // clean cancellation: it must NOT be turned into a fabricated
+    // `Error: ...cancelled` tool answer, and the follow-up `session.send(...)`
+    // must not crash on the already-closed input sink (a `StateError`).
+    test('cancel during a pending tool call does not fabricate a tool '
+        'answer or crash the session', () async {
+      final toolName = 'slowTool';
+      final modelName = 'cancelBidiModel';
+      final controller = CancellationController();
+      var modelSawToolMessage = false;
+
+      genkit.defineTool<MyToolInput, String>(
+        name: toolName,
+        description: 'A tool that observes cancellation',
+        inputSchema: MyToolInput.$schema,
+        fn: (input, context) async {
+          // Simulate the caller cancelling while this tool is in flight, then
+          // bail cooperatively like a well-behaved tool.
+          controller.cancel('stop it');
+          context.cancel?.throwIfCancelled();
+          return .response('unreachable');
+        },
+      );
+
+      genkit.defineBidiModel(
+        name: modelName,
+        fn: (input, context) async {
+          await for (final request in input) {
+            final msg = request.messages.first;
+            if (msg.role == Role.tool) {
+              modelSawToolMessage = true;
+            } else {
+              context.sendChunk(
+                ModelResponseChunk(
+                  content: [
+                    ToolRequestPart(
+                      toolRequest: ToolRequest(
+                        name: toolName,
+                        input: {'location': 'London'},
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }
+          }
+          return ModelResponse(finishReason: FinishReason.stop);
+        },
+      );
+
+      final session = await genkit.generateBidi(
+        model: modelName,
+        toolNames: [toolName],
+        cancel: controller.token,
+      );
+
+      Object? streamError;
+      final done = Completer<void>();
+      session.stream.listen(
+        (_) {},
+        onError: (Object e) {
+          streamError = e;
+          if (!done.isCompleted) done.complete();
+        },
+        onDone: () {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+
+      session.send('check weather');
+      await done.future.timeout(Duration(seconds: 2));
+      await session.close();
+
+      // The cancellation surfaced as a CancelledException, not a StateError from
+      // a closed sink, and the model was never fed a fabricated tool answer.
+      expect(streamError, anyOf(isNull, isA<CancelledException>()));
+      expect(streamError, isNot(isA<StateError>()));
+      expect(
+        modelSawToolMessage,
+        isFalse,
+        reason: 'a cancelled tool must not answer the model',
+      );
+    });
+
     // Interrupts are unary-only: a live bidi session has no resume path, so both
+
     // the returned `.interrupt(...)` and the deprecated throwing
     // `ctx.interrupt(...)` forms must fail the session (surface an error on the
     // stream) and must NOT answer the model with a tool message.

--- a/packages/genkit/test/ai/generate_cancel_test.dart
+++ b/packages/genkit/test/ai/generate_cancel_test.dart
@@ -1,0 +1,289 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:test/test.dart';
+
+/// A middleware that observes the ambient cancellation token at the `model`
+/// hook and records whether it was cancelled by the time the model ran.
+class _CancelObservingMiddleware extends GenerateMiddleware {
+  bool sawCancelledAtModel = false;
+  bool registeredHookFired = false;
+
+  @override
+  Future<ModelResponse> model(
+    ModelRequest request,
+    ActionFnArg<ModelResponseChunk, ModelRequest, void> ctx,
+    Future<ModelResponse> Function(
+      ModelRequest request,
+      ActionFnArg<ModelResponseChunk, ModelRequest, void> ctx,
+    )
+    next,
+  ) async {
+    ctx.cancel.onCancel(() => registeredHookFired = true);
+    sawCancelledAtModel = ctx.cancel.isCancelled;
+    return next(request, ctx);
+  }
+}
+
+void main() {
+  group('generate cancellation', () {
+    late Genkit genkit;
+
+    setUp(() {
+      genkit = Genkit(isDevEnv: false);
+    });
+
+    tearDown(() async {
+      await genkit.shutdown();
+    });
+
+    test('already-cancelled token returns an aborted response with the '
+        'request history', () async {
+      var modelCalled = false;
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          modelCalled = true;
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [TextPart(text: 'hi')],
+            ),
+          );
+        },
+      );
+
+      final controller = CancellationController()..cancel();
+      final res = await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'hello',
+        cancel: controller.token,
+      );
+
+      expect(res.finishReason, FinishReason.aborted);
+      expect(res.message, isNull);
+      expect(res.output, isNull);
+      // The last-good history (the user prompt) is preserved for resumption.
+      expect(res.messages, hasLength(1));
+      expect(res.messages.first.role, Role.user);
+      expect(modelCalled, isFalse);
+    });
+
+    test(
+      'cancelling during the model call returns an aborted response',
+      () async {
+        final controller = CancellationController();
+        genkit.defineModel(
+          name: 'm',
+          fn: (request, ctx) async {
+            // Cancel mid-flight and cooperatively bail.
+            controller.cancel();
+            ctx.cancel.throwIfCancelled();
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'hi')],
+              ),
+            );
+          },
+        );
+
+        final res = await genkit.generate(
+          model: modelRef('m'),
+          prompt: 'hello',
+          cancel: controller.token,
+        );
+
+        expect(res.finishReason, FinishReason.aborted);
+        expect(res.message, isNull);
+        // History carries the turn's input (the user prompt), not the partial
+        // model output.
+        expect(res.messages, hasLength(1));
+        expect(res.messages.first.role, Role.user);
+      },
+    );
+
+    test('middleware can observe the cancellation token', () async {
+      final mwInstance = _CancelObservingMiddleware();
+      final mw = defineMiddleware(
+        name: 'cancel-observer',
+        create: (c, ctx) => mwInstance,
+      );
+      genkit.registry.registerValue('middleware', 'cancel-observer', mw);
+
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [TextPart(text: 'hi')],
+            ),
+          );
+        },
+      );
+
+      final controller = CancellationController();
+      await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'hello',
+        cancel: controller.token,
+        use: [middlewareRef(name: 'cancel-observer')],
+      );
+      expect(mwInstance.sawCancelledAtModel, isFalse);
+
+      // Cancelling now fires the hook the middleware registered on the token.
+      controller.cancel();
+      expect(mwInstance.registeredHookFired, isTrue);
+    });
+
+    test('generateStream resolves to an aborted response when the token is '
+        'already cancelled', () async {
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          ctx.sendChunk(
+            ModelResponseChunk(content: [TextPart(text: 'partial')]),
+          );
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [TextPart(text: 'hi')],
+            ),
+          );
+        },
+      );
+
+      final controller = CancellationController()..cancel();
+      final stream = genkit.generateStream(
+        model: modelRef('m'),
+        prompt: 'hello',
+        cancel: controller.token,
+      );
+
+      final res = await stream.onResult;
+      expect(res.finishReason, FinishReason.aborted);
+      expect(res.message, isNull);
+    });
+
+    test('cancel aborts between tool-loop turns, preserving history', () async {
+      final controller = CancellationController();
+      var modelCalls = 0;
+
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          modelCalls++;
+          if (request.messages.last.role == Role.tool) {
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'done')],
+              ),
+            );
+          }
+          // First turn: request a tool, then cancel so the loop should not
+          // begin another turn.
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'noop', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      genkit.defineTool(
+        name: 'noop',
+        description: 'noop',
+        fn: (input, ctx) async {
+          // Cancel while the tool runs; the next loop turn must not start.
+          controller.cancel();
+          return 'ok';
+        },
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'go',
+        cancel: controller.token,
+      );
+
+      expect(res.finishReason, FinishReason.aborted);
+      // The model ran once (first turn); the second turn was aborted.
+      expect(modelCalls, 1);
+      // The tool completed, so the turn's model message and tool response were
+      // paired into the next turn's input before the top-of-loop cancel check
+      // fired. The aborted response carries the full, paired history
+      // (user + model tool-request + tool response) - a valid resume point.
+      expect(res.messages, hasLength(3));
+      expect(res.messages.first.role, Role.user);
+      expect(res.messages[1].role, Role.model);
+      expect(res.messages.last.role, Role.tool);
+    });
+
+    test(
+      'exceeding maxTurns returns an aborted response with history',
+      () async {
+        var modelCalls = 0;
+        genkit.defineModel(
+          name: 'm',
+          fn: (request, ctx) async {
+            modelCalls++;
+            // Always request the tool so the loop keeps going until maxTurns.
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [
+                  ToolRequestPart(
+                    toolRequest: ToolRequest(name: 'noop', input: {}),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+
+        genkit.defineTool(
+          name: 'noop',
+          description: 'noop',
+          fn: (input, ctx) async => 'ok',
+        );
+
+        final res = await genkit.generate(
+          model: modelRef('m'),
+          prompt: 'go',
+          maxTurns: 2,
+        );
+
+        expect(res.finishReason, FinishReason.aborted);
+        expect(res.finishMessage, contains('max turns'));
+        expect(modelCalls, 2);
+        expect(res.messages, isNotEmpty);
+      },
+    );
+  });
+}

--- a/packages/genkit/test/ai/generate_cancel_test.dart
+++ b/packages/genkit/test/ai/generate_cancel_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
+
 import 'package:genkit/genkit.dart';
 import 'package:test/test.dart';
 
@@ -31,8 +33,8 @@ class _CancelObservingMiddleware extends GenerateMiddleware {
     )
     next,
   ) async {
-    ctx.cancel.onCancel(() => registeredHookFired = true);
-    sawCancelledAtModel = ctx.cancel.isCancelled;
+    ctx.cancel?.onCancel(() => registeredHookFired = true);
+    sawCancelledAtModel = ctx.cancel?.isCancelled ?? false;
     return next(request, ctx);
   }
 }
@@ -91,7 +93,7 @@ void main() {
           fn: (request, ctx) async {
             // Cancel mid-flight and cooperatively bail.
             controller.cancel();
-            ctx.cancel.throwIfCancelled();
+            ctx.cancel?.throwIfCancelled();
             return ModelResponse(
               finishReason: FinishReason.stop,
               message: Message(
@@ -192,7 +194,7 @@ void main() {
           modelCalls++;
           if (request.messages.last.role == Role.tool) {
             controller.cancel();
-            ctx.cancel.throwIfCancelled();
+            ctx.cancel?.throwIfCancelled();
             return ModelResponse(
               finishReason: FinishReason.stop,
               message: Message(
@@ -331,5 +333,227 @@ void main() {
         expect(res.messages, isNotEmpty);
       },
     );
+
+    test('a completed model call is returned even if the token was cancelled '
+        'while it ran (work is not discarded)', () async {
+      final controller = CancellationController();
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          // Plugin does not observe cancellation: it runs to completion even
+          // though the token is cancelled mid-flight.
+          controller.cancel();
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [TextPart(text: 'complete answer')],
+            ),
+          );
+        },
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'hello',
+        cancel: controller.token,
+      );
+
+      // Cooperative cancellation is best-effort: a completed result is not
+      // thrown away and relabeled as aborted.
+      expect(res.finishReason, FinishReason.stop);
+      expect(res.text, 'complete answer');
+    });
+
+    test('a tool can observe the cancellation token via ctx.cancel', () async {
+      final controller = CancellationController();
+      var toolSawCancel = false;
+
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          if (request.messages.last.role == Role.tool) {
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'done')],
+              ),
+            );
+          }
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'waits', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      genkit.defineTool(
+        name: 'waits',
+        description: 'waits for cancellation',
+        fn: (input, ctx) async {
+          // The token is exposed on ToolFnArgs and can be raced/observed.
+          final cancel = ctx.cancel!;
+          controller.cancel('stop it');
+          await cancel.whenCancelled;
+          toolSawCancel = cancel.isCancelled;
+          throw CancelledException(reason: cancel.reason, token: cancel);
+        },
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'go',
+        cancel: controller.token,
+      );
+
+      expect(toolSawCancel, isTrue);
+      expect(res.finishReason, FinishReason.aborted);
+    });
+
+    test("a tool's own internal cancellation does not escape generate when the "
+        'caller never asked to cancel', () async {
+      var modelCalls = 0;
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          modelCalls++;
+          if (request.messages.last.role == Role.tool) {
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'recovered')],
+              ),
+            );
+          }
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'timeout', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      genkit.defineTool(
+        name: 'timeout',
+        description: 'has its own internal timeout token',
+        fn: (input, ctx) async {
+          // A tool's *own* cancellation token, unrelated to the caller's.
+          final internal = CancellationController()..cancel('tool timed out');
+          internal.token.throwIfCancelled();
+          return .response('unreachable');
+        },
+      );
+
+      // No `cancel:` supplied by the caller.
+      final res = await genkit.generate(model: modelRef('m'), prompt: 'go');
+
+      // The tool's internal cancellation is recorded as an error tool response
+      // (like any other tool failure) and the loop continues, rather than
+      // escaping generate() as a throw.
+      expect(res.finishReason, FinishReason.stop);
+      expect(res.text, 'recovered');
+      expect(modelCalls, 2);
+    });
+
+    test('an already-cancelled token on the resume/restart path returns an '
+        'aborted response instead of throwing', () async {
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async => ModelResponse(
+          finishReason: FinishReason.stop,
+          message: Message(
+            role: Role.model,
+            content: [TextPart(text: 'hi')],
+          ),
+        ),
+      );
+
+      genkit.defineTool(
+        name: 'restarted',
+        description: 'a tool being restarted',
+        fn: (input, ctx) async {
+          ctx.cancel?.throwIfCancelled();
+          return .response('ok');
+        },
+      );
+
+      final controller = CancellationController()..cancel();
+      // `interruptRestart` drives the resume/restart path in coreGenerate,
+      // which runs before the loop's own entry checkpoint.
+      final res = await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'go',
+        interruptRestart: [
+          ToolRequestPart(
+            toolRequest: ToolRequest(name: 'restarted', input: {}),
+          ),
+        ],
+        cancel: controller.token,
+      );
+
+      expect(res.finishReason, FinishReason.aborted);
+    });
+
+    test(
+      'jsonOutput returns null on an aborted response rather than throwing',
+      () async {
+        final controller = CancellationController()..cancel();
+        final res = await genkit.generate(
+          model: modelRef('m'),
+          prompt: 'give me json',
+          cancel: controller.token,
+        );
+
+        expect(res.finishReason, FinishReason.aborted);
+        // Degrades safely like the other accessors instead of throwing a
+        // FormatException on the empty text.
+        expect(res.jsonOutput, isNull);
+        expect(res.text, '');
+      },
+    );
+
+    test('a genuine failure that races a cancel is not masked as a clean '
+        'abort', () async {
+      final controller = CancellationController();
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          // A real provider failure surfaces, and the caller cancels in the
+          // same instant.
+          controller.cancel();
+          throw GenkitException(
+            '503 upstream',
+            status: StatusCodes.UNAVAILABLE,
+          );
+        },
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'hello',
+        cancel: controller.token,
+      );
+
+      // The abort still resolves (not throws), but the underlying cause is
+      // preserved in the finish message rather than reported as a clean
+      // "Generation was cancelled".
+      expect(res.finishReason, FinishReason.aborted);
+      expect(res.finishMessage, contains('503 upstream'));
+    });
   });
 }

--- a/packages/genkit/test/ai/generate_cancel_test.dart
+++ b/packages/genkit/test/ai/generate_cancel_test.dart
@@ -191,6 +191,8 @@ void main() {
         fn: (request, ctx) async {
           modelCalls++;
           if (request.messages.last.role == Role.tool) {
+            controller.cancel();
+            ctx.cancel.throwIfCancelled();
             return ModelResponse(
               finishReason: FinishReason.stop,
               message: Message(
@@ -219,8 +221,6 @@ void main() {
         name: 'noop',
         description: 'noop',
         fn: (input, ctx) async {
-          // Cancel while the tool runs; the next loop turn must not start.
-          controller.cancel();
           return 'ok';
         },
       );
@@ -232,12 +232,7 @@ void main() {
       );
 
       expect(res.finishReason, FinishReason.aborted);
-      // The model ran once (first turn); the second turn was aborted.
-      expect(modelCalls, 1);
-      // The tool completed, so the turn's model message and tool response were
-      // paired into the next turn's input before the top-of-loop cancel check
-      // fired. The aborted response carries the full, paired history
-      // (user + model tool-request + tool response) - a valid resume point.
+      expect(modelCalls, 2);
       expect(res.messages, hasLength(3));
       expect(res.messages.first.role, Role.user);
       expect(res.messages[1].role, Role.model);

--- a/packages/genkit/test/ai/generate_cancel_test.dart
+++ b/packages/genkit/test/ai/generate_cancel_test.dart
@@ -221,7 +221,7 @@ void main() {
         name: 'noop',
         description: 'noop',
         fn: (input, ctx) async {
-          return 'ok';
+          return .response('ok');
         },
       );
 
@@ -265,7 +265,7 @@ void main() {
         genkit.defineTool(
           name: 'noop',
           description: 'noop',
-          fn: (input, ctx) async => 'ok',
+          fn: (input, ctx) async => .response('ok'),
         );
 
         final res = await genkit.generate(

--- a/packages/genkit/test/ai/generate_cancel_test.dart
+++ b/packages/genkit/test/ai/generate_cancel_test.dart
@@ -239,6 +239,57 @@ void main() {
       expect(res.messages.last.role, Role.tool);
     });
 
+    test('a generic tool error during cancellation aborts instead of being '
+        'swallowed as a tool failure', () async {
+      final controller = CancellationController();
+      var modelCalls = 0;
+
+      genkit.defineModel(
+        name: 'm',
+        fn: (request, ctx) async {
+          modelCalls++;
+          // Always request the tool. If the generic tool error were swallowed
+          // into an error tool response, the loop would call the model again.
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'boom', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      genkit.defineTool(
+        name: 'boom',
+        description: 'boom',
+        fn: (input, ctx) async {
+          // Simulate a plugin that reacts to cancellation by tearing down its
+          // transport, surfacing a generic error (e.g. SocketException) rather
+          // than a CancelledException.
+          controller.cancel();
+          throw StateError('client closed');
+        },
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m'),
+        prompt: 'go',
+        cancel: controller.token,
+      );
+
+      expect(res.finishReason, FinishReason.aborted);
+      // The model ran exactly once: the generic tool error propagated as a
+      // cancellation and stopped the loop rather than triggering another turn.
+      expect(modelCalls, 1);
+      expect(res.messages, hasLength(1));
+      expect(res.messages.first.role, Role.user);
+    });
+
     test(
       'exceeding maxTurns returns an aborted response with history',
       () async {

--- a/packages/genkit/test/ai/generate_test.dart
+++ b/packages/genkit/test/ai/generate_test.dart
@@ -278,77 +278,65 @@ void main() {
       },
     );
 
-    test('should throw an error when maxTurns is reached', () async {
-      const modelName = 'maxTurnsModel';
-      const toolName = 'testTool';
+    test(
+      'should return an aborted response when maxTurns is reached',
+      () async {
+        const modelName = 'maxTurnsModel';
+        const toolName = 'testTool';
 
-      genkit.defineModel(
-        name: modelName,
-        fn: (request, context) async {
-          return ModelResponse(
-            finishReason: FinishReason.stop,
-            message: Message(
-              role: Role.model,
-              content: [
-                ToolRequestPart(
-                  toolRequest: ToolRequest(
-                    name: toolName,
-                    input: {'name': 'world'},
+        genkit.defineModel(
+          name: modelName,
+          fn: (request, context) async {
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [
+                  ToolRequestPart(
+                    toolRequest: ToolRequest(
+                      name: toolName,
+                      input: {'name': 'world'},
+                    ),
                   ),
-                ),
-              ],
-            ),
-          );
-        },
-      );
+                ],
+              ),
+            );
+          },
+        );
 
-      genkit.defineTool(
-        name: toolName,
-        description: 'A test tool',
-        inputSchema: TestToolInput.$schema,
-        fn: (input, context) async {
-          return .response('tool output');
-        },
-      );
+        genkit.defineTool(
+          name: toolName,
+          description: 'A test tool',
+          inputSchema: TestToolInput.$schema,
+          fn: (input, context) async {
+            return .response('tool output');
+          },
+        );
 
-      await expectLater(
-        () => genkit.generate(
+        // Exceeding maxTurns now resolves gracefully with an aborted response
+        // that carries the accumulated history, rather than throwing.
+        final res = await genkit.generate(
           model: modelRef(modelName),
           prompt: 'Use a tool',
           // this tool causes an infinite tool call loop
+
           toolNames: [toolName],
           maxTurns: 5,
-        ),
-        throwsA(
-          isA<GenkitException>()
-              .having((e) => e.status, 'status', StatusCodes.ABORTED)
-              .having(
-                (e) => e.message,
-                'message',
-                contains('Adjust maxTurns option'),
-              ),
-        ),
-      );
+        );
+        expect(res.finishReason, FinishReason.aborted);
+        expect(res.finishMessage, contains('Adjust maxTurns option'));
+        expect(res.messages, isNotEmpty);
 
-      await expectLater(
-        () => genkit.generate(
+        // maxTurns is not specified, should still use the default (5).
+        final resDefault = await genkit.generate(
           model: modelRef(modelName),
           prompt: 'Use a tool',
-          // this tool causes an infinite tool call loop
           toolNames: [toolName],
-          // maxTurns is not specified, should still use default (5).
-        ),
-        throwsA(
-          isA<GenkitException>()
-              .having((e) => e.status, 'status', StatusCodes.ABORTED)
-              .having(
-                (e) => e.message,
-                'message',
-                contains('Adjust maxTurns option'),
-              ),
-        ),
-      );
-    });
+        );
+        expect(resDefault.finishReason, FinishReason.aborted);
+        expect(resDefault.finishMessage, contains('Adjust maxTurns option'));
+      },
+    );
 
     test('should return full message history in response.messages', () async {
       const modelName = 'historyModel';

--- a/packages/genkit/test/ai/interrupt_test.dart
+++ b/packages/genkit/test/ai/interrupt_test.dart
@@ -304,6 +304,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
+          cancel: CancellationToken.none,
         ),
       );
 
@@ -344,6 +345,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
+          cancel: CancellationToken.none,
         ),
       );
 
@@ -418,6 +420,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
+          cancel: CancellationToken.none,
         ),
       );
 
@@ -450,6 +453,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
+          cancel: CancellationToken.none,
         ),
       );
 

--- a/packages/genkit/test/ai/interrupt_test.dart
+++ b/packages/genkit/test/ai/interrupt_test.dart
@@ -304,7 +304,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
-          cancel: CancellationToken.none,
+          cancel: null,
         ),
       );
 
@@ -345,7 +345,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
-          cancel: CancellationToken.none,
+          cancel: null,
         ),
       );
 
@@ -420,7 +420,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
-          cancel: CancellationToken.none,
+          cancel: null,
         ),
       );
 
@@ -453,7 +453,7 @@ void main() {
           inputStream: null,
           init: null,
           context: null,
-          cancel: CancellationToken.none,
+          cancel: null,
         ),
       );
 

--- a/packages/genkit/test/core/cancellation_test.dart
+++ b/packages/genkit/test/core/cancellation_test.dart
@@ -89,7 +89,7 @@ void main() {
     }) {
       return Action<String, String, void, void>(
         name: 'echo',
-        actionType: 'custom',
+        actionType: .custom,
         fn: (input, ctx) async {
           if (onRun != null) await onRun(ctx);
           ctx.cancel.throwIfCancelled();
@@ -130,7 +130,7 @@ void main() {
       CancellationToken? seen;
       final action = Action<String, String, void, void>(
         name: 'peek',
-        actionType: 'custom',
+        actionType: .custom,
         fn: (input, ctx) async {
           seen = ctx.cancel;
           return input!;
@@ -145,7 +145,7 @@ void main() {
       var torndown = false;
       final action = Action<String, String, void, void>(
         name: 'teardown',
-        actionType: 'custom',
+        actionType: .custom,
         fn: (input, ctx) async {
           ctx.cancel.onCancel(() => torndown = true);
           controller.cancel();

--- a/packages/genkit/test/core/cancellation_test.dart
+++ b/packages/genkit/test/core/cancellation_test.dart
@@ -75,11 +75,74 @@ void main() {
       expect(controller.token.throwIfCancelled, returnsNormally);
     });
 
-    group('CancellationToken.none', () {
-      test('never reports cancelled', () {
-        expect(CancellationToken.none.isCancelled, isFalse);
-        expect(CancellationToken.none.throwIfCancelled, returnsNormally);
+    test('onCancel on an already-cancelled token fires synchronously', () {
+      final controller = CancellationController()..cancel();
+      var fired = false;
+      controller.token.onCancel(() => fired = true);
+      expect(fired, isTrue);
+    });
+
+    test('onCancel disposer detaches the listener', () {
+      final controller = CancellationController();
+      var fired = false;
+      final dispose = controller.token.onCancel(() => fired = true);
+      dispose();
+      controller.cancel();
+      expect(fired, isFalse);
+    });
+
+    test('a throwing listener does not abort the fan-out or escape cancel', () {
+      final controller = CancellationController();
+      final fired = <int>[];
+      controller.token.onCancel(() => fired.add(1));
+      controller.token.onCancel(() => throw StateError('boom'));
+      controller.token.onCancel(() => fired.add(3));
+
+      // cancel() is documented as non-throwing/idempotent; the throwing
+      // listener is routed to the zone error handler, and the surviving
+      // listeners still fire.
+      runZonedGuarded(controller.cancel, (error, stack) {
+        // Swallow the routed listener error so the test zone doesn't fail.
       });
+
+      expect(fired, [1, 3]);
+    });
+
+    test('onCancelWithReason forwards the cancellation reason', () {
+      final controller = CancellationController();
+      Object? seenReason;
+      controller.token.onCancelWithReason((reason) => seenReason = reason);
+      controller.cancel('because');
+      expect(seenReason, 'because');
+    });
+
+    test('link forwards cancellation and reason to the child', () {
+      final parent = CancellationController();
+      final child = CancellationController();
+      parent.token.link(child);
+
+      parent.cancel('stop everything');
+      expect(child.isCancelled, isTrue);
+      expect(child.token.reason, 'stop everything');
+    });
+
+    test('link disposer unlinks the child', () {
+      final parent = CancellationController();
+      final child = CancellationController();
+      final unlink = parent.token.link(child);
+      unlink();
+      parent.cancel();
+      expect(child.isCancelled, isFalse);
+    });
+
+    test('CancelledException carries the producing token', () {
+      final controller = CancellationController()..cancel();
+      try {
+        controller.token.throwIfCancelled();
+        fail('expected throw');
+      } on CancelledException catch (e) {
+        expect(e.token, same(controller.token));
+      }
     });
   });
 
@@ -92,7 +155,7 @@ void main() {
         actionType: .custom,
         fn: (input, ctx) async {
           if (onRun != null) await onRun(ctx);
-          ctx.cancel.throwIfCancelled();
+          ctx.cancel?.throwIfCancelled();
           return 'echo:$input';
         },
       );
@@ -126,18 +189,21 @@ void main() {
       );
     });
 
-    test('ctx.cancel defaults to none when no token is supplied', () async {
+    test('ctx.cancel is null when no token is supplied', () async {
+      var sawCancel = false;
       CancellationToken? seen;
       final action = Action<String, String, void, void>(
         name: 'peek',
         actionType: .custom,
         fn: (input, ctx) async {
+          sawCancel = true;
           seen = ctx.cancel;
           return input!;
         },
       );
       await action.call('x');
-      expect(seen, same(CancellationToken.none));
+      expect(sawCancel, isTrue);
+      expect(seen, isNull);
     });
 
     test('onCancel hook fires when the token is cancelled mid-run', () async {
@@ -147,7 +213,7 @@ void main() {
         name: 'teardown',
         actionType: .custom,
         fn: (input, ctx) async {
-          ctx.cancel.onCancel(() => torndown = true);
+          ctx.cancel?.onCancel(() => torndown = true);
           controller.cancel();
           await Future<void>.delayed(Duration.zero);
           return input!;

--- a/packages/genkit/test/core/cancellation_test.dart
+++ b/packages/genkit/test/core/cancellation_test.dart
@@ -1,0 +1,160 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:genkit/genkit.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CancellationController / CancellationToken', () {
+    test('token starts uncancelled', () {
+      final controller = CancellationController();
+      expect(controller.token.isCancelled, isFalse);
+      expect(controller.isCancelled, isFalse);
+    });
+
+    test('cancel() flips isCancelled on both sides', () {
+      final controller = CancellationController();
+      controller.cancel();
+      expect(controller.isCancelled, isTrue);
+      expect(controller.token.isCancelled, isTrue);
+    });
+
+    test('whenCancelled completes on cancel', () async {
+      final controller = CancellationController();
+      var completed = false;
+      unawaited(controller.token.whenCancelled.then((_) => completed = true));
+      expect(completed, isFalse);
+      controller.cancel();
+      await controller.token.whenCancelled;
+      expect(completed, isTrue);
+    });
+
+    test('cancel is idempotent', () {
+      final controller = CancellationController();
+      var fired = 0;
+      controller.token.onCancel(() => fired++);
+      controller
+        ..cancel()
+        ..cancel();
+      expect(fired, 1);
+    });
+
+    test('reason is surfaced on the token', () {
+      final controller = CancellationController();
+      controller.cancel('stopped by user');
+      expect(controller.token.reason, 'stopped by user');
+    });
+
+    test('throwIfCancelled throws a CancelledException when cancelled', () {
+      final controller = CancellationController()..cancel('nope');
+      expect(
+        controller.token.throwIfCancelled,
+        throwsA(
+          isA<CancelledException>()
+              .having((e) => e.status, 'status', StatusCodes.CANCELLED)
+              .having((e) => e.message, 'message', 'nope'),
+        ),
+      );
+    });
+
+    test('throwIfCancelled is a no-op when not cancelled', () {
+      final controller = CancellationController();
+      expect(controller.token.throwIfCancelled, returnsNormally);
+    });
+
+    group('CancellationToken.none', () {
+      test('never reports cancelled', () {
+        expect(CancellationToken.none.isCancelled, isFalse);
+        expect(CancellationToken.none.throwIfCancelled, returnsNormally);
+      });
+    });
+  });
+
+  group('Action cancellation', () {
+    Action<String, String, void, void> echoAction({
+      Future<void> Function(ActionFnArg<void, String, void> ctx)? onRun,
+    }) {
+      return Action<String, String, void, void>(
+        name: 'echo',
+        actionType: 'custom',
+        fn: (input, ctx) async {
+          if (onRun != null) await onRun(ctx);
+          ctx.cancel.throwIfCancelled();
+          return 'echo:$input';
+        },
+      );
+    }
+
+    test('runs normally without a token', () async {
+      final action = echoAction();
+      expect(await action.call('hi'), 'echo:hi');
+    });
+
+    test('throws immediately when the token is already cancelled', () async {
+      final action = echoAction();
+      final controller = CancellationController()..cancel();
+      await expectLater(
+        action.call('hi', cancel: controller.token),
+        throwsA(isA<CancelledException>()),
+      );
+    });
+
+    test('the action body observes ctx.cancel', () async {
+      final controller = CancellationController();
+      final action = echoAction(
+        onRun: (ctx) async {
+          // Simulate cancellation arriving during execution.
+          controller.cancel();
+        },
+      );
+      await expectLater(
+        action.call('hi', cancel: controller.token),
+        throwsA(isA<CancelledException>()),
+      );
+    });
+
+    test('ctx.cancel defaults to none when no token is supplied', () async {
+      CancellationToken? seen;
+      final action = Action<String, String, void, void>(
+        name: 'peek',
+        actionType: 'custom',
+        fn: (input, ctx) async {
+          seen = ctx.cancel;
+          return input!;
+        },
+      );
+      await action.call('x');
+      expect(seen, same(CancellationToken.none));
+    });
+
+    test('onCancel hook fires when the token is cancelled mid-run', () async {
+      final controller = CancellationController();
+      var torndown = false;
+      final action = Action<String, String, void, void>(
+        name: 'teardown',
+        actionType: 'custom',
+        fn: (input, ctx) async {
+          ctx.cancel.onCancel(() => torndown = true);
+          controller.cancel();
+          await Future<void>.delayed(Duration.zero);
+          return input!;
+        },
+      );
+      await action.call('x', cancel: controller.token);
+      expect(torndown, isTrue);
+    });
+  });
+}

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -250,6 +250,7 @@ class A2uiMiddleware extends GenerateMiddleware {
         context: ctx.context,
         inputStream: ctx.inputStream,
         init: null,
+        cancel: ctx.cancel,
       );
     }
 

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -109,7 +109,13 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
 
         final service = await getApiClient(apiKey);
 
+        // Honor cooperative cancellation: closing the underlying HTTP client
+        // aborts any in-flight (unary or streaming) request. The `finally`
+        // below also closes it on the normal path; closing twice is safe.
+        final disposeCancel = ctx.cancel.onCancel(service.client.close);
+
         try {
+          ctx.cancel.throwIfCancelled();
           final systemMessage = req.messages
               .where((m) => m.role == Role.system)
               .firstOrNull;
@@ -140,6 +146,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             );
             final chunks = <gcl.GenerateContentResponse>[];
             await for (final chunk in stream) {
+              ctx.cancel.throwIfCancelled();
               chunks.add(chunk);
               if (chunk.candidates?.isNotEmpty == true) {
                 final (message, finishReason) = fromGeminiCandidate(
@@ -190,6 +197,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
         } catch (e, stack) {
           throw handleException(e, stack);
         } finally {
+          disposeCancel();
           service.client.close();
         }
       },

--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -112,10 +112,11 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
         // Honor cooperative cancellation: closing the underlying HTTP client
         // aborts any in-flight (unary or streaming) request. The `finally`
         // below also closes it on the normal path; closing twice is safe.
-        final disposeCancel = ctx.cancel.onCancel(service.client.close);
+        final disposeCancel = ctx.cancel?.onCancel(service.client.close);
 
         try {
-          ctx.cancel.throwIfCancelled();
+          ctx.cancel?.throwIfCancelled();
+
           final systemMessage = req.messages
               .where((m) => m.role == Role.system)
               .firstOrNull;
@@ -146,7 +147,8 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
             );
             final chunks = <gcl.GenerateContentResponse>[];
             await for (final chunk in stream) {
-              ctx.cancel.throwIfCancelled();
+              ctx.cancel?.throwIfCancelled();
+
               chunks.add(chunk);
               if (chunk.candidates?.isNotEmpty == true) {
                 final (message, finishReason) = fromGeminiCandidate(
@@ -197,7 +199,7 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
         } catch (e, stack) {
           throw handleException(e, stack);
         } finally {
-          disposeCancel();
+          disposeCancel?.call();
           service.client.close();
         }
       },

--- a/packages/genkit_middleware/lib/src/agents_middleware.dart
+++ b/packages/genkit_middleware/lib/src/agents_middleware.dart
@@ -336,9 +336,18 @@ class AgentsMiddleware extends GenerateMiddleware {
         );
       }
 
-      // ── Failure: surface the error to the orchestrator ────────────────
-      if (output.finishReason == AgentFinishReason.failed) {
-        final message = output.error?.message ?? 'Unknown sub-agent failure.';
+      // ── Failure / abort: surface the error to the orchestrator ────────
+      // A sub-agent that fails or overruns its turn limit now resolves with a
+      // `failed`/`aborted` finishReason (rather than throwing). Both are
+      // surfaced to the orchestrator as an error string instead of degrading
+      // to an empty '(no response)'.
+      if (output.finishReason == AgentFinishReason.failed ||
+          output.finishReason == AgentFinishReason.aborted) {
+        final message =
+            output.error?.message ??
+            (output.finishReason == AgentFinishReason.aborted
+                ? 'Sub-agent turn was aborted.'
+                : 'Unknown sub-agent failure.');
         return AgentDelegationResult(
           response: "Error calling agent '$agentName': $message",
         );

--- a/packages/genkit_middleware/lib/src/filesystem_middleware.dart
+++ b/packages/genkit_middleware/lib/src/filesystem_middleware.dart
@@ -387,6 +387,12 @@ class FilesystemMiddleware extends GenerateMiddleware {
   ) async {
     try {
       return await next(request, ctx);
+    } on CancelledException {
+      // A cooperative cancellation must propagate so the generation loop can
+      // abort. Converting it into an error tool response (below) would let the
+      // loop continue and record a fabricated "cancelled" tool result in the
+      // resumable history.
+      rethrow;
     } catch (e) {
       // Check if this tool is one of ours
       if ([

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -292,14 +292,7 @@ class OpenAIPlugin extends GenkitPlugin {
   Future<ModelResponse> _handleStreaming(
     sdk.OpenAIClient client,
     sdk.ChatCompletionCreateRequest request,
-    ({
-      bool streamingRequested,
-      void Function(ModelResponseChunk) sendChunk,
-      Map<String, dynamic>? context,
-      Stream<ModelRequest>? inputStream,
-      void init,
-    })
-    ctx,
+    ActionFnArg<ModelResponseChunk, ModelRequest, void> ctx,
   ) async {
     final streamRequest = request.copyWith(
       streamOptions: const sdk.StreamOptions(includeUsage: true),

--- a/testapps/agentic_patterns/lib/autonomous_operation.dart
+++ b/testapps/agentic_patterns/lib/autonomous_operation.dart
@@ -128,6 +128,13 @@ Flow<ResearchAgentInput, String, void, void> defineResearchAgent(
         );
       }
 
+      // A cancelled call or a run that overran `maxTurns` now resolves with an
+      // `aborted` finishReason and no model message (so `response.text` is
+      // empty). Surface the reason rather than reporting an empty success.
+      if (response.finishReason == FinishReason.aborted) {
+        return 'Operation aborted: ${response.finishMessage ?? 'unknown reason'}';
+      }
+
       return response.text;
     },
   );

--- a/testapps/ai_features/lib/cancellation_sample.dart
+++ b/testapps/ai_features/lib/cancellation_sample.dart
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Demonstrates cooperative cancellation of a `generate` call.
+///
+/// A [CancellationController] is created by the caller; its [CancellationToken]
+/// is passed into `generate` / `generateStream` via the `cancel:` parameter.
+/// Calling `controller.cancel()` aborts the in-flight model call (and the whole
+/// tool loop). Rather than throwing, `generate` resolves with a response whose
+/// `finishReason` is [FinishReason.aborted]; `response.messages` carries the
+/// last-good history so you can attempt to resume from there.
+///
+/// Run with:
+///   dart run lib/cancellation_sample.dart
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+
+Future<void> main() async {
+  final ai = Genkit(plugins: [googleAI()]);
+
+  // 1) Streaming generate that we cancel shortly after the first chunk.
+  final controller = CancellationController();
+  final stream = ai.generateStream(
+    model: googleAI.gemini('gemini-flash-latest'),
+    prompt: 'Write a long, detailed essay about the history of the internet.',
+    cancel: controller.token,
+  );
+
+  // Cancel after a brief delay to simulate a user hitting "stop".
+  Timer(const Duration(milliseconds: 300), () {
+    print('\n[cancelling...]');
+    controller.cancel('user pressed stop');
+  });
+
+  // Chunks emitted before the cancel still arrive; the stream then closes.
+  await for (final chunk in stream) {
+    print(chunk.text);
+  }
+  final res = await stream.onResult;
+  if (res.finishReason == FinishReason.aborted) {
+    print('\nGeneration was cancelled: ${res.finishMessage}');
+    print('Resumable history has ${res.messages.length} message(s): ${jsonEncode(res.messages).toString()}');
+  }
+
+  // 2) A token that is already cancelled short-circuits before the model runs
+  //    and resolves with an aborted response carrying the request history.
+  final preCancelled = CancellationController()..cancel();
+  final res2 = await ai.generate(
+    model: googleAI.gemini('gemini-flash-latest'),
+    prompt: 'This should never reach the model.',
+    cancel: preCancelled.token,
+  );
+  print(
+    'Pre-cancelled generate finished as ${res2.finishReason?.value} '
+    'with ${res2.messages.length} message(s) of history: ${jsonEncode(res2.messages).toString()}'
+    ,
+  );
+
+  await ai.shutdown();
+}

--- a/testapps/ai_features/lib/cancellation_sample.dart
+++ b/testapps/ai_features/lib/cancellation_sample.dart
@@ -55,7 +55,10 @@ Future<void> main() async {
   final res = await stream.onResult;
   if (res.finishReason == FinishReason.aborted) {
     print('\nGeneration was cancelled: ${res.finishMessage}');
-    print('Resumable history has ${res.messages.length} message(s): ${jsonEncode(res.messages).toString()}');
+    print(
+      'Resumable history has ${res.messages.length} message(s): '
+      '${jsonEncode(res.messages)}',
+    );
   }
 
   // 2) A token that is already cancelled short-circuits before the model runs
@@ -68,8 +71,8 @@ Future<void> main() async {
   );
   print(
     'Pre-cancelled generate finished as ${res2.finishReason?.value} '
-    'with ${res2.messages.length} message(s) of history: ${jsonEncode(res2.messages).toString()}'
-    ,
+    'with ${res2.messages.length} message(s) of history: '
+    '${jsonEncode(res2.messages)}',
   );
 
   await ai.shutdown();

--- a/testapps/middleware/bin/coding_agent.dart
+++ b/testapps/middleware/bin/coding_agent.dart
@@ -104,6 +104,17 @@ void main() async {
           maxTurns: 20,
         );
 
+        if (response.finishReason == FinishReason.aborted) {
+          // An overrun (e.g. maxTurns) or a cancel now resolves as `aborted`
+          // with no model message; surface the reason instead of printing an
+          // empty "AI Response:" below.
+          print(
+            '\nGeneration aborted: '
+            '${response.finishMessage ?? 'unknown reason'}',
+          );
+          return;
+        }
+
         if (response.finishReason != FinishReason.interrupted) {
           break;
         }


### PR DESCRIPTION
BREAKING CHANGE:
when using `maxTurns` option with the `generate` API, it will no longer throw a `GenkitException` with `ABORTED` status, but instead return an response with `aborted` finish reason. The response will contain the last turn's history, allowing you to continue execution if needed.

## Cancellation

```dart
import 'dart:async';
import 'package:genkit/genkit.dart';
import 'package:genkit_google_genai/genkit_google_genai.dart';

final ai = Genkit(plugins: [googleAI()]);

// Caller owns the controller; the token is handed to generate.
final controller = CancellationController();

final stream = ai.generateStream(
  model: googleAI.gemini('gemini-flash-latest'),
  prompt: 'Write a long, detailed essay about the history of the internet.',
  cancel: controller.token,
);

controller.cancel('user pressed stop');

// Chunks emitted before the cancel still arrive; the stream then closes.
await for (final chunk in stream) {
  stdout.write(chunk.text);
}

// Rather than throwing, generate resolves with an aborted response.
final res = await stream.onResult;
if (res.finishReason == FinishReason.aborted) {
  print('\nCancelled: ${res.finishMessage}');
}
```

## Resuming a cancelled request

An aborted response carries no model message, but `res.messages` holds the last-good history (the request messages, plus any completed tool turns). Feed that straight back into a fresh `generate` with a new (uncancelled) token to pick up where you left off.

```dart
// First attempt, cancelled mid-flight.
final controller = CancellationController();
final aborted = await ai.generate(
  model: googleAI.gemini('gemini-flash-latest'),
  prompt: 'Explain quantum computing in detail.',
  cancel: controller.token,
);

controller.cancel();

// Resume: reuse the preserved history.
if (aborted.finishReason == FinishReason.aborted) {
  final resumed = await ai.generate(
    model: googleAI.gemini('gemini-flash-latest'),
    // The last-good conversation state is right here.
    messages: aborted.messages,
  );
  print(resumed.text);
}
```

Same idea after a tool-loop cancel: because the history preserves completed user/model/tool turns (and drops the unanswered model turn so it stays a clean resume point), passing `aborted.messages` back lets the model continue the tool loop from the last settled state.
