### PR TITLE
feat: add promptParts parameter to generate functions

### DIFF
--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -7,7 +7,6 @@ Build production-ready AI-powered applications in Dart with a unified interface 
 [Documentation](https://genkit.dev) • [API Reference](https://pub.dev/packages/genkit) • [Discord](https://discord.gg/qXt5zzQKpc)
 
 ---
-kick ci
 
 ## Installation
 

--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -7,6 +7,7 @@ Build production-ready AI-powered applications in Dart with a unified interface 
 [Documentation](https://genkit.dev) • [API Reference](https://pub.dev/packages/genkit) • [Discord](https://discord.gg/qXt5zzQKpc)
 
 ---
+kick ci
 
 ## Installation
 

--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -6,7 +6,7 @@ Build production-ready AI-powered applications in Dart with a unified interface 
 
 [Documentation](https://genkit.dev) • [API Reference](https://pub.dev/packages/genkit) • [Discord](https://discord.gg/qXt5zzQKpc)
 
---- kick
+---
 
 ## Installation
 

--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -6,7 +6,7 @@ Build production-ready AI-powered applications in Dart with a unified interface 
 
 [Documentation](https://genkit.dev) • [API Reference](https://pub.dev/packages/genkit) • [Discord](https://discord.gg/qXt5zzQKpc)
 
----
+--- kick
 
 ## Installation
 

--- a/packages/genkit/lib/lite.dart
+++ b/packages/genkit/lib/lite.dart
@@ -42,6 +42,7 @@ export 'src/types.dart';
 Future<GenerateResponseHelper> generate<C>({
   String? system,
   String? prompt,
+  List<Part>? promptParts,
   List<Message>? messages,
   required Model<C> model,
   C? config,
@@ -112,6 +113,7 @@ Future<GenerateResponseHelper> generate<C>({
     registry,
     system: system,
     prompt: prompt,
+    promptParts: promptParts,
     messages: messages,
     model: model,
     config: config,
@@ -134,6 +136,7 @@ ActionStream<GenerateResponseChunk, GenerateResponseHelper> generateStream<C>({
   required Model<C> model,
   String? system,
   String? prompt,
+  List<Part>? promptParts,
   List<Message>? messages,
   C? config,
   List<Tool>? tools,
@@ -161,6 +164,7 @@ ActionStream<GenerateResponseChunk, GenerateResponseHelper> generateStream<C>({
   generate(
         system: system,
         prompt: prompt,
+        promptParts: promptParts,
         messages: messages,
         model: model,
         config: config,

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -623,6 +623,7 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
   Registry registry, {
   String? system,
   String? prompt,
+  List<Part>? promptParts,
   List<Message>? messages,
   ModelRef<CustomOptions>? model,
   CustomOptions? config,
@@ -641,8 +642,16 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
   /// List of tool requests to restart during an interrupted generation session.
   List<ToolRequestPart>? restart,
 }) async {
-  if (messages == null && prompt == null && system == null) {
-    throw ArgumentError('system, prompt, or messages must be provided');
+  if (messages == null &&
+      prompt == null &&
+      promptParts == null &&
+      system == null) {
+    throw ArgumentError(
+      'system, prompt, promptParts, or messages must be provided',
+    );
+  }
+  if (prompt != null && promptParts != null) {
+    throw ArgumentError('Cannot set both prompt and promptParts.');
   }
 
   GenerateResumeOptions? resolvedResume;
@@ -688,6 +697,9 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
         content: [TextPart(text: prompt)],
       ),
     );
+  }
+  if (promptParts != null) {
+    resolvedMessages.add(Message(role: Role.user, content: promptParts));
   }
 
   var resolvedModelName = model?.name;

--- a/packages/genkit/lib/src/ai/generate.dart
+++ b/packages/genkit/lib/src/ai/generate.dart
@@ -653,6 +653,9 @@ Future<GenerateResponseHelper> generateHelper<CustomOptions>(
   if (prompt != null && promptParts != null) {
     throw ArgumentError('Cannot set both prompt and promptParts.');
   }
+  if (promptParts != null && promptParts.isEmpty) {
+    throw ArgumentError('promptParts must not be empty.');
+  }
 
   GenerateResumeOptions? resolvedResume;
   if (resume != null || restart != null) {

--- a/packages/genkit/lib/src/genkit_ai.dart
+++ b/packages/genkit/lib/src/genkit_ai.dart
@@ -104,6 +104,7 @@ base class GenkitAI {
   Future<GenerateResponseHelper<Output>> generate<CustomOptions, Output>({
     String? system,
     String? prompt,
+    List<Part>? promptParts,
     List<Message>? messages,
     ModelRef<CustomOptions>? model,
     CustomOptions? config,
@@ -176,6 +177,7 @@ base class GenkitAI {
       resolved.registry,
       system: system,
       prompt: prompt,
+      promptParts: promptParts,
       messages: messages,
       model: model,
       config: config,
@@ -235,6 +237,7 @@ base class GenkitAI {
   generateStream<CustomOptions, Output>({
     String? system,
     String? prompt,
+    List<Part>? promptParts,
     List<Message>? messages,
     ModelRef<CustomOptions>? model,
     CustomOptions? config,
@@ -264,6 +267,7 @@ base class GenkitAI {
     generate(
           system: system,
           prompt: prompt,
+          promptParts: promptParts,
           messages: messages,
           model: model,
           config: config,

--- a/packages/genkit/test/ai/generate_test.dart
+++ b/packages/genkit/test/ai/generate_test.dart
@@ -1104,5 +1104,144 @@ void main() {
         );
       });
     });
+
+    group('promptParts parameter', () {
+      test('builds a user message from the provided parts', () async {
+        const modelName = 'promptPartsModel';
+        ModelRequest? captured;
+        genkit.defineModel(
+          name: modelName,
+          fn: (request, context) async {
+            captured = request;
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'ok')],
+              ),
+            );
+          },
+        );
+
+        await genkit.generate(
+          model: modelRef(modelName),
+          promptParts: [
+            TextPart(text: 'Describe this image:'),
+            MediaPart(media: Media(url: 'data:image/png;base64,abc123')),
+          ],
+        );
+
+        expect(captured, isNotNull);
+        expect(captured!.messages.length, 1);
+        expect(captured!.messages[0].role, Role.user);
+        expect(captured!.messages[0].content.length, 2);
+        expect(
+          captured!.messages[0].content[0].toJson()['text'],
+          'Describe this image:',
+        );
+        expect(captured!.messages[0].content[1].toJson()['media'], {
+          'url': 'data:image/png;base64,abc123',
+        });
+      });
+
+      test('orders as system -> messages -> promptParts', () async {
+        const modelName = 'promptPartsOrderModel';
+        ModelRequest? captured;
+        genkit.defineModel(
+          name: modelName,
+          fn: (request, context) async {
+            captured = request;
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'ok')],
+              ),
+            );
+          },
+        );
+
+        await genkit.generate(
+          model: modelRef(modelName),
+          system: 'sys',
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'past-u')],
+            ),
+          ],
+          promptParts: [TextPart(text: 'now')],
+        );
+
+        expect(captured, isNotNull);
+        expect(captured!.messages.length, 3);
+        expect(captured!.messages[0].role, Role.system);
+        expect(captured!.messages[1].role, Role.user);
+        expect(captured!.messages[1].content[0].toJson()['text'], 'past-u');
+        expect(captured!.messages[2].role, Role.user);
+        expect(captured!.messages[2].content[0].toJson()['text'], 'now');
+      });
+
+      test('flows through generateStream', () async {
+        const modelName = 'promptPartsStreamModel';
+        ModelRequest? captured;
+        genkit.defineModel(
+          name: modelName,
+          fn: (request, context) async {
+            captured = request;
+            context.sendChunk(
+              ModelResponseChunk(content: [TextPart(text: 'hi')]),
+            );
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'hi')],
+              ),
+            );
+          },
+        );
+
+        final stream = genkit.generateStream(
+          model: modelRef(modelName),
+          promptParts: [TextPart(text: 'streamed parts')],
+        );
+        await stream.toList();
+        await stream.onResult;
+
+        expect(captured, isNotNull);
+        expect(captured!.messages.length, 1);
+        expect(captured!.messages[0].role, Role.user);
+        expect(
+          captured!.messages[0].content[0].toJson()['text'],
+          'streamed parts',
+        );
+      });
+
+      test('throws when both prompt and promptParts are provided', () async {
+        const modelName = 'promptPartsConflictModel';
+        genkit.defineModel(
+          name: modelName,
+          fn: (request, context) async {
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'ok')],
+              ),
+            );
+          },
+        );
+
+        await expectLater(
+          () => genkit.generate(
+            model: modelRef(modelName),
+            prompt: 'a',
+            promptParts: [TextPart(text: 'b')],
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
   });
 }

--- a/packages/genkit/test/ai/generate_test.dart
+++ b/packages/genkit/test/ai/generate_test.dart
@@ -1242,6 +1242,27 @@ void main() {
           throwsA(isA<ArgumentError>()),
         );
       });
+
+      test('throws when promptParts is empty', () async {
+        const modelName = 'promptPartsEmptyModel';
+        genkit.defineModel(
+          name: modelName,
+          fn: (request, context) async {
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'ok')],
+              ),
+            );
+          },
+        );
+
+        await expectLater(
+          () => genkit.generate(model: modelRef(modelName), promptParts: []),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
     });
   });
 }

--- a/packages/genkit/test/lite_test.dart
+++ b/packages/genkit/test/lite_test.dart
@@ -139,6 +139,43 @@ void main() {
     expect(captured!.messages[1].content[0].toJson()['text'], 'Hello');
   });
 
+  test('lite generate builds a user message from promptParts', () async {
+    ModelRequest? captured;
+    final model = Model<void>(
+      name: 'promptPartsTestModel',
+      fn: (request, context) async {
+        captured = request;
+        return ModelResponse(
+          finishReason: FinishReason.stop,
+          message: Message(
+            role: Role.model,
+            content: [TextPart(text: 'ok')],
+          ),
+        );
+      },
+    );
+
+    await lite.generate(
+      model: model,
+      promptParts: [
+        TextPart(text: 'Describe this image:'),
+        MediaPart(media: Media(url: 'data:image/png;base64,abc123')),
+      ],
+    );
+
+    expect(captured, isNotNull);
+    expect(captured!.messages.length, 1);
+    expect(captured!.messages[0].role, Role.user);
+    expect(captured!.messages[0].content.length, 2);
+    expect(
+      captured!.messages[0].content[0].toJson()['text'],
+      'Describe this image:',
+    );
+    expect(captured!.messages[0].content[1].toJson()['media'], {
+      'url': 'data:image/png;base64,abc123',
+    });
+  });
+
   test('lite generateStream with outputSchema does not throw', () async {
     final model = Model<void>(
       name: 'testModelStream',

--- a/packages/genkit_anthropic/test/thinking_config_wire_test.dart
+++ b/packages/genkit_anthropic/test/thinking_config_wire_test.dart
@@ -51,7 +51,7 @@ Future<Map<String, dynamic>> _requestOnTheWire({
   });
   final plugin = AnthropicPluginImpl(apiKey: 'test-key', httpClient: client);
   addTearDown(plugin.close);
-  final action = plugin.resolve('model', model) as Model;
+  final action = plugin.resolve(.model, model) as Model;
 
   await action(
     ModelRequest(


### PR DESCRIPTION
Introduce an optional `promptParts` parameter across `generate` and `generateStream` in the lite API, `GenkitAI`, and `generateHelper`. This allows callers to build a user message from a list of `Part` objects (e.g. text and media), complementing the existing string `prompt`.

Add validation to require at least one of system, prompt, promptParts, or messages, and to reject setting both `prompt` and `promptParts`. Include tests covering the new parameter behavior.

```dart
const response = await ai.generate(
   promptParts: [
    TextPart(text: 'Describe this image:'),
    MediaPart(media: Media(url: 'data:image/png;base64,abc123')),
  ],
);
```