### PR TITLE
feat(genkit_anthropic): add beta/stable API selection and native structured outputs

### DIFF
--- a/packages/genkit_anthropic/README.md
+++ b/packages/genkit_anthropic/README.md
@@ -122,3 +122,36 @@ final response = await ai.generate(
 final person = response.output; // Typed Person object
 print('Name: ${person.name}, Age: ${person.age}');
 ```
+
+Models on Anthropic's Structured Outputs list are sent the schema natively, so
+structured output composes with extended thinking. Other models fall back to a
+tool the model is forced to call; that fallback cannot be combined with manual
+thinking, and the plugin reports an `INVALID_ARGUMENT` error rather than letting
+the API reject the request.
+
+### Stable and beta APIs
+
+Requests go to Anthropic's stable API by default. Set `apiVersion` to `'beta'`
+to reach beta-gated features, either for a single request or for every request:
+
+```dart
+// Per request.
+final response = await ai.generate(
+  model: anthropic.model('claude-sonnet-4-5'),
+  prompt: 'Hello',
+  config: AnthropicOptions(apiVersion: 'beta'),
+);
+
+// Or as the plugin-wide default; a request's own apiVersion still wins.
+final ai = Genkit(plugins: [anthropic(apiVersion: 'beta')]);
+```
+
+Beta requests send a curated `anthropic-beta` feature list. To opt into a beta
+the plugin does not know about yet, set `betas` to replace that list:
+
+```dart
+config: AnthropicOptions(
+  apiVersion: 'beta',
+  betas: ['some-new-beta-2026-01-01'],
+),
+```

--- a/packages/genkit_anthropic/lib/genkit_anthropic.dart
+++ b/packages/genkit_anthropic/lib/genkit_anthropic.dart
@@ -30,15 +30,21 @@ class AnthropicPluginHandle {
   ///
   /// You can optionally provide an [apiKey]. If omitted, it will be mapped
   /// to the standard `ANTHROPIC_API_KEY` environment variable.
+  ///
+  /// [apiVersion] selects the default Anthropic API surface (`'stable'` or
+  /// `'beta'`) for every request; individual requests can override it via
+  /// `AnthropicOptions.apiVersion`. Defaults to stable.
   GenkitPlugin call({
     String? apiKey,
     Map<String, String>? headers,
     String? baseUrl,
+    String? apiVersion,
   }) {
     return AnthropicPluginImpl(
       apiKey: apiKey,
       headers: headers,
       baseUrl: baseUrl,
+      apiVersion: apiVersion,
     );
   }
 

--- a/packages/genkit_anthropic/lib/src/model.dart
+++ b/packages/genkit_anthropic/lib/src/model.dart
@@ -22,6 +22,22 @@ abstract class $AnthropicOptions {
   /// Custom API key to use for this specific request. Overrides plugin config.
   String? get apiKey;
 
+  @StringField(
+    enumValues: ['stable', 'beta'],
+    description:
+        'Which Anthropic API surface to use for this request. '
+        'The beta surface also serves every stable feature. '
+        'Overrides the plugin-level default, which is "stable".',
+  )
+  String? get apiVersion;
+
+  /// Beta feature names sent in the `anthropic-beta` header.
+  ///
+  /// Only used when the request resolves to the beta API. Replaces the
+  /// plugin's curated default list rather than adding to it, so a new beta can
+  /// be opted into without waiting for a plugin release.
+  List<String>? get betas;
+
   @IntegerField(
     minimum: 1,
     description: 'The maximum number of tokens to generate before stopping.',

--- a/packages/genkit_anthropic/lib/src/model.g.dart
+++ b/packages/genkit_anthropic/lib/src/model.g.dart
@@ -30,6 +30,8 @@ base class AnthropicOptions {
 
   AnthropicOptions({
     String? apiKey,
+    String? apiVersion,
+    List<String>? betas,
     int? maxTokens,
     double? temperature,
     double? topP,
@@ -40,6 +42,8 @@ base class AnthropicOptions {
   }) {
     _json = {
       'apiKey': ?apiKey,
+      'apiVersion': ?apiVersion,
+      'betas': ?betas,
       'maxTokens': ?maxTokens,
       'temperature': ?temperature,
       'topP': ?topP,
@@ -67,6 +71,40 @@ base class AnthropicOptions {
       _json.remove('apiKey');
     } else {
       _json['apiKey'] = value;
+    }
+  }
+
+  String? get apiVersion {
+    return _json['apiVersion'] as String?;
+  }
+
+  set apiVersion(String? value) {
+    if (value == null) {
+      _json.remove('apiVersion');
+    } else {
+      _json['apiVersion'] = value;
+    }
+  }
+
+  /// Beta feature names sent in the `anthropic-beta` header.
+  ///
+  /// Only used when the request resolves to the beta API. Replaces the
+  /// plugin's curated default list rather than adding to it, so a new beta can
+  /// be opted into without waiting for a plugin release.
+  List<String>? get betas {
+    return (_json['betas'] as List?)?.cast<String>();
+  }
+
+  /// Beta feature names sent in the `anthropic-beta` header.
+  ///
+  /// Only used when the request resolves to the beta API. Replaces the
+  /// plugin's curated default list rather than adding to it, so a new beta can
+  /// be opted into without waiting for a plugin release.
+  set betas(List<String>? value) {
+    if (value == null) {
+      _json.remove('betas');
+    } else {
+      _json['betas'] = value;
     }
   }
 
@@ -193,6 +231,12 @@ base class _AnthropicOptionsTypeFactory
         .object(
           properties: {
             'apiKey': $Schema.string(),
+            'apiVersion': $Schema.string(
+              description:
+                  'Which Anthropic API surface to use for this request. The beta surface also serves every stable feature. Overrides the plugin-level default, which is "stable".',
+              enumValues: ['stable', 'beta'],
+            ),
+            'betas': $Schema.list(items: $Schema.string()),
             'maxTokens': $Schema.integer(
               description:
                   'The maximum number of tokens to generate before stopping.',

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -31,6 +31,26 @@ final _logger = Logger('genkit_anthropic');
 /// entry.
 final commonModelInfo = ModelInfo(supports: baseClaudeSupports);
 
+/// Beta features requested when a request resolves to the beta API surface.
+///
+/// Sent as the `anthropic-beta` header. Mirrors the list the Genkit JS plugin
+/// enables by default; a request can replace it via `AnthropicOptions.betas`.
+const defaultAnthropicBetas = <String>[
+  'files-api-2025-04-14',
+  'effort-2025-11-24',
+  'structured-outputs-2025-11-13',
+  'task-budgets-2026-03-13',
+];
+
+/// Resolves whether a request runs against the beta API surface.
+///
+/// The request's own `apiVersion` wins, then the plugin default, else stable.
+@visibleForTesting
+bool resolveBetaEnabled(String? requestApiVersion, String? pluginApiVersion) {
+  final selected = requestApiVersion ?? pluginApiVersion;
+  return selected == 'beta';
+}
+
 /// Core Genkit plugin implementation for Anthropic Claude models.
 ///
 /// Automatically discovers available models from the Anthropic API and
@@ -50,6 +70,11 @@ class AnthropicPluginImpl extends GenkitPlugin {
   /// instrumentation, or injecting a mock transport in tests.
   final http.Client? httpClient;
 
+  /// Default Anthropic API surface (`'stable'` or `'beta'`) for every request.
+  ///
+  /// A request's own `apiVersion` overrides this. Defaults to stable.
+  final String? apiVersion;
+
   sdk.AnthropicClient? _client;
 
   /// Creates an [AnthropicPluginImpl].
@@ -58,6 +83,7 @@ class AnthropicPluginImpl extends GenkitPlugin {
     this.headers,
     this.baseUrl,
     this.httpClient,
+    this.apiVersion,
   });
 
   @override
@@ -169,9 +195,16 @@ class AnthropicPluginImpl extends GenkitPlugin {
 
         try {
           final createRequest = _buildCreateRequest(req, modelName, options);
+          // Empty on the stable surface, which suppresses the header entirely.
+          final betas = resolveBetaEnabled(options.apiVersion, apiVersion)
+              ? (options.betas ?? defaultAnthropicBetas)
+              : const <String>[];
 
           if (ctx.streamingRequested) {
-            final stream = requestClient.messages.createStream(createRequest);
+            final stream = requestClient.messages.createStream(
+              createRequest,
+              betas: betas,
+            );
             final accumulator = sdk.MessageStreamAccumulator();
             await for (final event in stream) {
               accumulator.add(event);
@@ -184,7 +217,10 @@ class AnthropicPluginImpl extends GenkitPlugin {
               usage: mapUsage(message.usage),
             );
           } else {
-            final response = await requestClient.messages.create(createRequest);
+            final response = await requestClient.messages.create(
+              createRequest,
+              betas: betas,
+            );
             return ModelResponse(
               finishReason: mapFinishReason(response.stopReason),
               message: fromAnthropicMessage(response),
@@ -238,26 +274,41 @@ class AnthropicPluginImpl extends GenkitPlugin {
         req.tools?.map(toAnthropicTool).toList() ?? <sdk.ToolDefinition>[];
 
     sdk.ToolChoice? toolChoice;
+    sdk.JsonOutputFormat? outputFormat;
 
     if (req.output?.schema != null) {
       final schema = Map<String, dynamic>.from(req.output!.schema!);
-      if (!schema.containsKey('type')) {
-        schema['type'] = 'object';
-      }
-      const toolName = 'return_output';
-      tools.add(
-        sdk.ToolDefinition.custom(
-          sdk.Tool(
-            name: toolName,
-            description: 'Return the structured output.',
-            inputSchema: sdk.InputSchema.fromJson(schema),
+
+      if (_supportsNativeStructuredOutput(modelName)) {
+        // Native structured output needs no forced tool, so it composes with
+        // manual thinking - unlike the fallback below. The schema goes over
+        // as-authored; adding a `type` here would collide with a `$ref` root.
+        outputFormat = sdk.JsonOutputFormat(schema: _toAnthropicSchema(schema));
+      } else {
+        // Older and uncurated models are not on Anthropic's Structured Outputs
+        // list, so the schema is served by a tool the model is forced to call.
+        _assertToolOutputAllowed(req, modelName, options);
+        // Anthropic's tool input schemas must declare an object type.
+        if (!schema.containsKey('type')) {
+          schema['type'] = 'object';
+        }
+        const toolName = 'return_output';
+        tools.add(
+          sdk.ToolDefinition.custom(
+            sdk.Tool(
+              name: toolName,
+              description: 'Return the structured output.',
+              inputSchema: sdk.InputSchema.fromJson(schema),
+            ),
           ),
-        ),
-      );
-      toolChoice = sdk.ToolChoice.tool(toolName);
+        );
+        toolChoice = sdk.ToolChoice.tool(toolName);
+      }
     }
 
-    if (req.toolChoice != null) {
+    // A caller-supplied choice must not silently unforce `return_output`; that
+    // would leave the model free to answer without producing the schema.
+    if (req.toolChoice != null && toolChoice == null) {
       toolChoice = switch (req.toolChoice) {
         'auto' => sdk.ToolChoice.auto(),
         'any' => sdk.ToolChoice.any(),
@@ -267,7 +318,7 @@ class AnthropicPluginImpl extends GenkitPlugin {
     }
 
     final thinking = _mapThinkingConfig(options.thinking, modelName);
-    final outputConfig = _mapOutputConfig(options.outputConfig);
+    final outputConfig = _mapOutputConfig(options.outputConfig, outputFormat);
 
     return sdk.MessageCreateRequest(
       model: modelName,
@@ -502,12 +553,9 @@ Map<String, dynamic> _extractOutput(Map<String, dynamic> input) {
   return input;
 }
 
-sdk.ThinkingConfig? _mapThinkingConfig(
-  ThinkingConfig? config,
-  String modelName,
-) {
-  if (config == null) return null;
-
+/// Resolves the effective thinking type, applying the curated per-model default
+/// when the request does not name one.
+String _resolveThinkingType(ThinkingConfig config, String modelName) {
   final type =
       config.type ?? knownClaudeModelFor(modelName)?.defaultThinkingMode.name;
   if (type == null) {
@@ -516,6 +564,16 @@ sdk.ThinkingConfig? _mapThinkingConfig(
       status: StatusCodes.INVALID_ARGUMENT,
     );
   }
+  return type;
+}
+
+sdk.ThinkingConfig? _mapThinkingConfig(
+  ThinkingConfig? config,
+  String modelName,
+) {
+  if (config == null) return null;
+
+  final type = _resolveThinkingType(config, modelName);
 
   return switch (type) {
     'disabled' => sdk.ThinkingConfig.disabled(),
@@ -531,11 +589,83 @@ sdk.ThinkingConfig? _mapThinkingConfig(
   };
 }
 
-sdk.OutputConfig? _mapOutputConfig(AnthropicOutputConfig? config) {
+/// Whether [modelName] is on Anthropic's Structured Outputs list.
+///
+/// Curated models carry the flag; names resolved dynamically are assumed not to
+/// support it, so they keep the tool-based fallback.
+bool _supportsNativeStructuredOutput(String modelName) =>
+    knownClaudeModelFor(modelName)?.structuredOutputs ?? false;
+
+/// Rewrites a Genkit JSON schema into the shape Anthropic accepts.
+///
+/// Anthropic rejects `$schema` and requires `additionalProperties: false` on
+/// every object, including ones nested under `$defs`.
+Map<String, dynamic> _toAnthropicSchema(Map<String, dynamic> schema) {
+  final out = <String, dynamic>{};
+  for (final entry in schema.entries) {
+    if (entry.key == r'$schema') continue;
+    out[entry.key] = _normalizeSchemaValue(entry.value);
+  }
+  // A `$ref` node may not carry sibling constraints; Anthropic rejects the
+  // combination outright. Named Genkit schemas arrive as a bare `$ref` plus
+  // `$defs`, and the recursion above has already closed the definitions.
+  if (out.containsKey(r'$ref')) return out;
+
+  // A hand-written schema may describe an object through its keywords alone.
+  // Anthropic needs the type spelled out before it will accept the closed
+  // marker below, so infer it the way the tool fallback does.
+  if (!out.containsKey('type') &&
+      (out.containsKey('properties') || out.containsKey('required'))) {
+    out['type'] = 'object';
+  }
+  if (out['type'] == 'object') {
+    out['additionalProperties'] = false;
+  }
+  return out;
+}
+
+Object? _normalizeSchemaValue(Object? value) => switch (value) {
+  final Map<String, dynamic> map => _toAnthropicSchema(map),
+  final Map map => _toAnthropicSchema(map.cast<String, dynamic>()),
+  final List list => list.map(_normalizeSchemaValue).toList(),
+  _ => value,
+};
+
+/// Guards the tool-based structured-output fallback against manual thinking.
+///
+/// The fallback forces `tool_choice`, which Anthropic rejects when extended
+/// thinking is on. Native structured output has no such conflict, so the fix is
+/// to move to a model that supports it rather than to drop thinking.
+void _assertToolOutputAllowed(
+  ModelRequest req,
+  String modelName,
+  AnthropicOptions options,
+) {
+  final thinking = options.thinking;
+  if (thinking == null) return;
+  // Resolve through the same path the wire uses, so a bare ThinkingConfig()
+  // that defaults to manual on a 4.5-era model is caught too.
+  if (_resolveThinkingType(thinking, modelName) != 'enabled') return;
+
+  throw GenkitException(
+    'Structured output with manual thinking is not supported for '
+    '"$modelName": it needs a forced tool call, which Anthropic rejects '
+    'alongside extended thinking. Use a model with native structured output '
+    'support, or set thinking.type to "adaptive" or "disabled".',
+    status: StatusCodes.INVALID_ARGUMENT,
+  );
+}
+
+sdk.OutputConfig? _mapOutputConfig(
+  AnthropicOutputConfig? config,
+  sdk.JsonOutputFormat? format,
+) {
   final effort = config?.effort;
-  if (effort == null) return null;
+  if (effort == null && format == null) return null;
+  if (effort == null) return sdk.OutputConfig(format: format);
 
   return sdk.OutputConfig(
+    format: format,
     effort: switch (effort) {
       'low' => sdk.EffortLevel.low,
       'medium' => sdk.EffortLevel.medium,

--- a/packages/genkit_anthropic/lib/src/plugin_impl.dart
+++ b/packages/genkit_anthropic/lib/src/plugin_impl.dart
@@ -33,21 +33,39 @@ final commonModelInfo = ModelInfo(supports: baseClaudeSupports);
 
 /// Beta features requested when a request resolves to the beta API surface.
 ///
-/// Sent as the `anthropic-beta` header. Mirrors the list the Genkit JS plugin
-/// enables by default; a request can replace it via `AnthropicOptions.betas`.
+/// Sent as the `anthropic-beta` header. Limited to the features this plugin
+/// actually exposes - `effort` via [AnthropicOutputConfig], and structured
+/// outputs via an output schema.
+///
+/// Deliberately shorter than the Genkit JS default list, which also carries
+/// `files-api-2025-04-14` and `task-budgets-2026-03-13`. This plugin never
+/// calls `/v1/files` and exposes no task budget, so those names buy nothing -
+/// and Anthropic 400s on an unrecognised beta rather than ignoring it, so a
+/// name kept past its retirement fails every `apiVersion: 'beta'` request
+/// until the next release. A caller who needs one can pass it explicitly
+/// through `AnthropicOptions.betas`, which replaces this list.
 const defaultAnthropicBetas = <String>[
-  'files-api-2025-04-14',
   'effort-2025-11-24',
   'structured-outputs-2025-11-13',
-  'task-budgets-2026-03-13',
 ];
 
 /// Resolves whether a request runs against the beta API surface.
 ///
 /// The request's own `apiVersion` wins, then the plugin default, else stable.
+///
+/// Throws on anything but `'beta'` or `'stable'`. Silently reading `'Beta'`
+/// as stable would drop the beta header and the features that depend on it,
+/// with nothing to point at.
 @visibleForTesting
 bool resolveBetaEnabled(String? requestApiVersion, String? pluginApiVersion) {
   final selected = requestApiVersion ?? pluginApiVersion;
+  if (selected == null) return false;
+  if (selected != 'beta' && selected != 'stable') {
+    throw GenkitException(
+      'Invalid apiVersion "$selected". Expected "beta" or "stable".',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
   return selected == 'beta';
 }
 
@@ -196,6 +214,8 @@ class AnthropicPluginImpl extends GenkitPlugin {
         try {
           final createRequest = _buildCreateRequest(req, modelName, options);
           // Empty on the stable surface, which suppresses the header entirely.
+          // `betas: []` is an explicit "send none", distinct from omitting
+          // the field, which takes the defaults.
           final betas = resolveBetaEnabled(options.apiVersion, apiVersion)
               ? (options.betas ?? defaultAnthropicBetas)
               : const <String>[];
@@ -330,7 +350,11 @@ class AnthropicPluginImpl extends GenkitPlugin {
       topK: options.topK,
       stopSequences: options.stopSequences,
       tools: tools.isNotEmpty ? tools : null,
-      toolChoice: toolChoice,
+      // Anthropic rejects a choice with nothing to choose from - "tool_choice.
+      // any may only be specified while providing tools". Reachable since an
+      // output schema stopped always appending `return_output`: a caller's
+      // toolChoice can now outlive the tools it referred to.
+      toolChoice: tools.isNotEmpty ? toolChoice : null,
       thinking: thinking,
       outputConfig: outputConfig,
     );
@@ -591,20 +615,108 @@ sdk.ThinkingConfig? _mapThinkingConfig(
 
 /// Whether [modelName] is on Anthropic's Structured Outputs list.
 ///
-/// Curated models carry the flag; names resolved dynamically are assumed not to
-/// support it, so they keep the tool-based fallback.
+/// An uncurated name is assumed to support it. Every model Anthropic
+/// currently lists does, and assuming otherwise sent a newly released model
+/// down the tool fallback, which fails on exactly the models that do not
+/// accept a forced tool choice:
+///
+///     400 tool_choice: type "tool" and "any" are not supported for this model
+///
+/// So the fallback is opt-out now: a curated entry sets `structuredOutputs:
+/// false` to claim it, rather than every unknown name inheriting it.
 bool _supportsNativeStructuredOutput(String modelName) =>
-    knownClaudeModelFor(modelName)?.structuredOutputs ?? false;
+    knownClaudeModelFor(modelName)?.structuredOutputs ?? true;
+
+/// Keywords whose value is a single nested schema.
+const _schemaValuedKeywords = {
+  'items',
+  'additionalItems',
+  'contains',
+  'not',
+  'if',
+  'then',
+  'else',
+  'propertyNames',
+};
+
+/// Keywords whose value is a list of schemas.
+const _schemaListKeywords = {'allOf', 'anyOf', 'oneOf', 'prefixItems'};
+
+/// Keywords whose value maps names to schemas.
+const _schemaMapKeywords = {
+  'properties',
+  r'$defs',
+  'definitions',
+  'patternProperties',
+};
+
+/// Validation keywords Anthropic's structured-output schema rejects.
+///
+/// `output_config.format` validates the schema strictly and 400s on these -
+/// "For 'integer' type, properties maximum, minimum are not supported". The
+/// tool fallback never validated, which is why they rode through unnoticed.
+/// Genkit's own generator emits them from `@IntegerField(minimum:)` and
+/// friends, so ordinary annotated types hit this.
+///
+/// Dropped rather than translated: they constrain values, and losing them
+/// costs a validation the model was never guaranteed to honour anyway.
+const _unsupportedValidationKeywords = {
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'minProperties',
+  'maxProperties',
+};
+
+/// Whether [type] denotes an object, including the nullable `["object",
+/// "null"]` spelling schemantic emits for an optional object field.
+bool _isObjectType(Object? type) =>
+    type == 'object' || (type is List && type.contains('object'));
 
 /// Rewrites a Genkit JSON schema into the shape Anthropic accepts.
 ///
-/// Anthropic rejects `$schema` and requires `additionalProperties: false` on
-/// every object, including ones nested under `$defs`.
+/// Anthropic rejects `$schema`, rejects the validation keywords above, and
+/// requires `additionalProperties: false` on every object, including ones
+/// nested under `$defs`.
+///
+/// Recursion follows JSON Schema structure rather than descending into every
+/// map it meets. A `properties` map is not itself a schema - descending into
+/// it applied the object inference and the closed marker to the map of field
+/// names, which corrupted any schema with a field called `type`, `properties`
+/// or `required`.
 Map<String, dynamic> _toAnthropicSchema(Map<String, dynamic> schema) {
   final out = <String, dynamic>{};
   for (final entry in schema.entries) {
-    if (entry.key == r'$schema') continue;
-    out[entry.key] = _normalizeSchemaValue(entry.value);
+    final key = entry.key;
+    final value = entry.value;
+    if (key == r'$schema') continue;
+    if (_unsupportedValidationKeywords.contains(key)) continue;
+
+    if (_schemaMapKeywords.contains(key) && value is Map) {
+      out[key] = {
+        for (final field in value.entries)
+          field.key.toString(): _asSchema(field.value),
+      };
+    } else if (_schemaListKeywords.contains(key) && value is List) {
+      out[key] = value.map(_asSchema).toList();
+    } else if (_schemaValuedKeywords.contains(key)) {
+      // `items` may be a list of schemas in older drafts.
+      out[key] = value is List
+          ? value.map(_asSchema).toList()
+          : _asSchema(value);
+    } else if (key == 'additionalProperties' && value is Map) {
+      out[key] = _asSchema(value);
+    } else {
+      out[key] = value;
+    }
   }
   // A `$ref` node may not carry sibling constraints; Anthropic rejects the
   // combination outright. Named Genkit schemas arrive as a bare `$ref` plus
@@ -618,16 +730,16 @@ Map<String, dynamic> _toAnthropicSchema(Map<String, dynamic> schema) {
       (out.containsKey('properties') || out.containsKey('required'))) {
     out['type'] = 'object';
   }
-  if (out['type'] == 'object') {
+  if (_isObjectType(out['type'])) {
     out['additionalProperties'] = false;
   }
   return out;
 }
 
-Object? _normalizeSchemaValue(Object? value) => switch (value) {
+/// Normalises [value] when it is a schema, and leaves anything else alone.
+Object? _asSchema(Object? value) => switch (value) {
   final Map<String, dynamic> map => _toAnthropicSchema(map),
   final Map map => _toAnthropicSchema(map.cast<String, dynamic>()),
-  final List list => list.map(_normalizeSchemaValue).toList(),
   _ => value,
 };
 

--- a/packages/genkit_anthropic/test/test_live.dart
+++ b/packages/genkit_anthropic/test/test_live.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:genkit/genkit.dart';
 import 'package:genkit_anthropic/genkit_anthropic.dart';
+import 'package:genkit_anthropic/src/known_models.dart';
 import 'package:genkit_anthropic/src/plugin_impl.dart';
 import 'package:schemantic/schemantic.dart';
 import 'package:test/test.dart';
@@ -109,6 +110,64 @@ void main() {
       expect(finalResponse.output!.name, 'Jane Doe');
       expect(finalResponse.output!.age, 25);
     });
+
+    test('should generate structured output with manual thinking', () async {
+      // The forced-tool fallback cannot do this - Anthropic rejects a forced
+      // tool_choice alongside extended thinking - so this only passes because
+      // claude-sonnet-4-5 takes the native output_config.format path.
+      final response = await ai.generate(
+        model: anthropic.model('claude-sonnet-4-5'),
+        prompt: 'Generate a person named John Doe, age 30',
+        outputSchema: Person.$schema,
+        config: AnthropicOptions(
+          thinking: ThinkingConfig(type: 'enabled', budgetTokens: 1024),
+        ),
+      );
+
+      expect(response.output, isNotNull);
+      expect(response.output!.name, 'John Doe');
+      expect(response.output!.age, 30);
+    }, timeout: Timeout(Duration(minutes: 2)));
+
+    test('should generate structured output via the forced-tool '
+        'fallback', () async {
+      // Discovered rather than hard-coded: any model outside the curated
+      // Structured Outputs catalog takes the return_output path, and which
+      // older models an account can reach varies over time.
+      final available = await plugin!.client.models.list();
+      final uncurated = available.data
+          .map((m) => m.id)
+          .where((id) => knownClaudeModelFor(id) == null)
+          .toList();
+
+      if (uncurated.isEmpty) {
+        markTestSkipped('every available model is on the curated catalog');
+        return;
+      }
+
+      final response = await ai.generate(
+        model: anthropic.model(uncurated.first),
+        prompt: 'Generate a person named Ada Lovelace, age 36',
+        outputSchema: Person.$schema,
+      );
+
+      expect(response.output, isNotNull);
+      expect(response.output!.name, contains('Ada'));
+      expect(response.output!.age, 36);
+    }, timeout: Timeout(Duration(minutes: 2)));
+
+    test('should generate structured output over the beta API', () async {
+      final response = await ai.generate(
+        model: anthropic.model('claude-sonnet-4-5'),
+        prompt: 'Generate a person named Jane Doe, age 25',
+        outputSchema: Person.$schema,
+        config: AnthropicOptions(apiVersion: 'beta'),
+      );
+
+      expect(response.output, isNotNull);
+      expect(response.output!.name, 'Jane Doe');
+      expect(response.output!.age, 25);
+    }, timeout: Timeout(Duration(minutes: 2)));
 
     test('should use tools', () async {
       final tool = ai.defineTool(

--- a/packages/genkit_anthropic/test/thinking_config_wire_test.dart
+++ b/packages/genkit_anthropic/test/thinking_config_wire_test.dart
@@ -21,17 +21,72 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
+/// Headers of the most recent captured request, alongside its decoded body.
+Map<String, String> _lastHeaders = const {};
+
+/// A minimal well-formed Anthropic SSE stream, enough for the SDK accumulator.
+String _sseStream(String model) {
+  String event(String type, Map<String, dynamic> data) =>
+      'event: $type\ndata: ${jsonEncode(data)}\n\n';
+
+  return event('message_start', {
+        'type': 'message_start',
+        'message': {
+          'id': 'msg_test',
+          'type': 'message',
+          'role': 'assistant',
+          'model': model,
+          'content': <dynamic>[],
+          'stop_reason': null,
+          'stop_sequence': null,
+          'usage': {'input_tokens': 1, 'output_tokens': 1},
+        },
+      }) +
+      event('content_block_start', {
+        'type': 'content_block_start',
+        'index': 0,
+        'content_block': {'type': 'text', 'text': ''},
+      }) +
+      event('content_block_delta', {
+        'type': 'content_block_delta',
+        'index': 0,
+        'delta': {'type': 'text_delta', 'text': 'ok'},
+      }) +
+      event('content_block_stop', {'type': 'content_block_stop', 'index': 0}) +
+      event('message_delta', {
+        'type': 'message_delta',
+        'delta': {'stop_reason': 'end_turn', 'stop_sequence': null},
+        'usage': {'output_tokens': 1},
+      }) +
+      event('message_stop', {'type': 'message_stop'});
+}
+
 Future<Map<String, dynamic>> _requestOnTheWire({
   required String model,
   ThinkingConfig? thinking,
   AnthropicOutputConfig? outputConfig,
+  String? apiVersion,
+  List<String>? betas,
+  String? pluginApiVersion,
+  Map<String, dynamic>? outputSchema,
+  String? toolChoice,
+  bool streaming = false,
 }) async {
   Map<String, dynamic>? captured;
   final client = MockClient((request) async {
     if (request.url.path != '/v1/messages') {
       return http.Response('not found', 404);
     }
+    _lastHeaders = request.headers;
     captured = (jsonDecode(request.body) as Map).cast<String, dynamic>();
+
+    if (streaming) {
+      return http.Response(
+        _sseStream(model),
+        200,
+        headers: {'content-type': 'text/event-stream'},
+      );
+    }
     return http.Response(
       jsonEncode({
         'id': 'msg_test',
@@ -49,7 +104,11 @@ Future<Map<String, dynamic>> _requestOnTheWire({
       headers: {'content-type': 'application/json'},
     );
   });
-  final plugin = AnthropicPluginImpl(apiKey: 'test-key', httpClient: client);
+  final plugin = AnthropicPluginImpl(
+    apiKey: 'test-key',
+    httpClient: client,
+    apiVersion: pluginApiVersion,
+  );
   addTearDown(plugin.close);
   final action = plugin.resolve(.model, model) as Model;
 
@@ -61,11 +120,22 @@ Future<Map<String, dynamic>> _requestOnTheWire({
           content: [TextPart(text: 'hello')],
         ),
       ],
+      toolChoice: toolChoice,
+      output: outputSchema == null
+          ? null
+          : OutputConfig(
+              format: 'json',
+              constrained: true,
+              schema: outputSchema,
+            ),
       config: AnthropicOptions(
         thinking: thinking,
         outputConfig: outputConfig,
+        apiVersion: apiVersion,
+        betas: betas,
       ).toJson(),
     ),
+    onChunk: streaming ? (_) {} : null,
   );
 
   return captured!;
@@ -179,6 +249,334 @@ void main() {
         outputConfig: AnthropicOutputConfig(),
       );
       expect(body, isNot(contains('output_config')));
+    });
+  });
+
+  group('api version on the wire', () {
+    test('stable is the default and sends no beta header', () async {
+      await _requestOnTheWire(model: 'claude-sonnet-5');
+      expect(_lastHeaders, isNot(contains('anthropic-beta')));
+    });
+
+    test('request apiVersion beta sends the curated list', () async {
+      await _requestOnTheWire(model: 'claude-sonnet-5', apiVersion: 'beta');
+      expect(_lastHeaders['anthropic-beta'], defaultAnthropicBetas.join(','));
+    });
+
+    test('plugin-level beta applies when the request is silent', () async {
+      await _requestOnTheWire(
+        model: 'claude-sonnet-5',
+        pluginApiVersion: 'beta',
+      );
+      expect(_lastHeaders['anthropic-beta'], defaultAnthropicBetas.join(','));
+    });
+
+    test('request stable overrides a beta plugin default', () async {
+      await _requestOnTheWire(
+        model: 'claude-sonnet-5',
+        pluginApiVersion: 'beta',
+        apiVersion: 'stable',
+      );
+      expect(_lastHeaders, isNot(contains('anthropic-beta')));
+    });
+
+    test('a supplied betas list replaces the default', () async {
+      await _requestOnTheWire(
+        model: 'claude-sonnet-5',
+        apiVersion: 'beta',
+        betas: ['my-beta-2026-01-01'],
+      );
+      expect(_lastHeaders['anthropic-beta'], 'my-beta-2026-01-01');
+    });
+
+    test('betas are ignored on the stable surface', () async {
+      await _requestOnTheWire(
+        model: 'claude-sonnet-5',
+        betas: ['my-beta-2026-01-01'],
+      );
+      expect(_lastHeaders, isNot(contains('anthropic-beta')));
+    });
+
+    test('the streaming path sends the beta header too', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-5',
+        apiVersion: 'beta',
+        streaming: true,
+      );
+      expect(body['stream'], true);
+      expect(_lastHeaders['anthropic-beta'], defaultAnthropicBetas.join(','));
+    });
+
+    test('the streaming path stays stable by default', () async {
+      await _requestOnTheWire(model: 'claude-sonnet-5', streaming: true);
+      expect(_lastHeaders, isNot(contains('anthropic-beta')));
+    });
+  });
+
+  group('structured output on the wire', () {
+    final schema = <String, dynamic>{
+      r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+      'type': 'object',
+      'properties': {
+        'name': {'type': 'string'},
+        'pet': {
+          'type': 'object',
+          'properties': {
+            'species': {'type': 'string'},
+          },
+        },
+      },
+    };
+
+    test('a capable model sends a native json_schema format', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: schema,
+      );
+
+      final format =
+          (body['output_config'] as Map)['format'] as Map<String, dynamic>;
+      expect(format['type'], 'json_schema');
+      expect(body, isNot(contains('tools')));
+      expect(body, isNot(contains('tool_choice')));
+    });
+
+    test('normalization strips \$schema and closes nested objects', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: schema,
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      expect(sent, isNot(contains(r'$schema')));
+      expect(sent['additionalProperties'], false);
+
+      final pet = (sent['properties'] as Map)['pet'] as Map;
+      expect(pet['additionalProperties'], false);
+    });
+
+    test('an uncurated model falls back to the forced tool', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-future-model',
+        outputSchema: schema,
+      );
+
+      expect(body, isNot(contains('output_config')));
+      final tool = (body['tools'] as List).single as Map<String, dynamic>;
+      expect(tool['name'], 'return_output');
+      expect(body['tool_choice'], {'type': 'tool', 'name': 'return_output'});
+    });
+
+    test('native structured output composes with manual thinking', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: schema,
+        thinking: ThinkingConfig(type: 'enabled', budgetTokens: 1024),
+      );
+
+      expect(body['thinking'], {'type': 'enabled', 'budget_tokens': 1024});
+      expect((body['output_config'] as Map)['format'], isNotNull);
+    });
+
+    test('the fallback rejects manual thinking instead of erroring on the '
+        'wire', () async {
+      await expectLater(
+        _requestOnTheWire(
+          model: 'claude-future-model',
+          outputSchema: schema,
+          thinking: ThinkingConfig(type: 'enabled', budgetTokens: 1024),
+        ),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having((e) => e.message, 'message', contains('manual thinking')),
+        ),
+      );
+    });
+
+    test('the fallback allows adaptive thinking', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-future-model',
+        outputSchema: schema,
+        thinking: ThinkingConfig(type: 'adaptive'),
+      );
+      expect(body['tool_choice'], {'type': 'tool', 'name': 'return_output'});
+    });
+
+    test('a dated snapshot of a capable model still goes native', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5-20250929',
+        outputSchema: schema,
+      );
+      expect((body['output_config'] as Map)['format'], isNotNull);
+      expect(body, isNot(contains('tool_choice')));
+    });
+
+    test('normalization recurses through schema lists', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          'type': 'object',
+          'properties': {
+            'tags': {
+              'type': 'array',
+              'items': {
+                'type': 'object',
+                'properties': {
+                  'label': {'type': 'string'},
+                },
+              },
+            },
+            'either': {
+              'anyOf': [
+                {
+                  'type': 'object',
+                  'properties': {
+                    'a': {'type': 'string'},
+                  },
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      final props = sent['properties'] as Map;
+      final items = (props['tags'] as Map)['items'] as Map;
+      expect(items['additionalProperties'], false);
+
+      final anyOf = (props['either'] as Map)['anyOf'] as List;
+      expect((anyOf.single as Map)['additionalProperties'], false);
+    });
+
+    test('a \$ref root keeps no sibling constraints', () async {
+      // Named Genkit schemas arrive as a bare $ref plus $defs. Anthropic
+      // rejects `$ref` alongside `type`/`additionalProperties`, so neither may
+      // be added to the root - only to the definitions it points at.
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          r'$ref': '#/\$defs/Person',
+          r'$defs': {
+            'Person': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+              'required': ['name'],
+            },
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      expect(sent.containsKey('type'), isFalse);
+      expect(sent.containsKey('additionalProperties'), isFalse);
+
+      final person = (sent[r'$defs'] as Map)['Person'] as Map;
+      expect(person['additionalProperties'], false);
+    });
+
+    test('an untyped object schema is inferred and closed', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          'properties': {
+            'name': {'type': 'string'},
+            'inner': {
+              'required': ['x'],
+            },
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      expect(sent['type'], 'object');
+      expect(sent['additionalProperties'], false);
+
+      // Inferred from `required` alone, at depth.
+      final inner = (sent['properties'] as Map)['inner'] as Map;
+      expect(inner['type'], 'object');
+      expect(inner['additionalProperties'], false);
+
+      // A leaf with a declared non-object type is left alone.
+      final name = (sent['properties'] as Map)['name'] as Map;
+      expect(name.containsKey('additionalProperties'), isFalse);
+    });
+
+    test('type is not inferred onto a \$ref node', () async {
+      // Inferring here would recreate the sibling-constraint 400 that the
+      // $ref guard exists to prevent.
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          r'$ref': '#/\$defs/Person',
+          'properties': {
+            'name': {'type': 'string'},
+          },
+          r'$defs': {
+            'Person': {'type': 'object'},
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      expect(sent.containsKey('type'), isFalse);
+      expect(sent.containsKey('additionalProperties'), isFalse);
+    });
+
+    test('the fallback still types a \$ref root for the tool schema', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-future-model',
+        outputSchema: {
+          r'$ref': '#/\$defs/Person',
+          r'$defs': {
+            'Person': {'type': 'object'},
+          },
+        },
+      );
+
+      final tool = (body['tools'] as List).single as Map<String, dynamic>;
+      expect((tool['input_schema'] as Map)['type'], 'object');
+    });
+
+    test('effort and a native format ride in the same output_config', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: schema,
+        outputConfig: AnthropicOutputConfig(effort: 'low'),
+      );
+
+      final outputConfig = body['output_config'] as Map;
+      expect(outputConfig['effort'], 'low');
+      expect((outputConfig['format'] as Map)['type'], 'json_schema');
+    });
+
+    test('a caller toolChoice cannot unforce return_output', () async {
+      // Honoring 'auto' here would let the model skip the tool that carries
+      // the schema, silently losing structured output.
+      final body = await _requestOnTheWire(
+        model: 'claude-future-model',
+        outputSchema: schema,
+        toolChoice: 'auto',
+      );
+      expect(body['tool_choice'], {'type': 'tool', 'name': 'return_output'});
+    });
+
+    test('a caller toolChoice still applies on the native path', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: schema,
+        toolChoice: 'auto',
+      );
+      expect(body['tool_choice'], {'type': 'auto'});
+      expect((body['output_config'] as Map)['format'], isNotNull);
     });
   });
 }

--- a/packages/genkit_anthropic/test/thinking_config_wire_test.dart
+++ b/packages/genkit_anthropic/test/thinking_config_wire_test.dart
@@ -356,16 +356,19 @@ void main() {
       expect(pet['additionalProperties'], false);
     });
 
-    test('an uncurated model falls back to the forced tool', () async {
+    test('an uncurated model goes native, not to the fallback', () async {
+      // Inverted deliberately. Every model Anthropic lists supports
+      // structured outputs, and assuming otherwise sent each newly released
+      // one down a path it rejects outright:
+      //   400 tool_choice: type "tool" and "any" are not supported
       final body = await _requestOnTheWire(
         model: 'claude-future-model',
         outputSchema: schema,
       );
 
-      expect(body, isNot(contains('output_config')));
-      final tool = (body['tools'] as List).single as Map<String, dynamic>;
-      expect(tool['name'], 'return_output');
-      expect(body['tool_choice'], {'type': 'tool', 'name': 'return_output'});
+      expect((body['output_config'] as Map)['format'], isNotNull);
+      expect(body['tools'], isNull);
+      expect(body['tool_choice'], isNull);
     });
 
     test('native structured output composes with manual thinking', () async {
@@ -379,29 +382,18 @@ void main() {
       expect((body['output_config'] as Map)['format'], isNotNull);
     });
 
-    test('the fallback rejects manual thinking instead of erroring on the '
-        'wire', () async {
-      await expectLater(
-        _requestOnTheWire(
-          model: 'claude-future-model',
-          outputSchema: schema,
-          thinking: ThinkingConfig(type: 'enabled', budgetTokens: 1024),
-        ),
-        throwsA(
-          isA<GenkitException>()
-              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
-              .having((e) => e.message, 'message', contains('manual thinking')),
-        ),
-      );
-    });
-
-    test('the fallback allows adaptive thinking', () async {
+    test('an uncurated model composes output with manual thinking', () async {
+      // Previously this threw: the fallback forces a tool choice, which
+      // Anthropic rejects alongside extended thinking. Going native removes
+      // the conflict, so the guard no longer fires for uncurated names.
       final body = await _requestOnTheWire(
         model: 'claude-future-model',
         outputSchema: schema,
-        thinking: ThinkingConfig(type: 'adaptive'),
+        thinking: ThinkingConfig(type: 'enabled', budgetTokens: 1024),
       );
-      expect(body['tool_choice'], {'type': 'tool', 'name': 'return_output'});
+
+      expect(body['thinking'], {'type': 'enabled', 'budget_tokens': 1024});
+      expect((body['output_config'] as Map)['format'], isNotNull);
     });
 
     test('a dated snapshot of a capable model still goes native', () async {
@@ -531,7 +523,7 @@ void main() {
       expect(sent.containsKey('additionalProperties'), isFalse);
     });
 
-    test('the fallback still types a \$ref root for the tool schema', () async {
+    test('a \$ref root passes through without sibling constraints', () async {
       final body = await _requestOnTheWire(
         model: 'claude-future-model',
         outputSchema: {
@@ -542,8 +534,142 @@ void main() {
         },
       );
 
-      final tool = (body['tools'] as List).single as Map<String, dynamic>;
-      expect((tool['input_schema'] as Map)['type'], 'object');
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      expect(sent[r'$ref'], '#/\$defs/Person');
+      // A \$ref node may carry no siblings, so no inferred type is added.
+      expect(sent.containsKey('type'), isFalse);
+      expect(((sent[r'$defs'] as Map)['Person'] as Map)['type'], 'object');
+    });
+
+    test('a nullable object is still closed', () async {
+      // `["object","null"]` is how schemantic spells an optional object. An
+      // equality check against 'object' missed it, and Anthropic replied
+      //   400 For 'object' type, 'additionalProperties' must be explicitly
+      //   set to false
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          'type': 'object',
+          'properties': {
+            'nested': {
+              'type': ['object', 'null'],
+              'properties': {
+                'a': {'type': 'string'},
+              },
+            },
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      final nested = (sent['properties'] as Map)['nested'] as Map;
+      expect(nested['additionalProperties'], false);
+      expect(sent['additionalProperties'], false);
+    });
+
+    test('a field named like a keyword does not corrupt the schema', () async {
+      // The recursion descended into every Map, so `properties` was itself
+      // treated as a schema node: it gained `type: object` and a closed
+      // marker as though the field names were keywords.
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          'type': 'object',
+          'properties': {
+            'required': {'type': 'boolean'},
+            'type': {'type': 'string'},
+            'properties': {'type': 'string'},
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      final properties = sent['properties'] as Map;
+      expect(
+        properties.keys,
+        unorderedEquals(['required', 'type', 'properties']),
+      );
+      expect(properties['required'], {'type': 'boolean'});
+      expect(properties.containsKey('additionalProperties'), isFalse);
+    });
+
+    test('a \$defs map is not treated as a schema node', () async {
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          r'$ref': '#/\$defs/Person',
+          r'$defs': {
+            'Person': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+            },
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      final defs = sent[r'$defs'] as Map;
+      expect(defs.keys, ['Person']);
+      expect((defs['Person'] as Map)['additionalProperties'], false);
+      expect(defs.containsKey('type'), isFalse);
+    });
+
+    test('validation keywords are stripped from the native schema', () async {
+      // output_config validates strictly: "For 'integer' type, properties
+      // maximum, minimum are not supported". Genkit's generator emits these
+      // from @IntegerField(minimum:), so ordinary annotated types hit it.
+      final body = await _requestOnTheWire(
+        model: 'claude-sonnet-4-5',
+        outputSchema: {
+          'type': 'object',
+          'properties': {
+            'n': {'type': 'integer', 'minimum': 1, 'maximum': 10},
+            's': {'type': 'string', 'minLength': 2, 'pattern': '^a'},
+            'l': {
+              'type': 'array',
+              'minItems': 1,
+              'items': {'type': 'string'},
+            },
+          },
+        },
+      );
+
+      final sent =
+          ((body['output_config'] as Map)['format'] as Map)['schema'] as Map;
+      final properties = sent['properties'] as Map;
+      expect(properties['n'], {'type': 'integer'});
+      expect(properties['s'], {'type': 'string'});
+      expect(properties['l'], {
+        'type': 'array',
+        'items': {'type': 'string'},
+      });
+    });
+
+    test('an unrecognised apiVersion is rejected, not read as stable', () {
+      // Silently downgrading 'Beta' to stable would drop the header and the
+      // features that depend on it, with nothing to point at.
+      for (final value in ['Beta', 'BETA', 'preview', '']) {
+        expect(
+          () => resolveBetaEnabled(value, null),
+          throwsA(
+            isA<GenkitException>().having(
+              (e) => e.status,
+              'status',
+              StatusCodes.INVALID_ARGUMENT,
+            ),
+          ),
+          reason: value,
+        );
+      }
+      expect(resolveBetaEnabled('beta', null), isTrue);
+      expect(resolveBetaEnabled('stable', null), isFalse);
+      expect(resolveBetaEnabled(null, null), isFalse);
     });
 
     test('effort and a native format ride in the same output_config', () async {
@@ -558,25 +684,20 @@ void main() {
       expect((outputConfig['format'] as Map)['type'], 'json_schema');
     });
 
-    test('a caller toolChoice cannot unforce return_output', () async {
-      // Honoring 'auto' here would let the model skip the tool that carries
-      // the schema, silently losing structured output.
-      final body = await _requestOnTheWire(
-        model: 'claude-future-model',
-        outputSchema: schema,
-        toolChoice: 'auto',
-      );
-      expect(body['tool_choice'], {'type': 'tool', 'name': 'return_output'});
-    });
-
-    test('a caller toolChoice still applies on the native path', () async {
-      final body = await _requestOnTheWire(
-        model: 'claude-sonnet-4-5',
-        outputSchema: schema,
-        toolChoice: 'auto',
-      );
-      expect(body['tool_choice'], {'type': 'auto'});
-      expect((body['output_config'] as Map)['format'], isNotNull);
+    test('a caller toolChoice is dropped when there are no tools', () async {
+      // Anthropic rejects a choice with nothing to choose from - "tool_choice.
+      // any may only be specified while providing tools". Newly reachable:
+      // an output schema used to always append `return_output`, so a caller's
+      // toolChoice always had a tool to refer to.
+      for (final model in ['claude-sonnet-4-5', 'claude-future-model']) {
+        final body = await _requestOnTheWire(
+          model: model,
+          outputSchema: schema,
+          toolChoice: 'any',
+        );
+        expect(body['tools'], isNull, reason: model);
+        expect(body['tool_choice'], isNull, reason: model);
+      }
     });
   });
 }


### PR DESCRIPTION
The plugin always called stable `messages.create`, so no beta-gated feature was reachable, and structured output was faked with a synthetic return_output tool forced via `tool_choice` - which Anthropic rejects alongside extended thinking.

The PR adds apiVersion ('stable' | 'beta') on both the plugin and per-request config, with the request winning and stable as the default, plus a betas override for features the curated list does not know yet. Beta requests send the anthropic-beta header on the unary and streaming paths alike. Models on Anthropic's Structured Outputs list now send the schema natively via `output_config`.format, so structured output composes with manual thinking. Other models keep the forced-tool fallback, which now reports `INVALID_ARGUMENT` when combined with manual thinking rather than letting the API reject the request.

Also fixes a caller-supplied toolChoice silently unforcing `return_output`.

Closes #356