### PR TITLE
refactor(a2ui): accept Genkit instance in loadCatalog instead of Registry

### DIFF
--- a/packages/genkit_a2ui/README.md
+++ b/packages/genkit_a2ui/README.md
@@ -220,7 +220,7 @@ server:
 import 'package:genkit_a2ui/a2ui.dart';
 
 await loadCatalog(
-  ai.registry,
+  ai,
   id: 'my-catalog',
   file: './my-catalog.json',
 );
@@ -250,7 +250,7 @@ final myCatalog = A2uiCatalog(
 );
 
 await loadCatalog(
-  ai.registry,
+  ai,
   id: 'my-catalog',
   catalog: myCatalog,
 );

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -47,7 +47,7 @@ part 'a2ui_middleware.g.dart';
 abstract class $A2uiOptions {
   /// The id of the catalog describing what the agent may render. Defaults to
   /// `'basic'` (the bundled basic catalog). Register additional catalogs with
-  /// `loadCatalog(registry, id: ..., catalog: ...)` and reference them by id.
+  /// `loadCatalog(ai, id: ..., catalog: ...)` and reference them by id.
   String? get catalog;
 
   /// Where to inject the catalog's capabilities. `'system'` (default) appends

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.g.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.g.dart
@@ -51,14 +51,14 @@ base class A2uiOptions {
 
   /// The id of the catalog describing what the agent may render. Defaults to
   /// `'basic'` (the bundled basic catalog). Register additional catalogs with
-  /// `loadCatalog(registry, id: ..., catalog: ...)` and reference them by id.
+  /// `loadCatalog(ai, id: ..., catalog: ...)` and reference them by id.
   String? get catalog {
     return _json['catalog'] as String?;
   }
 
   /// The id of the catalog describing what the agent may render. Defaults to
   /// `'basic'` (the bundled basic catalog). Register additional catalogs with
-  /// `loadCatalog(registry, id: ..., catalog: ...)` and reference them by id.
+  /// `loadCatalog(ai, id: ..., catalog: ...)` and reference them by id.
   set catalog(String? value) {
     if (value == null) {
       _json.remove('catalog');

--- a/packages/genkit_a2ui/lib/src/loader.dart
+++ b/packages/genkit_a2ui/lib/src/loader.dart
@@ -26,6 +26,7 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:genkit/genkit.dart';
 import 'package:genkit/plugin.dart';
 
 import 'catalog.dart';
@@ -36,7 +37,7 @@ import 'catalog.dart';
 /// Returns the registered catalog (with its `id` set to the catalog's own id if
 /// present, otherwise the given [id]).
 Future<A2uiCatalog> loadCatalog(
-  Registry registry, {
+  Genkit ai, {
   required String id,
   A2uiCatalog? catalog,
   String? file,
@@ -60,7 +61,7 @@ Future<A2uiCatalog> loadCatalog(
     id: resolved.id.isNotEmpty ? resolved.id : id,
     components: resolved.components,
   );
-  registry.registerValue(a2uiCatalogValueType, id, registered);
+  ai.registry.registerValue(a2uiCatalogValueType, id, registered);
   return registered;
 }
 
@@ -96,7 +97,7 @@ A2uiCatalog resolveCatalog(Registry registry, String id) {
   if (id == defaultCatalogId) return basicCatalog;
   throw StateError(
     'a2ui(): no catalog registered under id "$id". '
-    'Register one with loadCatalog(registry, id: "$id", catalog: ...) or use '
+    'Register one with loadCatalog(ai, id: "$id", catalog: ...) or use '
     'the default "$defaultCatalogId" catalog.',
   );
 }

--- a/packages/genkit_a2ui/test/loader_test.dart
+++ b/packages/genkit_a2ui/test/loader_test.dart
@@ -44,7 +44,7 @@ void main() {
   group('loadCatalog', () {
     test('registers an in-memory catalog under its id', () async {
       final result = await loadCatalog(
-        genkit.registry,
+        genkit,
         id: 'my-catalog',
         catalog: custom,
       );
@@ -56,7 +56,7 @@ void main() {
       'defaults the catalog id to the registration id when absent',
       () async {
         final result = await loadCatalog(
-          genkit.registry,
+          genkit,
           id: 'anon',
           catalog: A2uiCatalog(id: '', components: custom.components),
         );
@@ -66,7 +66,7 @@ void main() {
 
     test('throws when neither catalog nor file is provided', () async {
       await expectLater(
-        loadCatalog(genkit.registry, id: 'x'),
+        loadCatalog(genkit, id: 'x'),
         throwsA(
           isA<ArgumentError>().having(
             (e) => e.message,
@@ -92,7 +92,7 @@ void main() {
         final file = File('${dir.path}/catalog.json');
         await file.writeAsString(jsonEncode(custom.toJson()));
         final result = await loadCatalog(
-          genkit.registry,
+          genkit,
           id: 'my-catalog',
           file: file.path,
         );
@@ -102,7 +102,7 @@ void main() {
 
       test('throws on a missing file', () async {
         await expectLater(
-          loadCatalog(genkit.registry, id: 'x', file: '${dir.path}/nope.json'),
+          loadCatalog(genkit, id: 'x', file: '${dir.path}/nope.json'),
           throwsA(
             isA<StateError>().having(
               (e) => e.message,
@@ -117,7 +117,7 @@ void main() {
         final file = File('${dir.path}/bad.json');
         await file.writeAsString('{not json}');
         await expectLater(
-          loadCatalog(genkit.registry, id: 'x', file: file.path),
+          loadCatalog(genkit, id: 'x', file: file.path),
           throwsA(
             isA<StateError>().having(
               (e) => e.message,
@@ -132,7 +132,7 @@ void main() {
         final file = File('${dir.path}/no-components.json');
         await file.writeAsString(jsonEncode({'id': 'x'}));
         await expectLater(
-          loadCatalog(genkit.registry, id: 'x', file: file.path),
+          loadCatalog(genkit, id: 'x', file: file.path),
           throwsA(
             isA<StateError>().having(
               (e) => e.message,
@@ -147,7 +147,7 @@ void main() {
 
   group('resolveCatalog', () {
     test('resolves a registered catalog by id', () async {
-      await loadCatalog(genkit.registry, id: 'my-catalog', catalog: custom);
+      await loadCatalog(genkit, id: 'my-catalog', catalog: custom);
       final resolved = resolveCatalog(genkit.registry, 'my-catalog');
       expect(resolved.id, 'my-catalog');
     });

--- a/packages/genkit_a2ui/test/middleware_test.dart
+++ b/packages/genkit_a2ui/test/middleware_test.dart
@@ -96,7 +96,7 @@ void main() {
 
     test('resolves a custom catalog registered by id', () async {
       await loadCatalog(
-        genkit.registry,
+        genkit,
         id: 'my-catalog',
         catalog: const A2uiCatalog(
           id: 'my-catalog',

--- a/testapps/a2ui/README.md
+++ b/testapps/a2ui/README.md
@@ -11,6 +11,11 @@ A complete, runnable sample of [A2UI](https://a2ui.org/) with Genkit Dart:
   renderer (`SurfaceController` + `Surface`). Button presses and form submits are
   sent back to the agent as the next turn.
 
+It also demonstrates a **custom catalog**: a bespoke `Gauge` component that is
+not part of the bundled basic catalog. See ["Custom catalog"](#custom-catalog)
+below.
+
+
 This is a Flutter package, so it lives outside the root pub workspace (like
 `testapps/flutter_genai`) and uses `path:` dependencies on the local packages.
 
@@ -48,6 +53,8 @@ This is a Flutter package, so it lives outside the root pub workspace (like
 ## Try it
 
 - "What's the weather in Tokyo?" — renders a weather card.
+- "Show the weather in Tokyo with a gauge." — renders the custom `Gauge`
+  component (see below).
 - "Compare the weather in London, Paris and Rome." — renders a comparison.
 - "Give me a short signup form (name and email) with a submit button." — renders
   a form; submitting sends the entered values back to the agent.
@@ -59,6 +66,33 @@ This is a Flutter package, so it lives outside the root pub workspace (like
   (`{ "envelopes": [...] }`, mime `application/a2ui+json`) on both the streamed
   chunks and the final message.
 - The client converts each envelope map to a genui `A2uiMessage`
-  (`A2uiMessage.fromJson`) and feeds it to a `SurfaceController`. The bundled
-  genui basic catalog is re-tagged with the plugin's basic-catalog id so surfaces
-  resolve to real widgets.
+  (`A2uiMessage.fromJson`) and feeds it to a `SurfaceController`. The client
+  catalog is tagged with the same catalog id the agent uses, so surfaces resolve
+  to real widgets.
+
+## Custom catalog
+
+By default the `a2ui()` middleware uses the bundled **basic catalog** (Text,
+Card, Column, Button, ...). This sample instead ships its own catalog that adds
+a bespoke `Gauge` component. A catalog has two halves that must agree on a
+catalog id (here `com.example.a2ui.weather`, defined once in `lib/shared.dart`):
+
+- **Server** (`lib/agent.dart`): `weatherCatalog` is an `A2uiCatalog` built from
+  `basicCatalog.components` plus one `A2uiCatalogComponent` describing `Gauge`
+  (its name, a one-line description, and a plain-text `props` line). This is the
+  model-facing half: the middleware injects it into the system prompt so the
+  model knows `Gauge` exists, and validates that emitted surfaces only reference
+  components in the catalog. `registerCatalogs()` (called from
+  `bin/server.dart`) registers it with `loadCatalog(...)`, and the agent selects
+  it with `a2ui(catalog: weatherCatalogId, validate: 'strict')`.
+- **Client** (`lib/gauge.dart` + `lib/main.dart`): `gaugeCatalogItem` is a genui
+  `CatalogItem` (a `name`, a prop `dataSchema`, and a `widgetBuilder` that paints
+  the gauge). `main.dart` adds it to genui's basic widgets and re-tags the whole
+  catalog with the same id
+  (`BasicCatalogItems.asCatalog().copyWith(newItems: [gaugeCatalogItem],
+  catalogId: weatherCatalogId)`).
+
+The `name` on both sides (`'Gauge'`) and the catalog id must match, otherwise the
+model would emit a `Gauge` the client can't render, or the client would register
+widgets under an id no surface references.
+

--- a/testapps/a2ui/bin/server.dart
+++ b/testapps/a2ui/bin/server.dart
@@ -34,6 +34,10 @@ import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 import 'package:shelf_router/shelf_router.dart';
 
 void main() async {
+  // Register the app's custom A2UI catalog before serving any turns, so the
+  // agent's `a2ui(catalog: weatherCatalogId)` can resolve it from the registry.
+  await registerCatalogs();
+
   final router = Router();
 
   router.get('/', (Request request) {

--- a/testapps/a2ui/lib/agent.dart
+++ b/testapps/a2ui/lib/agent.dart
@@ -18,12 +18,20 @@
 /// list; `A2uiPlugin()` is registered on the Genkit instance so the reference
 /// resolves. The API key is read from the `GEMINI_API_KEY` environment variable
 /// by the `googleAI()` plugin.
+///
+/// This sample also demonstrates a **custom catalog**: [weatherCatalog] extends
+/// the bundled basic catalog with a bespoke `Gauge` component. The catalog
+/// tells the model what it may render; the Flutter client registers a matching
+/// `Gauge` widget under the same id (see `lib/main.dart`) so the surface renders
+/// to a real widget.
 library;
 
 import 'package:genkit/genkit.dart';
 import 'package:genkit_a2ui/a2ui.dart';
 import 'package:genkit_google_genai/genkit_google_genai.dart';
 import 'package:schemantic/schemantic.dart';
+
+import 'shared.dart';
 
 part 'agent.g.dart';
 
@@ -42,7 +50,49 @@ abstract class $GetWeatherOutput {
 }
 
 /// The shared Genkit instance. `A2uiPlugin()` registers the `a2ui()` middleware.
-final Genkit ai = Genkit(plugins: [googleAI(), A2uiPlugin()]);
+final Genkit ai = Genkit(plugins: [googleAI(), A2uiPlugin(), RetryPlugin()]);
+
+/// The app's custom A2UI catalog.
+///
+/// A catalog is just the list of components the model is allowed to render,
+/// each with a short, model-facing description of its props. Here we start from
+/// the bundled [basicCatalog] (Text, Card, Column, Button, ...) and add one
+/// bespoke component, `Gauge`, that has no basic-catalog equivalent. The
+/// matching `Gauge` *widget* is registered on the client under the same
+/// [weatherCatalogId] (see `lib/main.dart`).
+///
+/// Because the middleware validates emitted surfaces against this catalog (see
+/// `a2ui(validate: 'strict')` below), the model can only reference components
+/// listed here - so `Gauge` is both advertised to the model and enforced.
+final A2uiCatalog weatherCatalog = A2uiCatalog(
+  id: weatherCatalogId,
+  components: [
+    // Reuse everything the bundled basic catalog offers...
+    ...basicCatalog.components,
+    // ...plus one component of our own. The description and `props` line are
+    // what the model sees; keep them concise and concrete.
+    const A2uiCatalogComponent(
+      name: 'Gauge',
+      description:
+          'A circular gauge that visualizes a single numeric value within a '
+          'range (e.g. temperature or humidity). Prefer this over plain text '
+          'for a headline metric.',
+      props:
+          'value: number or { path } binding (required); min?: number '
+          '(default 0); max?: number (default 100); label?: string; unit?: '
+          'string (e.g. "°C" or "%").',
+    ),
+  ],
+);
+
+/// Registers [weatherCatalog] on the Genkit registry so `a2ui(catalog: ...)`
+/// can resolve it by id. Call this once at startup (see `bin/server.dart`)
+/// before the agent handles a turn.
+///
+/// [loadCatalog] is the documented way to register a catalog; you can also load
+/// one from a JSON file with `loadCatalog(ai.registry, id: ..., file: ...)`.
+Future<void> registerCatalogs() =>
+    loadCatalog(ai, id: weatherCatalogId, catalog: weatherCatalog);
 
 /// A demo tool the model can call to fetch (fake) weather data.
 final getWeather = ai.defineTool(
@@ -54,11 +104,13 @@ final getWeather = ai.defineTool(
     // Deterministic pseudo-values so the demo is stable per-city.
     final seed = input.city.codeUnits.fold<int>(0, (a, c) => a + c);
     const conditions = ['Sunny', 'Partly cloudy', 'Rainy', 'Windy', 'Foggy'];
-    return GetWeatherOutput(
-      city: input.city,
-      tempC: (10 + (seed % 20)).toDouble(),
-      condition: conditions[seed % conditions.length],
-      humidity: 40 + (seed % 50),
+    return .response(
+      GetWeatherOutput(
+        city: input.city,
+        tempC: (10 + (seed % 20)).toDouble(),
+        condition: conditions[seed % conditions.length],
+        humidity: 40 + (seed % 50),
+      ),
     );
   },
 );
@@ -75,9 +127,17 @@ final uiAgent = ai.defineAgent(
       'example weather, comparisons, lists, forms, or anything interactive. '
       'Keep any prose brief; put the substance in the UI. When asked about '
       'weather, call the getWeather tool, then render a nice Card/Column '
-      'summarizing it (temperature, condition, humidity). Feel free to add a '
-      'Button (e.g. "Refresh") when useful.',
+      'summarizing it (temperature, condition, humidity). Use the custom '
+      'Gauge component for the headline temperature (e.g. min -10, max 40, '
+      'unit "°C") and consider a second Gauge for humidity (min 0, max 100, '
+      'unit "%"). Feel free to add a Button (e.g. "Refresh") when useful.',
   tools: [getWeather],
-  use: [a2ui()],
+  // Point the middleware at our custom catalog by id, and use strict
+  // validation so any surface referencing a component outside the catalog
+  // fails fast during development.
+  use: [
+    a2ui(catalog: weatherCatalogId, validate: 'strict'),
+    retry(),
+  ],
   store: InMemorySessionStore(),
 );

--- a/testapps/a2ui/lib/agent.g.dart
+++ b/testapps/a2ui/lib/agent.g.dart
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'agent.dart';

--- a/testapps/a2ui/lib/agent.g.dart
+++ b/testapps/a2ui/lib/agent.g.dart
@@ -1,17 +1,3 @@
-// Copyright 2025 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'agent.dart';

--- a/testapps/a2ui/lib/gauge.dart
+++ b/testapps/a2ui/lib/gauge.dart
@@ -1,0 +1,215 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The client-side half of the sample's custom A2UI catalog: a `Gauge` widget.
+///
+/// The server advertises a `Gauge` component to the model (see
+/// `weatherCatalog` in `lib/agent.dart`). Here we implement the matching
+/// Flutter widget as a genui [CatalogItem]. genui builds a widget for a
+/// component by looking up a [CatalogItem] whose [CatalogItem.name] equals the
+/// component's `component` field, so the name here (`'Gauge'`) MUST match the
+/// name the server catalog uses.
+///
+/// A [CatalogItem] is three things:
+///  1. a `name` (the component type in the A2UI JSON),
+///  2. a `dataSchema` describing its props (used for client-side validation),
+///  3. a `widgetBuilder` that turns the parsed props into a Flutter widget.
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:genui/genui.dart';
+import 'package:json_schema_builder/json_schema_builder.dart';
+
+/// The prop schema for the `Gauge` component.
+///
+/// `value` uses [A2uiSchemas.numberReference] so it accepts either a literal
+/// number or a `{ "path": "/..." }` data-model binding, exactly like the basic
+/// catalog's Slider. The rest are simple literals.
+final _gaugeSchema = S.object(
+  description: 'A circular gauge visualizing a single numeric value.',
+  properties: {
+    'value': A2uiSchemas.numberReference(
+      description:
+          'The value to display. Literal number or a { path } binding.',
+    ),
+    'min': S.number(description: 'The minimum of the range. Defaults to 0.'),
+    'max': S.number(description: 'The maximum of the range. Defaults to 100.'),
+    'label': A2uiSchemas.stringReference(
+      description: 'An optional caption shown under the value.',
+    ),
+    'unit': S.string(description: 'An optional unit suffix, e.g. "°C" or "%".'),
+  },
+  required: ['value'],
+);
+
+/// The `Gauge` catalog item.
+///
+/// Register it on the client by adding it to the catalog with
+/// `catalog.copyWith(newItems: [gaugeCatalogItem])`.
+final CatalogItem gaugeCatalogItem = CatalogItem(
+  name: 'Gauge',
+  dataSchema: _gaugeSchema,
+  widgetBuilder: (itemContext) {
+    final data = itemContext.data as Map<String, Object?>;
+    final min = (data['min'] as num?)?.toDouble() ?? 0.0;
+    final max = (data['max'] as num?)?.toDouble() ?? 100.0;
+    final unit = data['unit'] as String?;
+
+    // `value` and `label` may be literals or { path } bindings, so resolve
+    // them through genui's Bound* widgets, which subscribe to the data model
+    // and rebuild when it changes.
+    return BoundNumber(
+      dataContext: itemContext.dataContext,
+      value: data['value'],
+      builder: (context, value) {
+        return BoundString(
+          dataContext: itemContext.dataContext,
+          value: data['label'],
+          builder: (context, label) {
+            return _GaugeView(
+              value: (value ?? min).toDouble(),
+              min: min,
+              max: max,
+              label: label,
+              unit: unit,
+            );
+          },
+        );
+      },
+    );
+  },
+  exampleData: [
+    () => '''
+      [
+        {
+          "id": "root",
+          "component": "Gauge",
+          "value": 18,
+          "min": -10,
+          "max": 40,
+          "unit": "\u00b0C",
+          "label": "Temperature"
+        }
+      ]
+    ''',
+  ],
+);
+
+/// A simple circular gauge painted with a [CustomPainter].
+class _GaugeView extends StatelessWidget {
+  const _GaugeView({
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.unit,
+    required this.label,
+  });
+
+  final double value;
+  final double min;
+  final double max;
+  final String? unit;
+  final String? label;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final span = (max - min);
+    final fraction = span == 0
+        ? 0.0
+        : ((value - min) / span).clamp(0.0, 1.0).toDouble();
+
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: SizedBox(
+        width: 120,
+        height: 120,
+        child: CustomPaint(
+          painter: _GaugePainter(
+            fraction: fraction,
+            trackColor: scheme.surfaceContainerHighest,
+            valueColor: scheme.primary,
+          ),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '${_formatValue(value)}${unit ?? ''}',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                if (label != null && label!.isNotEmpty)
+                  Text(
+                    label!,
+                    style: Theme.of(context).textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Drops a trailing ".0" so whole numbers read cleanly (e.g. "18" not "18.0").
+  String _formatValue(double v) =>
+      v == v.roundToDouble() ? v.toStringAsFixed(0) : v.toStringAsFixed(1);
+}
+
+class _GaugePainter extends CustomPainter {
+  _GaugePainter({
+    required this.fraction,
+    required this.trackColor,
+    required this.valueColor,
+  });
+
+  final double fraction;
+  final Color trackColor;
+  final Color valueColor;
+
+  // A 270-degree arc, starting at the bottom-left (135 degrees), leaving a gap
+  // at the bottom so it reads as a gauge rather than a full ring.
+  static const double _startAngle = math.pi * 0.75;
+  static const double _sweep = math.pi * 1.5;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const stroke = 10.0;
+    final rect = Offset.zero & size;
+    final arcRect = rect.deflate(stroke / 2);
+
+    final track = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke
+      ..strokeCap = StrokeCap.round
+      ..color = trackColor;
+    final progress = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke
+      ..strokeCap = StrokeCap.round
+      ..color = valueColor;
+
+    canvas.drawArc(arcRect, _startAngle, _sweep, false, track);
+    canvas.drawArc(arcRect, _startAngle, _sweep * fraction, false, progress);
+  }
+
+  @override
+  bool shouldRepaint(_GaugePainter old) =>
+      old.fraction != fraction ||
+      old.trackColor != trackColor ||
+      old.valueColor != valueColor;
+}

--- a/testapps/a2ui/lib/main.dart
+++ b/testapps/a2ui/lib/main.dart
@@ -31,9 +31,10 @@ import 'package:a2ui_core/a2ui_core.dart' as core;
 import 'package:flutter/material.dart';
 import 'package:genkit/client.dart';
 import 'package:genkit_a2ui/client.dart';
-// `basicCatalogId` is defined by both genkit_a2ui and genui (with different
-// values); we want the plugin's id, so hide genui's.
-import 'package:genui/genui.dart' hide basicCatalogId;
+import 'package:genui/genui.dart';
+
+import 'gauge.dart';
+import 'shared.dart';
 
 /// The base URL of the agent server. Override with `--dart-define=AGENT_BASE_URL`.
 const String _baseUrl = String.fromEnvironment(
@@ -41,12 +42,18 @@ const String _baseUrl = String.fromEnvironment(
   defaultValue: 'http://localhost:8080',
 );
 
-/// The genui basic catalog, re-tagged with the catalog id the `genkit_a2ui`
-/// plugin's bundled basic catalog advertises, so surfaces created by the agent
-/// resolve to real widgets (genui otherwise registers an empty stub for an
-/// unknown catalog id).
+/// The client catalog, matching the server's custom `weatherCatalog`.
+///
+/// The server's catalog is the bundled basic components plus a custom `Gauge`
+/// (see `lib/agent.dart`), advertised under [weatherCatalogId]. Here we mirror
+/// that: start from genui's basic widgets, add the matching [gaugeCatalogItem],
+/// and re-tag the whole thing with the same [weatherCatalogId] so a surface the
+/// agent creates with that `catalogId` resolves to these widgets. (genui
+/// registers an empty stub for a catalog id it doesn't know, so the ids MUST
+/// match on both sides.)
 final Catalog _catalog = BasicCatalogItems.asCatalog().copyWith(
-  catalogId: basicCatalogId,
+  newItems: [gaugeCatalogItem],
+  catalogId: weatherCatalogId,
 );
 
 void main() {
@@ -330,6 +337,7 @@ class _SuggestionBar extends StatelessWidget {
 
   static const _prompts = [
     "What's the weather in Tokyo?",
+    'Show the weather in Tokyo with a gauge.',
     'Compare the weather in London, Paris and Rome.',
     'Give me a short signup form (name and email) with a submit button.',
   ];

--- a/testapps/a2ui/lib/shared.dart
+++ b/testapps/a2ui/lib/shared.dart
@@ -1,0 +1,31 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Values shared by the server (`lib/agent.dart`, `bin/server.dart`) and the
+/// Flutter client (`lib/main.dart`).
+///
+/// This file has no server-only or Flutter-only imports so it is safe to
+/// include from either side. It exists mainly so the custom catalog id is
+/// defined in exactly one place: the server catalog and the client renderer
+/// MUST agree on it, otherwise a surface created by the agent won't resolve to
+/// the client's widgets.
+library;
+
+/// The id of the app's custom A2UI catalog.
+///
+/// The server registers a catalog under this id (see `weatherCatalog` in
+/// `lib/agent.dart`) and the client registers a matching set of widgets under
+/// the same id (see `_catalog` in `lib/main.dart`). Reverse-domain notation is
+/// recommended to avoid clashes with other catalogs.
+const String weatherCatalogId = 'com.example.a2ui.weather';

--- a/testapps/a2ui/pubspec.yaml
+++ b/testapps/a2ui/pubspec.yaml
@@ -12,6 +12,10 @@ dependencies:
     sdk: flutter
   a2ui_core: ^0.1.0
   genui: ^0.10.1
+  # Used by the custom `Gauge` catalog item (lib/gauge.dart) to build its prop
+  # schema with `S`/`Schema`. genui depends on the same package.
+  json_schema_builder: ^0.1.3
+
   genkit:
     path: ../../packages/genkit
   genkit_a2ui:
@@ -20,6 +24,8 @@ dependencies:
     path: ../../packages/genkit_google_genai
   genkit_shelf:
     path: ../../packages/genkit_shelf
+  genkit_middleware:
+    path: ../../packages/genkit_middleware
   schemantic:
     path: ../../packages/schemantic
   shelf: ^1.4.0
@@ -35,6 +41,8 @@ dependency_overrides:
     path: ../../packages/genkit_google_genai
   genkit_shelf:
     path: ../../packages/genkit_shelf
+  genkit_middleware:
+    path: ../../packages/genkit_middleware
   schemantic:
     path: ../../packages/schemantic
   schemantic_builder:


### PR DESCRIPTION
Change the `loadCatalog` API to take the `Genkit` instance directly rather than its `Registry`, simplifying the caller experience. Update docs, generated code, and tests to reflect the new signature.