### PR TITLE
fix(a2ui): reconstruct prior surfaces as a2ui blocks in history

### DIFF
--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -434,46 +434,87 @@ List<Part> _partsFromSegments(List<ParseSegment> segments) {
   return out;
 }
 
-/// Summarizes a list of a2ui envelopes / actions into a short text string.
+/// Converts a list of a2ui envelopes from an inbound message part back into
+/// model-readable text - the inverse of the outbound block-to-part transform.
+///
+/// The two envelope kinds are handled differently on purpose:
+///
+/// - Assistant-authored surface envelopes (`createSurface`, `updateComponents`,
+///   `updateDataModel`, `deleteSurface`) are reconstructed as the canonical
+///   `a2ui` fenced block the model originally emitted. Replaying a prior turn's
+///   surface as history therefore shows the model its own UI output in the exact
+///   format it is asked to produce, reinforcing correct behavior. (Summarizing
+///   it to a sentinel like `[rendered UI surface]` instead taught the model to
+///   emit that literal string in place of a real block.)
+/// - Client-synthesized `action` envelopes never had a block form, so they
+///   become a short text summary the model can reason about.
+///
+/// Consecutive surface envelopes are grouped into a single block (one surface is
+/// usually several envelopes: create + update(s)). Unknown envelope shapes are
+/// dropped; the caller keeps the message non-empty when everything drops.
 String _summarizeA2uiPart(List<A2uiEnvelope> envelopes) {
-  final lines = <String>[];
+  final out = <String>[];
+  final pendingSurface = <A2uiEnvelope>[];
+
+  void flushSurface() {
+    if (pendingSurface.isEmpty) return;
+    // Rewrite concrete surface ids back to the placeholder the model originally
+    // wrote (the middleware swapped in a real id on the way out). Replaying the
+    // real id would let the model copy it into a fresh `createSurface`, and the
+    // parser passes an explicit pre-existing id through unchanged - so a brand
+    // new answer would reuse (and overwrite, in place) the prior surface instead
+    // of rendering a new one. Using the placeholder makes the parser mint a
+    // fresh id per turn, so each turn is a distinct surface.
+    final placeheld = pendingSurface
+        .map(_withPlaceholderSurfaceId)
+        .toList(growable: false);
+    out.add('```a2ui\n${JsonEncoder.withIndent('  ').convert(placeheld)}\n```');
+    pendingSurface.clear();
+  }
+
   for (final env in envelopes) {
     final action = env['action'];
     if (action is Map) {
+      // Emit any buffered surface block before the action, preserving order.
+      flushSurface();
       final name = action['name'];
       final surfaceId = action['surfaceId'];
       final context = action['context'];
       final ctx = (context is Map && context.isNotEmpty)
           ? ' context=${jsonEncode(context)}'
           : '';
-      lines.add('[UI action "$name" on surface $surfaceId$ctx]');
-    } else if (env['createSurface'] is Map) {
-      final surfaceId = (env['createSurface'] as Map)['surfaceId'];
-      lines.add('[UI surface $surfaceId created]');
-    } else if (env['updateComponents'] != null ||
+      out.add('[UI action "$name" on surface $surfaceId$ctx]');
+    } else if (env['createSurface'] != null ||
+        env['updateComponents'] != null ||
         env['updateDataModel'] != null ||
         env['deleteSurface'] != null) {
-      // Prior assistant surface content - summarize as a rendered surface.
-      lines.add(_renderedSurfaceLine);
+      pendingSurface.add(env);
     }
   }
-  // Collapse consecutive "[rendered UI surface]" sentinels (a single surface is
-  // often described by several envelopes) without deduping distinct action
-  // lines - two identical actions in one message are meaningfully distinct.
-  final collapsed = <String>[];
-  for (final line in lines) {
-    if (line == _renderedSurfaceLine &&
-        collapsed.isNotEmpty &&
-        collapsed.last == _renderedSurfaceLine) {
-      continue;
-    }
-    collapsed.add(line);
-  }
-  return collapsed.join(' ');
+  flushSurface();
+  return out.join('\n');
 }
 
-/// Sentinel summary line for a rendered (non-action) a2ui surface.
-const String _renderedSurfaceLine = '[rendered UI surface]';
+/// Returns a copy of [env] with any concrete `surfaceId` replaced by the
+/// [surfaceIdPlaceholder]. Used when reconstructing prior surfaces for history
+/// so a replayed surface reads exactly as the model first wrote it (with the
+/// placeholder), and the parser mints a fresh id for it on the next turn rather
+/// than the model copying a real id and reusing the old surface.
+A2uiEnvelope _withPlaceholderSurfaceId(A2uiEnvelope env) {
+  final copy = <String, dynamic>{...env};
+  for (final key in const [
+    'createSurface',
+    'updateComponents',
+    'updateDataModel',
+    'deleteSurface',
+  ]) {
+    final payload = copy[key];
+    if (payload is Map && payload['surfaceId'] is String) {
+      copy[key] = {...payload, 'surfaceId': surfaceIdPlaceholder};
+    }
+  }
+  return copy;
+}
 
 /// Wraps a surface-id factory so a single model turn's streamed parse and its
 /// final-message parse mint the *same* surface ids.

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -458,17 +458,15 @@ String _summarizeA2uiPart(List<A2uiEnvelope> envelopes) {
 
   void flushSurface() {
     if (pendingSurface.isEmpty) return;
-    // Rewrite concrete surface ids back to the placeholder the model originally
-    // wrote (the middleware swapped in a real id on the way out). Replaying the
-    // real id would let the model copy it into a fresh `createSurface`, and the
-    // parser passes an explicit pre-existing id through unchanged - so a brand
-    // new answer would reuse (and overwrite, in place) the prior surface instead
-    // of rendering a new one. Using the placeholder makes the parser mint a
-    // fresh id per turn, so each turn is a distinct surface.
-    final placeheld = pendingSurface
-        .map(_withPlaceholderSurfaceId)
-        .toList(growable: false);
-    out.add('```a2ui\n${JsonEncoder.withIndent('  ').convert(placeheld)}\n```');
+    // Keep the real surface ids verbatim. The model may not reuse them for a
+    // NEW surface: the parser forces a fresh id onto every `createSurface`
+    // block (see `_finalizeBlock`), so a copied id can't overwrite a prior
+    // surface. Keeping the real ids lets the model correlate a replayed action
+    // (`[UI action ... on surface <id>]`) with the surface it targeted - which
+    // matters when several surfaces are on screen at once.
+    out.add(
+      '```a2ui\n${JsonEncoder.withIndent('  ').convert(pendingSurface)}\n```',
+    );
     pendingSurface.clear();
   }
 
@@ -495,32 +493,9 @@ String _summarizeA2uiPart(List<A2uiEnvelope> envelopes) {
   return out.join('\n');
 }
 
-/// Returns a copy of [env] with any concrete `surfaceId` replaced by the
-/// [surfaceIdPlaceholder]. Used when reconstructing prior surfaces for history
-/// so a replayed surface reads exactly as the model first wrote it (with the
-/// placeholder), and the parser mints a fresh id for it on the next turn rather
-/// than the model copying a real id and reusing the old surface.
-A2uiEnvelope _withPlaceholderSurfaceId(A2uiEnvelope env) {
-  final copy = <String, dynamic>{...env};
-  for (final key in const [
-    'createSurface',
-    'updateComponents',
-    'updateDataModel',
-    'deleteSurface',
-  ]) {
-    final payload = copy[key];
-    if (payload is Map && payload['surfaceId'] is String) {
-      copy[key] = <String, dynamic>{
-        ...payload.cast<String, dynamic>(),
-        'surfaceId': surfaceIdPlaceholder,
-      };
-    }
-  }
-  return copy;
-}
-
 /// Wraps a surface-id factory so a single model turn's streamed parse and its
 /// final-message parse mint the *same* surface ids.
+
 class _ReplayableSurfaceIds {
   final String Function() _base;
   final List<String> _generated = [];

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -464,9 +464,17 @@ String _summarizeA2uiPart(List<A2uiEnvelope> envelopes) {
     // surface. Keeping the real ids lets the model correlate a replayed action
     // (`[UI action ... on surface <id>]`) with the surface it targeted - which
     // matters when several surfaces are on screen at once.
-    out.add(
-      '```a2ui\n${JsonEncoder.withIndent('  ').convert(pendingSurface)}\n```',
-    );
+    //
+    // Encode compactly (not pretty-printed): fewer tokens, and it collapses the
+    // payload to a single line so the block is exactly three lines (open fence,
+    // JSON, close fence). Because JSON escapes any newline inside a string as
+    // `\n`, an A2UI `Text` value containing a fenced code sample can't put a
+    // literal ``` at the start of a line, so it can never prematurely close this
+    // block (the parser's close fence is line-anchored). The block text can
+    // still contain ``` characters mid-line; a fully robust emitter would use a
+    // variable-length fence, but that also requires the parser's fixed
+    // three-backtick open fence to become count-aware, so it is deferred.
+    out.add('```a2ui\n${jsonEncode(pendingSurface)}\n```');
     pendingSurface.clear();
   }
 

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -510,7 +510,10 @@ A2uiEnvelope _withPlaceholderSurfaceId(A2uiEnvelope env) {
   ]) {
     final payload = copy[key];
     if (payload is Map && payload['surfaceId'] is String) {
-      copy[key] = {...payload, 'surfaceId': surfaceIdPlaceholder};
+      copy[key] = <String, dynamic>{
+        ...payload.cast<String, dynamic>(),
+        'surfaceId': surfaceIdPlaceholder,
+      };
     }
   }
   return copy;

--- a/packages/genkit_a2ui/lib/src/parser.dart
+++ b/packages/genkit_a2ui/lib/src/parser.dart
@@ -272,7 +272,18 @@ class A2uiStreamParser {
 
     final hasCreate = out.any((e) => e['createSurface'] != null);
     if (hasCreate) {
-      // A full-surface render. Enforce the "must contain a root" protocol rule.
+      // A full-surface render. `createSurface` means "new surface" by
+      // definition, so the id the model wrote is never authoritative - force
+      // every envelope in this block onto the freshly-minted [surface] id, even
+      // if the model copied a real id from replayed history (which would
+      // otherwise reuse and overwrite that prior surface in place). This is the
+      // single chokepoint that guarantees a distinct surface per render, so
+      // history can keep real ids verbatim (needed to correlate actions with
+      // their surface) without risking id reuse.
+      for (final e in out) {
+        _forceSurfaceId(e, surface);
+      }
+      // Enforce the "must contain a root" protocol rule.
       final err = _validateRoot(out);
       if (err != null) return _reject(err);
       return out;
@@ -310,6 +321,24 @@ class A2uiStreamParser {
       });
     }
     return out;
+  }
+
+  /// Overwrites the `surfaceId` of whichever payload [env] carries with
+  /// [surface], unconditionally (unlike the placeholder-only swap in
+  /// [_normalizeEnvelope]). Used to force every envelope in a
+  /// `createSurface`-bearing block onto a single freshly-minted id.
+  void _forceSurfaceId(A2uiEnvelope env, String surface) {
+    for (final key in const [
+      'createSurface',
+      'updateComponents',
+      'updateDataModel',
+      'deleteSurface',
+    ]) {
+      final payload = env[key];
+      if (payload is Map) {
+        (payload as Map<String, dynamic>)['surfaceId'] = surface;
+      }
+    }
   }
 
   /// Validates a single envelope, substitutes the real surface id for the

--- a/packages/genkit_a2ui/test/middleware_test.dart
+++ b/packages/genkit_a2ui/test/middleware_test.dart
@@ -476,7 +476,7 @@ void main() {
       // the reconstructed surface block and the action line (correlation).
       final modelMsg = seen!.messages.firstWhere((m) => m.role == Role.model);
       final modelText = modelMsg.content.map((p) => p.text ?? '').join('\n');
-      expect(modelText, contains('"surfaceId": "s1"'));
+      expect(modelText, contains('"surfaceId":"s1"'));
       final userMsg = seen!.messages.firstWhere((m) => m.role == Role.user);
       final userText = userMsg.content.map((p) => p.text ?? '').join('\n');
       expect(userText, contains('on surface s1'));

--- a/packages/genkit_a2ui/test/middleware_test.dart
+++ b/packages/genkit_a2ui/test/middleware_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:genkit/genkit.dart';
 import 'package:genkit_a2ui/a2ui.dart';
 import 'package:logging/logging.dart';
@@ -300,6 +302,129 @@ void main() {
       final joined = userMsg.content.map((p) => p.text ?? '').join(' ');
       expect(joined, contains('UI action "refresh"'));
       expect(joined, contains('Tokyo'));
+    });
+
+    test('replays a prior assistant surface as a fenced a2ui block, not a '
+        'sentinel', () async {
+      ModelRequest? seen;
+      defineReplyModel('m_replay', 'ok', onRequest: (r) => seen = r);
+
+      // A prior assistant turn that rendered a surface: create + update.
+      final surfacePart = DataPart(
+        data: {
+          'envelopes': [
+            {
+              'createSurface': {
+                'surfaceId': 's1',
+                'catalogId': basicCatalog.id,
+              },
+              'version': 'v0.9',
+            },
+            {
+              'updateComponents': {
+                'surfaceId': 's1',
+                'components': [
+                  {'id': 'root', 'component': 'Text', 'text': 'hi'},
+                ],
+              },
+              'version': 'v0.9',
+            },
+          ],
+        },
+        metadata: {'mimeType': a2uiMimeType},
+      );
+
+      await genkit.generate(
+        model: modelRef('m_replay'),
+        messages: [
+          Message(
+            role: Role.model,
+            content: [
+              TextPart(text: 'Here you go:'),
+              surfacePart,
+            ],
+          ),
+          Message(
+            role: Role.user,
+            content: [TextPart(text: 'thanks')],
+          ),
+        ],
+        use: [a2ui()],
+      );
+
+      final modelMsg = seen!.messages.firstWhere((m) => m.role == Role.model);
+      // The a2ui part is gone (the model converter never sees the mime type)...
+      expect(modelMsg.content.any(isA2uiPart), isFalse);
+      final joined = modelMsg.content.map((p) => p.text ?? '').join('\n');
+      // ...replaced by the canonical fenced block the model originally emitted,
+      // NOT the old `[rendered UI surface]` sentinel that poisoned the model.
+      expect(joined, isNot(contains('[rendered UI surface]')));
+      expect(joined, isNot(contains('[UI surface')));
+      expect(joined, contains('```a2ui'));
+      expect(joined, contains('createSurface'));
+      expect(joined, contains('updateComponents'));
+      expect(joined, contains('Here you go:'));
+
+      // The reconstructed block round-trips: parsing it yields the envelopes.
+      final block = joined.substring(
+        joined.indexOf('```a2ui') + '```a2ui'.length,
+        joined.lastIndexOf('```'),
+      );
+      final decoded = jsonDecode(block.trim()) as List;
+      expect(decoded.length, 2);
+      expect((decoded[0] as Map)['createSurface'], isNotNull);
+
+      // The concrete surface id is rewritten back to the placeholder, so the
+      // model can't copy a real id into a fresh render and reuse (overwrite) the
+      // prior surface. The parser mints a fresh id per turn instead.
+      expect(joined, isNot(contains('s1')));
+      final create = (decoded[0] as Map)['createSurface'] as Map;
+      final update = (decoded[1] as Map)['updateComponents'] as Map;
+      expect(create['surfaceId'], surfaceIdPlaceholder);
+      expect(update['surfaceId'], surfaceIdPlaceholder);
+    });
+
+    test('groups consecutive surface envelopes into one block but splits '
+        'around an action', () async {
+      ModelRequest? seen;
+      defineReplyModel('m_mixed', 'ok', onRequest: (r) => seen = r);
+
+      final mixedPart = DataPart(
+        data: {
+          'envelopes': [
+            {
+              'createSurface': {
+                'surfaceId': 's1',
+                'catalogId': basicCatalog.id,
+              },
+            },
+            {
+              'updateComponents': {'surfaceId': 's1', 'components': []},
+            },
+            {
+              'action': {'name': 'refresh', 'surfaceId': 's1'},
+            },
+          ],
+        },
+        metadata: {'mimeType': a2uiMimeType},
+      );
+
+      await genkit.generate(
+        model: modelRef('m_mixed'),
+        messages: [
+          Message(role: Role.user, content: [mixedPart]),
+        ],
+        use: [a2ui()],
+      );
+
+      final userMsg = seen!.messages.firstWhere((m) => m.role == Role.user);
+      final joined = userMsg.content.map((p) => p.text ?? '').join('\n');
+      // Exactly one fenced block (the two surface envelopes grouped together)...
+      expect('```a2ui'.allMatches(joined).length, 1);
+      // ...plus the action rendered as a text summary after it.
+      expect(joined, contains('UI action "refresh"'));
+      // The block precedes the action line (source order preserved).
+      expect(joined.indexOf('```a2ui'), lessThan(joined.indexOf('UI action')));
     });
 
     test('transforms streamed chunks and mints a matching final id', () async {

--- a/packages/genkit_a2ui/test/middleware_test.dart
+++ b/packages/genkit_a2ui/test/middleware_test.dart
@@ -374,14 +374,112 @@ void main() {
       expect(decoded.length, 2);
       expect((decoded[0] as Map)['createSurface'], isNotNull);
 
-      // The concrete surface id is rewritten back to the placeholder, so the
-      // model can't copy a real id into a fresh render and reuse (overwrite) the
-      // prior surface. The parser mints a fresh id per turn instead.
-      expect(joined, isNot(contains('s1')));
+      // The real surface id is kept verbatim (NOT scrubbed to a placeholder),
+      // so a replayed action `[UI action ... on surface s1]` can still be
+      // correlated with this surface. Reuse is prevented at the parser instead:
+      // `createSurface` always mints a fresh id (see the distinct-id test).
       final create = (decoded[0] as Map)['createSurface'] as Map;
       final update = (decoded[1] as Map)['updateComponents'] as Map;
-      expect(create['surfaceId'], surfaceIdPlaceholder);
-      expect(update['surfaceId'], surfaceIdPlaceholder);
+      expect(create['surfaceId'], 's1');
+      expect(update['surfaceId'], 's1');
+    });
+
+    test('a new render never reuses a surface id copied from history', () async {
+      // Regression for the "new answer overwrites the prior surface in place"
+      // bug: history keeps real ids (for action correlation), so the model can
+      // copy an old id into a fresh `createSurface`. The parser must still mint
+      // a distinct id for that new render.
+      ModelRequest? seen;
+
+      // A model whose reply copies the prior surface's real id (`s1`) into a
+      // brand-new createSurface - exactly what a model does after seeing `s1`
+      // in replayed history.
+      genkit.defineModel(
+        name: 'm_reuse',
+        fn: (req, ctx) async {
+          seen = req;
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                TextPart(
+                  text:
+                      '''Here you go:
+```a2ui
+[
+  { "createSurface": { "surfaceId": "s1", "catalogId": "${basicCatalog.id}" } },
+  { "updateComponents": { "surfaceId": "s1", "components": [
+    { "id": "root", "component": "Text", "text": "new" }
+  ] } }
+]
+```
+''',
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      // Prior assistant surface `s1` + an action on it, replayed as history.
+      final priorSurface = DataPart(
+        data: {
+          'envelopes': [
+            {
+              'createSurface': {
+                'surfaceId': 's1',
+                'catalogId': basicCatalog.id,
+              },
+            },
+            {
+              'updateComponents': {
+                'surfaceId': 's1',
+                'components': [
+                  {'id': 'root', 'component': 'Text', 'text': 'old'},
+                ],
+              },
+            },
+          ],
+        },
+        metadata: {'mimeType': a2uiMimeType},
+      );
+      final actionOnS1 = DataPart(
+        data: {
+          'envelopes': [
+            {
+              'action': {'name': 'refresh', 'surfaceId': 's1'},
+            },
+          ],
+        },
+        metadata: {'mimeType': a2uiMimeType},
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m_reuse'),
+        messages: [
+          Message(role: Role.model, content: [priorSurface]),
+          Message(role: Role.user, content: [actionOnS1]),
+        ],
+        use: [a2ui(surfaceId: 'sfc-new')],
+      );
+
+      // The new render is minted onto the fixed id `sfc-new`, NOT the copied
+      // `s1`, so it can't overwrite the prior surface.
+      final envelopes = a2uiEnvelopesFromParts(res.message!.content);
+      final create = envelopes.firstWhere((e) => e['createSurface'] != null);
+      expect((create['createSurface'] as Map)['surfaceId'], 'sfc-new');
+      final update = envelopes.firstWhere((e) => e['updateComponents'] != null);
+      expect((update['updateComponents'] as Map)['surfaceId'], 'sfc-new');
+
+      // Meanwhile, the sanitized history the model saw kept the real id on both
+      // the reconstructed surface block and the action line (correlation).
+      final modelMsg = seen!.messages.firstWhere((m) => m.role == Role.model);
+      final modelText = modelMsg.content.map((p) => p.text ?? '').join('\n');
+      expect(modelText, contains('"surfaceId": "s1"'));
+      final userMsg = seen!.messages.firstWhere((m) => m.role == Role.user);
+      final userText = userMsg.content.map((p) => p.text ?? '').join('\n');
+      expect(userText, contains('on surface s1'));
     });
 
     test('groups consecutive surface envelopes into one block but splits '


### PR DESCRIPTION
Convert inbound a2ui surface envelopes back into canonical `a2ui` fenced blocks instead of summarizing them to a `[rendered UI surface]` sentinel. Replaying the model's own UI output in its original format reinforces correct behavior; the sentinel taught the model to emit that literal string in place of a real block.

Concrete surface ids are rewritten to the placeholder so the parser mints a fresh id per turn, preventing the model from reusing and overwriting a prior surface. Client-synthesized action envelopes remain short text summaries, and consecutive surface envelopes are grouped into one block.