### PR TITLE
feat: add Interrupt tool and export tools in Lite API

### DIFF
--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -604,10 +604,23 @@ void main() async {
   // 1. Initialize the plugin directly
   final gemini = googleAI();
 
-  // 2. Direct generation call without a Genkit instance
+  // 2. Define a tool. Tools are plain objects in the Lite API, so you can
+  //    pass them straight to `generate` without registering them anywhere.
+  final weather = Tool(
+    name: 'getWeather',
+    description: 'Gets the current weather for a location.',
+    inputSchema: SchemanticType.map(
+      SchemanticType.string(),
+      SchemanticType.dynamicSchema(),
+    ),
+    fn: (input, ctx) async => .response('Sunny, 24°C in ${input['location']}'),
+  );
+
+  // 3. Direct generation call without a Genkit instance
   final response = await lite.generate(
     model: gemini.model('gemini-flash-latest'),
-    prompt: 'Hello from Lite API!',
+    prompt: 'What is the weather in Toronto?',
+    tools: [weather],
     // Middleware objects are used directly in the Lite API
     use: [
       RetryMiddleware(maxRetries: 2),

--- a/packages/genkit/lib/genkit.dart
+++ b/packages/genkit/lib/genkit.dart
@@ -100,6 +100,7 @@ export 'src/ai/template_helper.dart'
     show TemplateHelperFn, TemplateHelperOptions;
 export 'src/ai/tool.dart'
     show
+        Interrupt,
         Tool,
         ToolFn,
         ToolFnArgs,

--- a/packages/genkit/lib/lite.dart
+++ b/packages/genkit/lib/lite.dart
@@ -35,7 +35,18 @@ import 'src/core/action.dart';
 import 'src/core/registry.dart';
 import 'src/types.dart';
 
+export 'src/ai/generate_types.dart'
+    show GenerateResponseChunk, GenerateResponseHelper, InterruptResponse;
 export 'src/ai/remote_model.dart' show remoteModel;
+export 'src/ai/tool.dart'
+    show
+        Interrupt,
+        Tool,
+        ToolFn,
+        ToolFnArgs,
+        ToolInterruptResult,
+        ToolResponseResult,
+        ToolResult;
 export 'src/schema_extensions.dart';
 export 'src/types.dart';
 

--- a/packages/genkit/lib/plugin.dart
+++ b/packages/genkit/lib/plugin.dart
@@ -38,6 +38,7 @@ export 'package:genkit/src/ai/model.dart'
     show BidiModel, Model, ModelRef, modelMetadata, modelRef;
 export 'package:genkit/src/ai/tool.dart'
     show
+        Interrupt,
         Tool,
         ToolFn,
         ToolFnArgs,

--- a/packages/genkit/lib/src/ai/tool.dart
+++ b/packages/genkit/lib/src/ai/tool.dart
@@ -230,3 +230,77 @@ class Tool<Input, Output>
   @override
   SchemanticType? get manifestOutputSchema => toolOutputSchema;
 }
+
+/// A special kind of [Tool] that always interrupts the generation loop.
+///
+/// Interrupts make it simpler to implement "human-in-the-loop" and
+/// out-of-band processing patterns that require waiting on external actions
+/// to complete. When the model calls an interrupt, the tool request bubbles
+/// back to the caller (with `finishReason == interrupted`) instead of
+/// executing any logic. You can then resume generation on a follow-up
+/// `generate` call by supplying `interruptRespond` to provide an answer.
+///
+/// A pure interrupt can only be responded to, never restarted: its body always
+/// interrupts, so restarting it (via `interruptRestart`) would just interrupt
+/// again, forever. That is why its `tool` metadata carries `restartable: false`.
+/// If you need a tool that interrupts once and then runs to completion when
+/// resumed, use a regular [Tool] whose function returns `.interrupt(...)`
+/// conditionally (for example, based on `ctx.resumed`).
+///
+/// This is the unregistered constructor form (the analog of [Tool]); it can be
+/// passed directly to `generate`/`generateStream` via the `tools:` parameter,
+/// including with the lightweight `lite.dart` API. To define and register an
+/// interrupt on a full `Genkit` instance, use `defineInterrupt`.
+///
+/// Example:
+/// ```dart
+/// final confirm = Interrupt<Map<String, dynamic>, String>(
+///   name: 'confirmAction',
+///   description: 'Asks the user to confirm before proceeding.',
+///   inputSchema: SchemanticType.map(
+///     SchemanticType.string(),
+///     SchemanticType.dynamicSchema(),
+///   ),
+/// );
+/// ```
+final class Interrupt<Input, Output> extends Tool<Input, Output> {
+  // Uses an explicit super call (not super parameters) because the base `fn`
+  // and `metadata` are synthesized here, which is incompatible with
+  // super-parameter forwarding.
+  // ignore: use_super_parameters
+  Interrupt({
+    required String name,
+    required String description,
+    SchemanticType<Input>? inputSchema,
+    SchemanticType<Output>? outputSchema,
+    Map<String, dynamic>? metadata,
+
+    /// Optional data attached to the `interrupt` metadata of the generated tool
+    /// request. Receives the tool input and may return a value or a future.
+    /// When omitted, the interrupt metadata defaults to `true`.
+    FutureOr<Object?> Function(Input input, ToolFnArgs<Input> ctx)?
+    requestMetadata,
+  }) : super(
+         name: name,
+         description: description,
+         inputSchema: inputSchema,
+         toolOutputSchema: outputSchema,
+         metadata: {
+           ...?metadata,
+           'tool': {
+             // `metadata['tool']` is user-supplied; only spread it when it is
+             // actually a map (it may be absent, a `Map<dynamic, dynamic>` from
+             // a literal, or an unrelated value), otherwise ignore it.
+             if (metadata?['tool'] is Map)
+               ...(metadata!['tool'] as Map).cast<String, dynamic>(),
+             'restartable': false,
+           },
+         },
+         fn: (input, ctx) async {
+           final data = requestMetadata == null
+               ? null
+               : await requestMetadata(input, ctx);
+           return ToolResult.interrupt(data);
+         },
+       );
+}

--- a/packages/genkit/lib/src/genkit_class.dart
+++ b/packages/genkit/lib/src/genkit_class.dart
@@ -220,7 +220,7 @@ final class Genkit extends GenkitAI {
   ///   ),
   /// );
   /// ```
-  Tool<Input, Output> defineInterrupt<Input, Output>({
+  Interrupt<Input, Output> defineInterrupt<Input, Output>({
     required String name,
     required String description,
     SchemanticType<Input>? inputSchema,
@@ -233,31 +233,16 @@ final class Genkit extends GenkitAI {
     FutureOr<Object?> Function(Input input, ToolFnArgs<Input> ctx)?
     requestMetadata,
   }) {
-    final tool = Tool<Input, Output>(
+    final interrupt = Interrupt<Input, Output>(
       name: name,
       description: description,
       inputSchema: inputSchema,
-      toolOutputSchema: outputSchema,
-      metadata: {
-        ...?metadata,
-        'tool': {
-          // `metadata['tool']` is user-supplied; only spread it when it is
-          // actually a map (it may be absent, a `Map<dynamic, dynamic>` from a
-          // literal, or an unrelated value), otherwise ignore it.
-          if (metadata?['tool'] is Map)
-            ...(metadata!['tool'] as Map).cast<String, dynamic>(),
-          'restartable': false,
-        },
-      },
-      fn: (input, ctx) async {
-        final data = requestMetadata == null
-            ? null
-            : await requestMetadata(input, ctx);
-        return ToolResult.interrupt(data);
-      },
+      outputSchema: outputSchema,
+      metadata: metadata,
+      requestMetadata: requestMetadata,
     );
-    registry.register(tool);
-    return tool;
+    registry.register(interrupt);
+    return interrupt;
   }
 
   /// Defines an executable prompt with Handlebars template support.

--- a/packages/genkit/test/lite_test.dart
+++ b/packages/genkit/test/lite_test.dart
@@ -214,6 +214,232 @@ void main() {
     expect(response.text, '{"result": "success"}');
   });
 
+  group('lite tools and interrupts', () {
+    test('runs a tool and feeds its output back to the model', () async {
+      final weather = Tool(
+        name: 'weather',
+        description: 'Gets the weather.',
+        inputSchema: .map(.string(), .dynamicSchema()),
+        fn: (input, ctx) async => .response('sunny'),
+      );
+
+      final model = Model<void>(
+        name: 'toolModel',
+        fn: (request, context) async {
+          if (request!.messages.last.role == Role.tool) {
+            final toolResponse =
+                request.messages.last.content.first.toolResponse!;
+
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'weather is ${toolResponse.output}')],
+              ),
+            );
+          }
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'weather', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      final response = await lite.generate(
+        model: model,
+        prompt: 'what is the weather?',
+        tools: [weather],
+      );
+
+      expect(response.text, 'weather is sunny');
+    });
+
+    test('a tool returning .interrupt halts the generation loop', () async {
+      final needsApproval = Tool(
+        name: 'needsApproval',
+        description: 'requires approval',
+        inputSchema: .map(.string(), .dynamicSchema()),
+        fn: (input, ctx) async => .interrupt({'requiresConfirmation': true}),
+      );
+
+      final model = Model<void>(
+        name: 'interruptModel',
+        fn: (request, context) async {
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'needsApproval', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      final response = await lite.generate(
+        model: model,
+        prompt: 'go',
+        tools: [needsApproval],
+      );
+
+      expect(response.finishReason, FinishReason.interrupted);
+      expect(response.interrupts, hasLength(1));
+      expect(response.interrupts.first.toolRequest.name, 'needsApproval');
+      expect(response.interrupts.first.metadata?['interrupt'], {
+        'requiresConfirmation': true,
+      });
+    });
+
+    test('an Interrupt always interrupts with default metadata', () async {
+      final confirm = Interrupt(
+        name: 'confirmAction',
+        description: 'Asks the user to confirm.',
+        inputSchema: .map(.string(), .dynamicSchema()),
+      );
+
+      expect(confirm.metadata['tool'], {'restartable': false});
+
+      final model = Model<void>(
+        name: 'confirmModel',
+        fn: (request, context) async {
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'confirmAction', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      final response = await lite.generate(
+        model: model,
+        prompt: 'do the thing',
+        tools: [confirm],
+      );
+
+      expect(response.finishReason, FinishReason.interrupted);
+      expect(response.interrupts, hasLength(1));
+      expect(response.message!.content.first.metadata?['interrupt'], true);
+    });
+
+    test('an Interrupt attaches computed requestMetadata', () async {
+      final confirm = Interrupt(
+        name: 'confirmCharge',
+        description: 'Asks the user to confirm a charge.',
+        inputSchema: .map(.string(), .dynamicSchema()),
+        requestMetadata: (input, _) => {'amount': input['amount']},
+      );
+
+      final model = Model<void>(
+        name: 'chargeModel',
+        fn: (request, context) async {
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(
+                    name: 'confirmCharge',
+                    input: {'amount': 42},
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      final response = await lite.generate(
+        model: model,
+        prompt: 'charge me',
+        tools: [confirm],
+      );
+
+      expect(response.finishReason, FinishReason.interrupted);
+      expect(response.message!.content.first.metadata?['interrupt'], {
+        'amount': 42,
+      });
+    });
+
+    test('an interrupted Interrupt can be resumed with '
+        'interruptRespond', () async {
+      final confirm = Interrupt(
+        name: 'confirmAction',
+        description: 'Asks the user to confirm.',
+        inputSchema: .map(.string(), .dynamicSchema()),
+      );
+
+      var modelCallCount = 0;
+      final model = Model<void>(
+        name: 'resumeModel',
+        fn: (request, context) async {
+          modelCallCount++;
+
+          if (request!.messages.last.role == Role.tool) {
+            final toolResponse =
+                request.messages.last.content.first.toolResponse!;
+            return ModelResponse(
+              finishReason: FinishReason.stop,
+              message: Message(
+                role: Role.model,
+                content: [TextPart(text: 'confirmed: ${toolResponse.output}')],
+              ),
+            );
+          }
+
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                ToolRequestPart(
+                  toolRequest: ToolRequest(name: 'confirmAction', input: {}),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      final response1 = await lite.generate(
+        model: model,
+        prompt: 'do the thing',
+        tools: [confirm],
+      );
+      expect(response1.finishReason, FinishReason.interrupted);
+      expect(response1.interrupts, hasLength(1));
+
+      final response2 = await lite.generate(
+        model: model,
+        messages: response1.messages,
+        tools: [confirm],
+        interruptRespond: [
+          InterruptResponse(response1.interrupts.first, 'UserConfirmed'),
+        ],
+      );
+
+      expect(response2.finishReason, FinishReason.stop);
+      expect(response2.text, 'confirmed: UserConfirmed');
+      expect(modelCallCount, 2);
+    });
+  });
+
   group('remoteModel', () {
     late MockClient mockClient;
     const remoteUrl = 'http://localhost:3400/remote-model';


### PR DESCRIPTION
Introduce the `Interrupt` tool class for human-in-the-loop and out-of-band processing patterns that interrupt the generation loop.

Export `Interrupt`, `Tool`, and related tool types across `genkit.dart`, `lite.dart`, and `plugin.dart` so tools can be passed directly to `generate`/`generateStream`, including via the lightweight Lite API.

Update the README to demonstrate defining and using a tool with the Lite API.