### PR TITLE
fix(a2ui): stitch a2ui blocks split across multiple text parts

### DIFF
--- a/packages/genkit/test/client_test.mocks.dart
+++ b/packages/genkit/test/client_test.mocks.dart
@@ -17,6 +17,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i3;
 import 'dart:convert' as _i4;
 import 'dart:typed_data' as _i6;

--- a/packages/genkit/test/remote_model_test.mocks.dart
+++ b/packages/genkit/test/remote_model_test.mocks.dart
@@ -17,6 +17,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i3;
 import 'dart:convert' as _i4;
 import 'dart:typed_data' as _i6;

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -316,7 +316,7 @@ class A2uiMiddleware extends GenerateMiddleware {
     final newContent = <Part>[];
     for (final part in chunk.content) {
       final text = part.text;
-      if (part.isText && text != null && text != '') {
+      if (part.isText && text != null && text.isNotEmpty) {
         final result = parser.push(text);
         newContent.addAll(_partsFromSegments(result.segments));
       } else {
@@ -359,7 +359,7 @@ class A2uiMiddleware extends GenerateMiddleware {
 
     for (final part in message.content) {
       final text = part.text;
-      if (part.isText && text != null && text != '') {
+      if (part.isText && text != null && text.isNotEmpty) {
         // Push WITHOUT flushing between consecutive text parts so an a2ui block
         // that spans several adjacent text parts is stitched back together. The
         // model's final message is not guaranteed to coalesce adjacent text:

--- a/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
+++ b/packages/genkit_a2ui/lib/src/a2ui_middleware.dart
@@ -349,19 +349,39 @@ class A2uiMiddleware extends GenerateMiddleware {
       surfaceId: surfaceId,
     );
     final newContent = <Part>[];
-    // Push every text part through the parser first so a block spanning
-    // multiple text parts stays intact, then flush once at the end to drain
-    // any trailing block. Ordering (prose before/after a block) is preserved.
+
+    // Drains whatever the parser is still holding (a withheld prose tail, or an
+    // unterminated trailing block) and appends it. Called at every non-text
+    // boundary and once at the end.
+    void flushHeld() {
+      newContent.addAll(_partsFromSegments(parser.flush().segments));
+    }
+
     for (final part in message.content) {
-      if (part.isText) {
-        final pushed = parser.push(part.text ?? '');
-        newContent.addAll(_partsFromSegments(pushed.segments));
+      final text = part.text;
+      if (part.isText && text != null && text != '') {
+        // Push WITHOUT flushing between consecutive text parts so an a2ui block
+        // that spans several adjacent text parts is stitched back together. The
+        // model's final message is not guaranteed to coalesce adjacent text:
+        // the Gemini plugin, for instance, aggregates a turn into many separate
+        // text parts (fence, JSON body split many ways, close fence, then a
+        // trailing empty-text part carrying the thought signature), so a
+        // per-part flush would reset the parser mid-block and leak the whole
+        // surface back out as raw prose. This mirrors the streaming path, which
+        // shares one parser across all chunks and flushes only once at the end.
+        newContent.addAll(_partsFromSegments(parser.push(text).segments));
       } else {
+        // A non-text part (e.g. a toolRequest) or an empty-text part (e.g. the
+        // trailing thought-signature carrier) is a boundary: flush any held
+        // tail so it lands before this part, preserving order. This is what a
+        // tool-calling turn [text("Checking the weather."), toolRequest] relies
+        // on so the prose is not reordered behind the toolRequest. Then carry
+        // the part through untouched so its metadata survives.
+        flushHeld();
         newContent.add(part);
       }
     }
-    final flushed = parser.flush();
-    newContent.addAll(_partsFromSegments(flushed.segments));
+    flushHeld();
 
     return ModelResponse(
       message: Message(

--- a/packages/genkit_a2ui/test/middleware_test.dart
+++ b/packages/genkit_a2ui/test/middleware_test.dart
@@ -184,6 +184,140 @@ void main() {
       expect((envelopes[0]['createSurface'] as Map)['surfaceId'], 'sfc');
     });
 
+    test('stitches a block split across many final-message text parts', () async {
+      // The aggregated final message is not guaranteed to coalesce adjacent
+      // text: the Gemini plugin splits a turn into many text parts (fence, JSON
+      // body split many ways, close fence, then a trailing empty-text part
+      // carrying the thought signature). _transformResponse must stitch a block
+      // spanning several parts into a single a2ui data part rather than flushing
+      // per part and leaking the whole surface back out as raw prose. The
+      // trailing empty-text part (a boundary) must survive with its metadata.
+      genkit.defineModel(
+        name: 'm_split',
+        fn: (req, ctx) async {
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                TextPart(text: 'Here is the weather:\n\n``'),
+                TextPart(
+                  text: '`a2ui\n[{"createSurface":{"surfaceId":"SURFACE_ID",',
+                ),
+                TextPart(text: '"catalogId":"${basicCatalog.id}"}},'),
+                TextPart(
+                  text: '{"updateComponents":{"surfaceId":"SURFACE_ID",',
+                ),
+                TextPart(
+                  text: '"components":[{"id":"root","component":"Text",',
+                ),
+                TextPart(text: '"text":"hi"}]}}]\n``'),
+                TextPart(text: '`'),
+                // A trailing empty-text part that only carries metadata (e.g. a
+                // thought signature).
+                TextPart(text: '', metadata: {'signature': 'thought-sig-xyz'}),
+              ],
+            ),
+          );
+        },
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m_split'),
+        system: 'sys',
+        prompt: 'weather',
+        use: [a2ui(surfaceId: 'sfc')],
+      );
+
+      final out = res.message!.content;
+
+      // The block spread over many parts is stitched into exactly two envelopes
+      // on a single a2ui data part.
+      final envelopes = a2uiEnvelopesFromParts(out);
+      expect(envelopes.length, 2);
+      expect((envelopes[0]['createSurface'] as Map)['surfaceId'], 'sfc');
+
+      // No text part should still contain the raw fence: the JSON must have been
+      // parsed out, not leaked back as prose.
+      final joinedText = out
+          .where((p) => p.isText)
+          .map((p) => p.text ?? '')
+          .join();
+      expect(joinedText, isNot(contains('a2ui')));
+      expect(joinedText, isNot(contains('createSurface')));
+
+      // The leading prose survives (the parser may hold back a few chars that
+      // could begin a fence, splitting it across parts, so assert on the join).
+      expect(
+        joinedText,
+        contains('Here is the weather'),
+        reason: 'expected the leading prose to be preserved',
+      );
+
+      // The trailing signature part is carried through untouched.
+      expect(
+        out.any((p) => p.metadata?['signature'] == 'thought-sig-xyz'),
+        isTrue,
+        reason: 'expected the trailing thought-signature part to survive',
+      );
+    });
+
+    test('flushes the held tail before a non-text part in the final '
+        'message', () async {
+      // The parser withholds a prose tail on push (up to a partial opening
+      // fence). A non-text part (here a MediaPart) is a boundary: the held tail
+      // must be flushed BEFORE it so prose is not reordered behind the part.
+      // The trailing text ends in backticks so the parser holds it back,
+      // exercising the boundary flush rather than an end-of-message flush.
+      genkit.defineModel(
+        name: 'm_media_order',
+        fn: (req, ctx) async {
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                TextPart(text: 'Here is an image: ``'),
+                MediaPart(
+                  media: Media(
+                    contentType: 'image/png',
+                    url: 'data:image/png;base64,AAAA',
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      final res = await genkit.generate(
+        model: modelRef('m_media_order'),
+        system: 'sys',
+        prompt: 'image',
+        use: [a2ui()],
+      );
+
+      final out = res.message!.content;
+      final mediaIdx = out.indexWhere((p) => p.isMedia);
+      expect(mediaIdx, isNonNegative);
+
+      // Every text part precedes the media part: the withheld prose tail was
+      // flushed at the boundary, not after the media part.
+      final lastTextIdx = out.lastIndexWhere((p) => p.isText);
+      expect(
+        lastTextIdx,
+        lessThan(mediaIdx),
+        reason: 'prose (incl. the withheld tail) must stay before the media',
+      );
+
+      // The full prose survives intact across the split text parts.
+      final joinedText = out
+          .where((p) => p.isText)
+          .map((p) => p.text ?? '')
+          .join();
+      expect(joinedText, 'Here is an image: ``');
+    });
+
     test('leaves plain prose responses untouched (no a2ui parts)', () async {
       defineReplyModel('m7', 'just chatting');
 


### PR DESCRIPTION
Fix _transformResponse to keep the parser state across consecutive text parts so an a2ui block spanning several adjacent parts is reassembled into a single data part instead of leaking as raw prose. Non-text and empty-text parts (e.g. thought-signature carriers) are treated as boundaries that flush held content while preserving order and metadata.

This mirrors the streaming path and handles final messages that do not coalesce adjacent text, such as those from the Gemini plugin.