### PR TITLE
feat(genkit_openai): support whisper on OpenAI stt

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -213,6 +213,47 @@ final response = await ai.generate(
 );
 ```
 
+### Text to Speech
+
+Speech models are referenced with `speechModel()` rather than `model()`, take
+`OpenAISpeechOptions`, and answer with a single audio media part whose `url` is
+a base64 `data:` URL:
+
+```dart
+final response = await ai.generate(
+  model: openAI.speechModel('gpt-4o-mini-tts'),
+  prompt: 'Genkit is an amazing AI framework.',
+  config: OpenAISpeechOptions(
+    voice: 'sage',
+    instructions: 'Speak in a calm, warm tone.',
+  ),
+);
+
+final media = response.media!;            // contentType: audio/mpeg
+final bytes = base64Decode(media.url.split(',').last);
+await File('speech.mp3').writeAsBytes(bytes);
+```
+
+`tts-1` and `tts-1-hd` also accept `speed`. `gpt-4o-mini-tts` rejects it, so the
+plugin drops the field for that model; `instructions` is only honored there.
+
+Speech models are detected by name (`*tts*`). For an OpenAI-compatible provider
+whose speech model is named differently, declare media output when registering
+it and the plugin will route it to `/audio/speech`:
+
+```dart
+openAI(
+  name: 'voicecorp',
+  baseUrl: 'https://api.voicecorp.example/v1',
+  models: [
+    CustomModelDefinition(
+      name: 'voicebox-1',
+      info: ModelInfo(supports: {'output': ['media']}),
+    ),
+  ],
+)
+```
+
 ## Options
 
 The `OpenAIChatOptions` class supports the following options:
@@ -227,6 +268,14 @@ The `OpenAIChatOptions` class supports the following options:
 - `user` (String?) - User identifier for abuse detection
 - `jsonMode` (bool?) - Enable JSON mode
 - `visualDetailLevel` (String?, 'auto'|'low'|'high') - Visual detail level for images
+- `version` (String?) - Model version override
+
+The `OpenAISpeechOptions` class supports the following options:
+
+- `voice` (String?) - Voice name, e.g. `'alloy'`, `'sage'`, `'coral'` (defaults to `'alloy'`). Free-form, so new OpenAI voices work without a plugin update
+- `instructions` (String?) - Tone and delivery guidance (`gpt-4o-mini-tts` only)
+- `speed` (double?, 0.25-4.0) - Playback speed (not supported by `gpt-4o-mini-tts`)
+- `responseFormat` (String?, 'mp3'|'opus'|'aac'|'flac'|'wav'|'pcm') - Audio container (defaults to `'mp3'`)
 - `version` (String?) - Model version override
 
 ## Custom Headers

--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -254,6 +254,52 @@ openAI(
 )
 ```
 
+### Speech to Text
+
+Transcription models take audio in and return text. The audio goes in through
+`promptParts` as a `MediaPart` holding a base64 `data:` URL:
+
+```dart
+final response = await ai.generate(
+  model: openAI.transcriptionModel('whisper-1'),
+  promptParts: [
+    MediaPart(
+      media: Media(contentType: 'audio/mpeg', url: 'data:audio/mpeg;base64,...'),
+    ),
+  ],
+  config: OpenAITranscriptionOptions(language: 'en'),
+);
+
+print(response.text); // 'The quick brown fox jumps over the lazy dog.'
+```
+
+`whisper-1`, `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` are supported.
+Set `responseFormat: 'srt'` or `'vtt'` to get subtitle markup instead of a
+plain transcript, and `'verbose_json'` (with `timestampGranularities`) for
+timing metadata.
+
+`whisper-1` can also translate: `translate: true` routes the request to
+OpenAI's translation endpoint, which returns English text for audio in any
+language.
+
+```dart
+final response = await ai.generate(
+  model: openAI.transcriptionModel('whisper-1'),
+  promptParts: [MediaPart(media: spanishAudio)],
+  config: OpenAITranscriptionOptions(translate: true),
+);
+```
+
+As with speech models, a compatible provider whose transcription model is not
+named `*whisper*` or `*transcribe*` can declare audio input when registering it:
+
+```dart
+CustomModelDefinition(
+  name: 'earbox-1',
+  info: ModelInfo(supports: {'media': true}),
+)
+```
+
 ## Options
 
 The `OpenAIChatOptions` class supports the following options:
@@ -276,6 +322,18 @@ The `OpenAISpeechOptions` class supports the following options:
 - `instructions` (String?) - Tone and delivery guidance (`gpt-4o-mini-tts` only)
 - `speed` (double?, 0.25-4.0) - Playback speed (not supported by `gpt-4o-mini-tts`)
 - `responseFormat` (String?, 'mp3'|'opus'|'aac'|'flac'|'wav'|'pcm') - Audio container (defaults to `'mp3'`)
+- `version` (String?) - Model version override
+
+The `OpenAITranscriptionOptions` class supports the following options:
+
+- `language` (String?) - ISO-639-1 code of the spoken language; improves accuracy and latency
+- `prompt` (String?) - Decoding hint (vocabulary, names, style). Defaults to the request's text content
+- `temperature` (double?, 0.0-1.0) - Sampling temperature
+- `responseFormat` (String?, 'json'|'text'|'srt'|'verbose_json'|'vtt') - Transcript format (defaults to `'json'`)
+- `timestampGranularities` (List<String>?) - `'word'` and/or `'segment'`; needs `verbose_json`, `whisper-1` only
+- `chunkingStrategy` (Object?) - `'auto'` or a server-VAD map; `gpt-4o-transcribe` family only
+- `include` (List<String>?) - Extra response fields, e.g. `['logprobs']`
+- `translate` (bool?) - Translate to English instead of transcribing; `whisper-1` only
 - `version` (String?) - Model version override
 
 ## Custom Headers

--- a/packages/genkit_openai/lib/genkit_openai.dart
+++ b/packages/genkit_openai/lib/genkit_openai.dart
@@ -20,10 +20,12 @@ import 'package:http/http.dart' as http;
 import 'src/chat.dart' as chat;
 import 'src/openai_plugin.dart';
 import 'src/speech.dart' as speech;
+import 'src/transcription.dart' as transcription;
 
 export 'src/chat.dart' show OpenAIChatOptions, OpenAIOptions;
 export 'src/converters.dart' show GenkitConverter;
 export 'src/speech.dart' show OpenAISpeechOptions;
+export 'src/transcription.dart' show OpenAITranscriptionOptions;
 export 'src/utils.dart'
     show
         defaultModelInfo,
@@ -160,6 +162,33 @@ class OpenAICompatPluginHandle {
     return modelRef(
       '$namespace/$name',
       customOptions: speech.speechModelOptionsSchema(),
+    );
+  }
+
+  /// Reference to a speech-to-text model, e.g. `whisper-1` or
+  /// `gpt-4o-transcribe`.
+  ///
+  /// Transcription models read audio from the request and answer with text,
+  /// so the audio goes in through `promptParts`:
+  ///
+  /// ```dart
+  /// final response = await ai.generate(
+  ///   model: openAI.transcriptionModel('whisper-1'),
+  ///   promptParts: [MediaPart(media: recording)],
+  ///   config: OpenAITranscriptionOptions(language: 'en'),
+  /// );
+  /// print(response.text);
+  /// ```
+  ///
+  /// `whisper-1` also accepts `translate: true` to return English text for
+  /// audio in any language.
+  ModelRef<transcription.OpenAITranscriptionOptions> transcriptionModel(
+    String name, {
+    String namespace = defaultOpenAINamespace,
+  }) {
+    return modelRef(
+      '$namespace/$name',
+      customOptions: transcription.transcriptionModelOptionsSchema(),
     );
   }
 }

--- a/packages/genkit_openai/lib/genkit_openai.dart
+++ b/packages/genkit_openai/lib/genkit_openai.dart
@@ -19,9 +19,11 @@ import 'package:http/http.dart' as http;
 
 import 'src/chat.dart' as chat;
 import 'src/openai_plugin.dart';
+import 'src/speech.dart' as speech;
 
 export 'src/chat.dart' show OpenAIChatOptions, OpenAIOptions;
 export 'src/converters.dart' show GenkitConverter;
+export 'src/speech.dart' show OpenAISpeechOptions;
 export 'src/utils.dart'
     show
         defaultModelInfo,
@@ -131,6 +133,33 @@ class OpenAICompatPluginHandle {
     return modelRef(
       '$namespace/$name',
       customOptions: chat.chatModelOptionsSchema(),
+    );
+  }
+
+  /// Reference to a text-to-speech model, e.g. `tts-1` or `gpt-4o-mini-tts`.
+  ///
+  /// Separate from [model] because speech models take
+  /// `OpenAISpeechOptions` rather than `OpenAIChatOptions`, and return a
+  /// single audio media part instead of text:
+  ///
+  /// ```dart
+  /// final response = await ai.generate(
+  ///   model: openAI.speechModel('gpt-4o-mini-tts'),
+  ///   prompt: 'Genkit is an amazing AI framework.',
+  ///   config: OpenAISpeechOptions(
+  ///     voice: 'sage',
+  ///     instructions: 'Speak in a calm, warm tone.',
+  ///   ),
+  /// );
+  /// final audio = response.media; // data:audio/mpeg;base64,...
+  /// ```
+  ModelRef<speech.OpenAISpeechOptions> speechModel(
+    String name, {
+    String namespace = defaultOpenAINamespace,
+  }) {
+    return modelRef(
+      '$namespace/$name',
+      customOptions: speech.speechModelOptionsSchema(),
     );
   }
 }

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:genkit/plugin.dart';
 import 'package:http/http.dart' as http;
@@ -21,6 +22,7 @@ import 'package:openai_dart/openai_dart.dart' as sdk;
 import '../genkit_openai.dart';
 import 'chat.dart' as chat;
 import 'speech.dart' as speech;
+import 'transcription.dart' as transcription;
 
 /// Core Genkit plugin implementation for OpenAI-compatible APIs.
 ///
@@ -28,6 +30,9 @@ import 'speech.dart' as speech;
 /// [baseUrl] is set) and registers them in the Genkit action registry.
 /// Additional models can be provided via [customModels].
 class OpenAIPlugin extends GenkitPlugin {
+  /// Base URL used when the plugin was not given one.
+  static const String _defaultBaseUrl = 'https://api.openai.com/v1';
+
   final String _pluginName;
 
   @override
@@ -100,6 +105,17 @@ class OpenAIPlugin extends GenkitPlugin {
             continue;
           }
 
+          if (transcription.isTranscriptionModel(modelId)) {
+            registered.add(modelId);
+            actions.add(
+              _createTranscriptionModel(
+                modelId,
+                transcription.transcriptionModelInfo(modelId),
+              ),
+            );
+            continue;
+          }
+
           final modelType = getModelType(modelId);
 
           if (modelType != 'chat' && modelType != 'unknown') {
@@ -119,6 +135,17 @@ class OpenAIPlugin extends GenkitPlugin {
             );
           }
         }
+
+        for (final modelId in transcription.knownTranscriptionModels) {
+          if (registered.add(modelId)) {
+            actions.add(
+              _createTranscriptionModel(
+                modelId,
+                transcription.transcriptionModelInfo(modelId),
+              ),
+            );
+          }
+        }
       } catch (e) {
         throw GenkitException(
           'Error fetching available models from $_pluginName: $e',
@@ -132,6 +159,9 @@ class OpenAIPlugin extends GenkitPlugin {
       if (speech.isSpeechModel(model.name) ||
           speech.declaresMediaOutput(model.info)) {
         actions.add(_createSpeechModel(model.name, model.info));
+      } else if (transcription.isTranscriptionModel(model.name) ||
+          transcription.declaresMediaInput(model.info)) {
+        actions.add(_createTranscriptionModel(model.name, model.info));
       } else {
         actions.add(_createModel(model.name, model.info));
       }
@@ -209,6 +239,12 @@ class OpenAIPlugin extends GenkitPlugin {
           continue;
         }
 
+        if (transcription.isTranscriptionModel(modelId)) {
+          listed.add(modelId);
+          modelMetadataList.add(_transcriptionModelMetadata(modelId));
+          continue;
+        }
+
         final modelType = getModelType(modelId);
         if (modelType != 'chat' && modelType != 'unknown') {
           continue;
@@ -229,6 +265,12 @@ class OpenAIPlugin extends GenkitPlugin {
         }
       }
 
+      for (final modelId in transcription.knownTranscriptionModels) {
+        if (listed.add(modelId)) {
+          modelMetadataList.add(_transcriptionModelMetadata(modelId));
+        }
+      }
+
       return modelMetadataList;
     } catch (e, stackTrace) {
       throw GenkitException(
@@ -245,6 +287,10 @@ class OpenAIPlugin extends GenkitPlugin {
       final info = _customModelInfo(name);
       if (speech.isSpeechModel(name) || speech.declaresMediaOutput(info)) {
         return _createSpeechModel(name, info);
+      }
+      if (transcription.isTranscriptionModel(name) ||
+          transcription.declaresMediaInput(info)) {
+        return _createTranscriptionModel(name, info);
       }
       return _createModel(name, info);
     }
@@ -268,6 +314,15 @@ class OpenAIPlugin extends GenkitPlugin {
       '$_pluginName/$modelId',
       modelInfo: speech.speechModelInfo(modelId),
       customOptions: speech.speechModelOptionsSchema(),
+    );
+  }
+
+  ActionMetadata<dynamic, dynamic, dynamic, dynamic>
+  _transcriptionModelMetadata(String modelId) {
+    return modelMetadata(
+      '$_pluginName/$modelId',
+      modelInfo: transcription.transcriptionModelInfo(modelId),
+      customOptions: transcription.transcriptionModelOptionsSchema(),
     );
   }
 
@@ -530,6 +585,222 @@ class OpenAIPlugin extends GenkitPlugin {
     }
 
     return text;
+  }
+
+  /// Builds a speech-to-text model action.
+  ///
+  /// Transcription models read an audio [MediaPart] out of the request and
+  /// return the transcript as a single text part. The request is a
+  /// hand-built multipart upload rather than an SDK call: the SDK's
+  /// `TranscriptionRequest` cannot express `chunking_strategy` or `include`,
+  /// and its `create()` always JSON-decodes the response, which breaks the
+  /// `text`, `srt` and `vtt` formats.
+  Model _createTranscriptionModel(String modelName, ModelInfo? info) {
+    final modelInfo = info ?? transcription.transcriptionModelInfo(modelName);
+
+    return Model(
+      name: '$_pluginName/$modelName',
+      customOptions: transcription.transcriptionModelOptionsSchema(),
+      metadata: {'model': modelInfo.toJson()},
+      fn: (req, ctx) async {
+        final modelRequest = req!;
+        final options = transcription.parseTranscriptionModelOptions(
+          modelRequest.config,
+        );
+
+        if (modelRequest.output?.format == 'media') {
+          throw GenkitException(
+            'Transcription models return text; output format '
+            "'media' is not supported.",
+            status: StatusCodes.INVALID_ARGUMENT,
+          );
+        }
+
+        final audio = _transcriptionAudio(modelRequest);
+        final resolvedModel = options.version ?? modelName;
+        final format = _transcriptionResponseFormat(modelRequest, options);
+        final translate =
+            options.translate == true &&
+            transcription.supportsTranslation(resolvedModel);
+
+        final resolvedConfig = await _resolveClientConfig();
+        final client = httpClient ?? http.Client();
+
+        try {
+          final endpoint = translate
+              ? '/audio/translations'
+              : '/audio/transcriptions';
+          final url = Uri.parse(
+            '${resolvedConfig.baseUrl ?? _defaultBaseUrl}$endpoint',
+          );
+
+          final request = http.MultipartRequest('POST', url)
+            ..headers['Authorization'] = 'Bearer ${resolvedConfig.apiKey}';
+          resolvedConfig.headers?.forEach((key, value) {
+            request.headers[key] = value;
+          });
+
+          request.files.add(
+            http.MultipartFile.fromBytes(
+              'file',
+              audio.bytes,
+              filename: transcription.audioFilenameFor(audio.mimeType),
+            ),
+          );
+          request.fields['model'] = resolvedModel;
+          request.fields['response_format'] = format;
+
+          final prompt = options.prompt ?? modelRequest.messages.first.text;
+          if (prompt.trim().isNotEmpty) {
+            request.fields['prompt'] = prompt;
+          }
+          if (options.temperature != null) {
+            request.fields['temperature'] = '${options.temperature}';
+          }
+
+          // The translations endpoint only accepts file, model, prompt,
+          // response_format and temperature.
+          if (!translate) {
+            if (options.language != null) {
+              request.fields['language'] = options.language!;
+            }
+            final chunking = options.chunkingStrategy;
+            if (chunking != null) {
+              request.fields['chunking_strategy'] = chunking is String
+                  ? chunking
+                  : jsonEncode(chunking);
+            }
+            for (final value in options.include ?? const <String>[]) {
+              _addRepeatedField(request, 'include[]', value);
+            }
+            for (final value
+                in options.timestampGranularities ?? const <String>[]) {
+              _addRepeatedField(request, 'timestamp_granularities[]', value);
+            }
+          }
+
+          final response = await http.Response.fromStream(
+            await client.send(request),
+          );
+
+          if (response.statusCode < 200 || response.statusCode >= 300) {
+            throw GenkitException(
+              'OpenAI API error: HTTP ${response.statusCode}',
+              status: StatusCodes.fromHttpStatus(response.statusCode),
+              details: response.body,
+            );
+          }
+
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [TextPart(text: _transcriptText(response.body, format))],
+            ),
+          );
+        } catch (e, stackTrace) {
+          if (e is GenkitException) {
+            rethrow;
+          }
+
+          throw GenkitException(
+            'OpenAI API error: $e',
+            details: e.toString(),
+            underlyingException: e,
+            stackTrace: stackTrace,
+          );
+        } finally {
+          if (httpClient == null) {
+            client.close();
+          }
+        }
+      },
+    );
+  }
+
+  /// Adds a repeated multipart field.
+  ///
+  /// `MultipartRequest.fields` is a plain map and cannot hold duplicate keys,
+  /// but OpenAI expects array parameters as repeated fields.
+  void _addRepeatedField(
+    http.MultipartRequest request,
+    String name,
+    String value,
+  ) {
+    request.files.add(http.MultipartFile.fromString(name, value));
+  }
+
+  /// Extracts the audio to transcribe from the first message.
+  ({Uint8List bytes, String mimeType}) _transcriptionAudio(
+    ModelRequest request,
+  ) {
+    final media = request.messages.isEmpty
+        ? null
+        : request.messages.first.media;
+    if (media == null) {
+      throw GenkitException(
+        'Transcription models require an audio media part in the request.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+
+    final uri = Uri.tryParse(media.url);
+    final data = uri?.data;
+    if (data == null) {
+      throw GenkitException(
+        'Transcription models require audio as a base64 data URL; '
+        'got ${media.url.split(':').first}.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+
+    final mimeType = (media.contentType ?? data.mimeType)
+        .split(';')
+        .first
+        .trim();
+    return (bytes: data.contentAsBytes(), mimeType: mimeType);
+  }
+
+  /// Resolves the transcript format, rejecting combinations OpenAI cannot
+  /// satisfy.
+  String _transcriptionResponseFormat(
+    ModelRequest request,
+    transcription.OpenAITranscriptionOptions options,
+  ) {
+    final requested = options.responseFormat;
+    final wantsJson = request.output?.format == 'json';
+
+    if (wantsJson &&
+        requested != null &&
+        requested != 'json' &&
+        requested != 'verbose_json') {
+      throw GenkitException(
+        "Response format '$requested' cannot satisfy output format 'json'.",
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+
+    if (requested != null) {
+      return requested;
+    }
+    return wantsJson
+        ? 'json'
+        : transcription.defaultTranscriptionResponseFormat;
+  }
+
+  /// Pulls the transcript out of a response body.
+  ///
+  /// `json` and `verbose_json` wrap it in an object; `text`, `srt` and `vtt`
+  /// are already the transcript.
+  String _transcriptText(String body, String format) {
+    if (format != 'json' && format != 'verbose_json') {
+      return body;
+    }
+    final decoded = jsonDecode(body);
+    if (decoded is Map && decoded['text'] is String) {
+      return decoded['text'] as String;
+    }
+    return body;
   }
 }
 

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:genkit/plugin.dart';
 import 'package:http/http.dart' as http;
 import 'package:openai_dart/openai_dart.dart' as sdk;
 
 import '../genkit_openai.dart';
 import 'chat.dart' as chat;
+import 'speech.dart' as speech;
 
 /// Core Genkit plugin implementation for OpenAI-compatible APIs.
 ///
@@ -86,7 +89,17 @@ class OpenAIPlugin extends GenkitPlugin {
       try {
         final availableModelIds = await _fetchAvailableModels();
 
+        final registered = <String>{};
+
         for (final modelId in availableModelIds) {
+          if (speech.isSpeechModel(modelId)) {
+            registered.add(modelId);
+            actions.add(
+              _createSpeechModel(modelId, speech.speechModelInfo(modelId)),
+            );
+            continue;
+          }
+
           final modelType = getModelType(modelId);
 
           if (modelType != 'chat' && modelType != 'unknown') {
@@ -95,6 +108,16 @@ class OpenAIPlugin extends GenkitPlugin {
 
           final info = modelInfoFor(modelId);
           actions.add(_createModel(modelId, info));
+        }
+
+        // Speech models are not always advertised by GET /models, so register
+        // the known ones regardless.
+        for (final modelId in speech.knownSpeechModels) {
+          if (registered.add(modelId)) {
+            actions.add(
+              _createSpeechModel(modelId, speech.speechModelInfo(modelId)),
+            );
+          }
         }
       } catch (e) {
         throw GenkitException(
@@ -106,7 +129,12 @@ class OpenAIPlugin extends GenkitPlugin {
 
     // Register custom models
     for (final model in customModels) {
-      actions.add(_createModel(model.name, model.info));
+      if (speech.isSpeechModel(model.name) ||
+          speech.declaresMediaOutput(model.info)) {
+        actions.add(_createSpeechModel(model.name, model.info));
+      } else {
+        actions.add(_createModel(model.name, model.info));
+      }
     }
 
     return actions;
@@ -172,7 +200,15 @@ class OpenAIPlugin extends GenkitPlugin {
       final modelMetadataList =
           <ActionMetadata<dynamic, dynamic, dynamic, dynamic>>[];
 
+      final listed = <String>{};
+
       for (final modelId in modelIds) {
+        if (speech.isSpeechModel(modelId)) {
+          listed.add(modelId);
+          modelMetadataList.add(_speechModelMetadata(modelId));
+          continue;
+        }
+
         final modelType = getModelType(modelId);
         if (modelType != 'chat' && modelType != 'unknown') {
           continue;
@@ -185,6 +221,12 @@ class OpenAIPlugin extends GenkitPlugin {
             customOptions: chat.chatModelOptionsSchema(),
           ),
         );
+      }
+
+      for (final modelId in speech.knownSpeechModels) {
+        if (listed.add(modelId)) {
+          modelMetadataList.add(_speechModelMetadata(modelId));
+        }
       }
 
       return modelMetadataList;
@@ -200,9 +242,33 @@ class OpenAIPlugin extends GenkitPlugin {
   @override
   Action? resolve(ActionType actionType, String name) {
     if (actionType == .model) {
-      return _createModel(name, null);
+      final info = _customModelInfo(name);
+      if (speech.isSpeechModel(name) || speech.declaresMediaOutput(info)) {
+        return _createSpeechModel(name, info);
+      }
+      return _createModel(name, info);
     }
     return null;
+  }
+
+  /// Metadata for [modelName] if the caller registered it as a custom model.
+  ModelInfo? _customModelInfo(String modelName) {
+    for (final model in customModels) {
+      if (model.name == modelName) {
+        return model.info;
+      }
+    }
+    return null;
+  }
+
+  ActionMetadata<dynamic, dynamic, dynamic, dynamic> _speechModelMetadata(
+    String modelId,
+  ) {
+    return modelMetadata(
+      '$_pluginName/$modelId',
+      modelInfo: speech.speechModelInfo(modelId),
+      customOptions: speech.speechModelOptionsSchema(),
+    );
   }
 
   Model _createModel(String modelName, ModelInfo? info) {
@@ -353,6 +419,118 @@ class OpenAIPlugin extends GenkitPlugin {
       raw: response.toJson(),
     );
   }
+
+  /// Builds a text-to-speech model action.
+  ///
+  /// Speech models take the prompt text and return a single audio
+  /// [MediaPart] holding a base64 data URL. Streaming is not supported by the
+  /// `/audio/speech` endpoint, so streaming requests are ignored.
+  Model _createSpeechModel(String modelName, ModelInfo? info) {
+    final modelInfo = info ?? speech.speechModelInfo(modelName);
+
+    return Model(
+      name: '$_pluginName/$modelName',
+      customOptions: speech.speechModelOptionsSchema(),
+      metadata: {'model': modelInfo.toJson()},
+      fn: (req, ctx) async {
+        final modelRequest = req!;
+        final options = speech.parseSpeechModelOptions(modelRequest.config);
+        final input = _speechInputText(modelRequest);
+
+        final resolvedConfig = await _resolveClientConfig();
+        final client = sdk.OpenAIClient.withApiKey(
+          resolvedConfig.apiKey,
+          baseUrl: resolvedConfig.baseUrl,
+          defaultHeaders: resolvedConfig.headers,
+          httpClient: httpClient,
+        );
+
+        try {
+          final format =
+              options.responseFormat ?? speech.defaultSpeechResponseFormat;
+          final resolvedModel = options.version ?? modelName;
+
+          final body = _SpeechRequestBody(
+            model: resolvedModel,
+            input: input,
+            voiceName: options.voice ?? speech.defaultSpeechVoice,
+            instructions: options.instructions,
+            responseFormat: options.responseFormat == null
+                ? null
+                : sdk.SpeechResponseFormat.fromJson(format),
+            // gpt-4o-mini-tts rejects `speed` outright.
+            speed: speech.speechModelRejectsSpeed(resolvedModel)
+                ? null
+                : options.speed,
+          );
+
+          final bytes = await client.audio.speech.create(body);
+          final contentType =
+              speech.speechResponseFormatMediaTypes[format] ?? 'audio/mpeg';
+
+          return ModelResponse(
+            finishReason: FinishReason.stop,
+            message: Message(
+              role: Role.model,
+              content: [
+                MediaPart(
+                  media: Media(
+                    contentType: contentType,
+                    url: 'data:$contentType;base64,${base64Encode(bytes)}',
+                  ),
+                ),
+              ],
+            ),
+          );
+        } catch (e, stackTrace) {
+          if (e is GenkitException) {
+            rethrow;
+          }
+
+          StatusCodes? status;
+          String? details;
+
+          if (e is sdk.ApiException) {
+            status = StatusCodes.fromHttpStatus(e.statusCode);
+            details = e.body?.toString();
+          }
+
+          throw GenkitException(
+            'OpenAI API error: $e',
+            status: status,
+            details: details ?? e.toString(),
+            underlyingException: e,
+            stackTrace: stackTrace,
+          );
+        } finally {
+          if (httpClient == null) {
+            client.close();
+          }
+        }
+      },
+    );
+  }
+
+  /// Extracts the text to synthesize: the first message only, matching the
+  /// JS plugin's `toTTSRequest`.
+  String _speechInputText(ModelRequest request) {
+    if (request.messages.isEmpty) {
+      throw GenkitException(
+        'Speech models require a prompt, but no messages were provided.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+
+    final text = request.messages.first.text;
+    if (text.trim().isEmpty) {
+      throw GenkitException(
+        'Speech models require non-empty prompt text.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+    }
+
+    return text;
+  }
 }
 
 final class _ResolvedClientConfig {
@@ -365,4 +543,35 @@ final class _ResolvedClientConfig {
     required this.baseUrl,
     required this.headers,
   });
+}
+
+/// Request body for `/audio/speech`.
+///
+/// The SDK's [sdk.SpeechRequest] caps `voice` at six legacy values and has no
+/// `instructions` field, which is the whole point of `gpt-4o-mini-tts`.
+/// The SDK's speech resource only ever calls `toJson()` on the request, so
+/// overriding it here buys full API fidelity while keeping every call on the
+/// SDK's transport (auth, retries, error mapping).
+final class _SpeechRequestBody extends sdk.SpeechRequest {
+  _SpeechRequestBody({
+    required super.model,
+    required super.input,
+    required this.voiceName,
+    this.instructions,
+    super.responseFormat,
+    super.speed,
+  }) : super(voice: sdk.SpeechVoice.alloy); // Placeholder; replaced in toJson.
+
+  /// Free-form voice name, unconstrained by [sdk.SpeechVoice].
+  final String voiceName;
+
+  /// Tone and delivery guidance for `gpt-4o-mini-tts`.
+  final String? instructions;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'voice': voiceName,
+    if (instructions != null) 'instructions': instructions,
+  };
 }

--- a/packages/genkit_openai/lib/src/speech.dart
+++ b/packages/genkit_openai/lib/src/speech.dart
@@ -1,0 +1,123 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'utils.dart';
+
+part 'speech.g.dart';
+
+/// Speech-specific options for OpenAI text-to-speech models.
+@Schema()
+abstract class $OpenAISpeechOptions {
+  /// Model version override (e.g., 'tts-1-1106')
+  String? get version;
+
+  /// Voice used to render the audio (e.g. 'alloy', 'sage', 'coral').
+  ///
+  /// Left free-form on purpose: OpenAI adds voices without warning, and an
+  /// enum here would reject them until the plugin shipped a new release.
+  /// Defaults to 'alloy' when unset.
+  String? get voice;
+
+  /// Tone and delivery guidance, e.g. 'Speak in a calm, warm tone.'
+  ///
+  /// Only honored by `gpt-4o-mini-tts`; the `tts-1` family ignores it.
+  String? get instructions;
+
+  /// Playback speed multiplier (0.25 - 4.0).
+  ///
+  /// Not supported by `gpt-4o-mini-tts`, which rejects the field outright.
+  @DoubleField(minimum: 0.25, maximum: 4.0)
+  double? get speed;
+
+  /// Audio container for the generated speech. Defaults to 'mp3'.
+  @StringField(enumValues: ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'])
+  String? get responseFormat;
+}
+
+/// Maps an OpenAI speech `response_format` to the MIME type used on the
+/// returned [MediaPart].
+const Map<String, String> speechResponseFormatMediaTypes = {
+  'mp3': 'audio/mpeg',
+  'opus': 'audio/opus',
+  'aac': 'audio/aac',
+  'flac': 'audio/flac',
+  'wav': 'audio/wav',
+  'pcm': 'audio/L16',
+};
+
+/// Speech models registered eagerly, even when absent from `GET /models`.
+const List<String> knownSpeechModels = ['tts-1', 'tts-1-hd', 'gpt-4o-mini-tts'];
+
+/// Default audio container when the caller does not pick one.
+const String defaultSpeechResponseFormat = 'mp3';
+
+/// Default voice when the caller does not pick one.
+const String defaultSpeechVoice = 'alloy';
+
+/// Returns true when [modelId] is a text-to-speech model.
+///
+/// [getModelType] lumps every audio model together, so the extra `tts` check
+/// is what separates speech synthesis from transcription (`whisper-1`,
+/// `gpt-4o-transcribe`), realtime, and audio-in chat models.
+bool isSpeechModel(String modelId) {
+  return getModelType(modelId) == 'audio' &&
+      modelId.toLowerCase().contains('tts');
+}
+
+/// Returns true when [info] declares audio output.
+///
+/// Speech models on OpenAI-compatible providers are not always named
+/// `*tts*`, so a caller registering one through `CustomModelDefinition` says
+/// so with `supports: {'output': ['media']}`. That declaration is the only
+/// signal available for those models.
+bool declaresMediaOutput(ModelInfo? info) {
+  final output = info?.supports?['output'];
+  return output is List && output.contains('media');
+}
+
+/// Returns true when [modelId] rejects the `speed` parameter.
+bool speechModelRejectsSpeed(String modelId) {
+  return modelId.toLowerCase().contains('gpt-4o-mini-tts');
+}
+
+/// Capability metadata for a text-to-speech model.
+///
+/// Speech models take text in and hand back a single audio [MediaPart], so
+/// they advertise `output: ['media']` and opt out of everything conversational.
+ModelInfo speechModelInfo(String modelId) {
+  return ModelInfo(
+    label: modelId,
+    supports: {
+      'media': false,
+      'output': ['media'],
+      'multiturn': false,
+      'systemRole': false,
+      'tools': false,
+    },
+  );
+}
+
+/// Returns custom options schema for speech models.
+SchemanticType<OpenAISpeechOptions> speechModelOptionsSchema() =>
+    OpenAISpeechOptions.$schema;
+
+/// Parses speech-model options from action config.
+OpenAISpeechOptions parseSpeechModelOptions(Map<String, dynamic>? config) {
+  return config != null
+      ? OpenAISpeechOptions.$schema.parse(config)
+      : OpenAISpeechOptions();
+}

--- a/packages/genkit_openai/lib/src/speech.g.dart
+++ b/packages/genkit_openai/lib/src/speech.g.dart
@@ -1,0 +1,178 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+part of 'speech.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+/// Speech-specific options for OpenAI text-to-speech models.
+base class OpenAISpeechOptions {
+  /// Creates a [OpenAISpeechOptions] from a JSON map.
+  factory OpenAISpeechOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  OpenAISpeechOptions._(this._json);
+
+  OpenAISpeechOptions({
+    String? version,
+    String? voice,
+    String? instructions,
+    double? speed,
+    String? responseFormat,
+  }) {
+    _json = {
+      'version': ?version,
+      'voice': ?voice,
+      'instructions': ?instructions,
+      'speed': ?speed,
+      'responseFormat': ?responseFormat,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [OpenAISpeechOptions].
+  static const SchemanticType<OpenAISpeechOptions> $schema =
+      _OpenAISpeechOptionsTypeFactory();
+
+  /// Model version override (e.g., 'tts-1-1106')
+  String? get version {
+    return _json['version'] as String?;
+  }
+
+  /// Model version override (e.g., 'tts-1-1106')
+  set version(String? value) {
+    if (value == null) {
+      _json.remove('version');
+    } else {
+      _json['version'] = value;
+    }
+  }
+
+  /// Voice used to render the audio (e.g. 'alloy', 'sage', 'coral').
+  ///
+  /// Left free-form on purpose: OpenAI adds voices without warning, and an
+  /// enum here would reject them until the plugin shipped a new release.
+  /// Defaults to 'alloy' when unset.
+  String? get voice {
+    return _json['voice'] as String?;
+  }
+
+  /// Voice used to render the audio (e.g. 'alloy', 'sage', 'coral').
+  ///
+  /// Left free-form on purpose: OpenAI adds voices without warning, and an
+  /// enum here would reject them until the plugin shipped a new release.
+  /// Defaults to 'alloy' when unset.
+  set voice(String? value) {
+    if (value == null) {
+      _json.remove('voice');
+    } else {
+      _json['voice'] = value;
+    }
+  }
+
+  /// Tone and delivery guidance, e.g. 'Speak in a calm, warm tone.'
+  ///
+  /// Only honored by `gpt-4o-mini-tts`; the `tts-1` family ignores it.
+  String? get instructions {
+    return _json['instructions'] as String?;
+  }
+
+  /// Tone and delivery guidance, e.g. 'Speak in a calm, warm tone.'
+  ///
+  /// Only honored by `gpt-4o-mini-tts`; the `tts-1` family ignores it.
+  set instructions(String? value) {
+    if (value == null) {
+      _json.remove('instructions');
+    } else {
+      _json['instructions'] = value;
+    }
+  }
+
+  /// Playback speed multiplier (0.25 - 4.0).
+  ///
+  /// Not supported by `gpt-4o-mini-tts`, which rejects the field outright.
+  double? get speed {
+    return (_json['speed'] as num?)?.toDouble();
+  }
+
+  /// Playback speed multiplier (0.25 - 4.0).
+  ///
+  /// Not supported by `gpt-4o-mini-tts`, which rejects the field outright.
+  set speed(double? value) {
+    if (value == null) {
+      _json.remove('speed');
+    } else {
+      _json['speed'] = value;
+    }
+  }
+
+  /// Audio container for the generated speech. Defaults to 'mp3'.
+  String? get responseFormat {
+    return _json['responseFormat'] as String?;
+  }
+
+  /// Audio container for the generated speech. Defaults to 'mp3'.
+  set responseFormat(String? value) {
+    if (value == null) {
+      _json.remove('responseFormat');
+    } else {
+      _json['responseFormat'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [OpenAISpeechOptions] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _OpenAISpeechOptionsTypeFactory
+    extends SchemanticType<OpenAISpeechOptions> {
+  const _OpenAISpeechOptionsTypeFactory();
+
+  @override
+  OpenAISpeechOptions parse(Object? json) {
+    return OpenAISpeechOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'OpenAISpeechOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'version': $Schema.string(),
+            'voice': $Schema.string(),
+            'instructions': $Schema.string(),
+            'speed': $Schema.number(minimum: 0.25, maximum: 4.0),
+            'responseFormat': $Schema.string(
+              enumValues: ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'],
+            ),
+          },
+        )
+        .value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_openai/lib/src/transcription.dart
+++ b/packages/genkit_openai/lib/src/transcription.dart
@@ -1,0 +1,164 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'utils.dart';
+
+part 'transcription.g.dart';
+
+/// Transcription-specific options for OpenAI speech-to-text models.
+@Schema()
+abstract class $OpenAITranscriptionOptions {
+  /// Model version override (e.g., 'whisper-1').
+  String? get version;
+
+  /// ISO-639-1 code of the spoken language, e.g. 'en', 'es'.
+  ///
+  /// Supplying it improves accuracy and latency. Not accepted by the
+  /// translation endpoint, which always outputs English.
+  String? get language;
+
+  /// Decoding hint: vocabulary, names, or the expected style.
+  ///
+  /// Distinct from the Genkit prompt. When unset, the text content of the
+  /// request message is used instead.
+  String? get prompt;
+
+  /// Sampling temperature (0.0 - 1.0).
+  @DoubleField(minimum: 0.0, maximum: 1.0)
+  double? get temperature;
+
+  /// Transcript format. Defaults to 'json'.
+  ///
+  /// 'srt' and 'vtt' return subtitle markup, 'verbose_json' adds timing
+  /// metadata. Whatever the format, the transcript is returned as a single
+  /// text part; the untouched payload is available on `ModelResponse.raw`.
+  @StringField(enumValues: ['json', 'text', 'srt', 'verbose_json', 'vtt'])
+  String? get responseFormat;
+
+  /// Timestamp detail to include: 'word' and/or 'segment'.
+  ///
+  /// Requires `responseFormat: 'verbose_json'`, and is only supported by
+  /// `whisper-1`.
+  List<String>? get timestampGranularities;
+
+  /// How to split long audio: the string 'auto', or a map such as
+  /// `{'type': 'server_vad', 'prefix_padding_ms': 300}`.
+  ///
+  /// Only supported by the `gpt-4o-transcribe` family.
+  Object? get chunkingStrategy;
+
+  /// Extra fields to include in the response, e.g. `['logprobs']`.
+  List<String>? get include;
+
+  /// Translate the audio into English instead of transcribing it verbatim.
+  ///
+  /// Routes to `/audio/translations`, which only `whisper-1` supports.
+  bool? get translate;
+}
+
+/// Transcript format used when the caller does not pick one.
+///
+/// The OpenAI default is 'json', which every model supports and which yields
+/// a `{"text": ...}` body.
+const String defaultTranscriptionResponseFormat = 'json';
+
+/// Transcription models registered eagerly, even when absent from
+/// `GET /models`.
+const List<String> knownTranscriptionModels = [
+  'whisper-1',
+  'gpt-4o-transcribe',
+  'gpt-4o-mini-transcribe',
+];
+
+/// Maps an audio MIME type to the filename sent with the upload.
+///
+/// OpenAI infers the codec from this filename, so it has to be a real audio
+/// extension. A generic `type/subtype` split is not good enough: `audio/x-m4a`
+/// would yield `x-m4a`, which the API rejects.
+const Map<String, String> _audioMimeExtensions = {
+  'audio/flac': 'flac',
+  'audio/mp4': 'mp4',
+  'audio/mpeg': 'mp3',
+  'audio/mpga': 'mpga',
+  'audio/m4a': 'm4a',
+  'audio/x-m4a': 'm4a',
+  'audio/oga': 'oga',
+  'audio/ogg': 'ogg',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/webm': 'webm',
+};
+
+/// Filename to upload audio of [mimeType] under.
+String audioFilenameFor(String mimeType) {
+  final ext = _audioMimeExtensions[mimeType.toLowerCase()];
+  return ext == null ? 'input' : 'input.$ext';
+}
+
+/// Returns true when [modelId] transcribes audio into text.
+///
+/// [getModelType] returns 'audio' for speech synthesis, realtime and
+/// audio-in chat models too, so the name check is what keeps those on their
+/// own paths.
+bool isTranscriptionModel(String modelId) {
+  final id = modelId.toLowerCase();
+  return getModelType(modelId) == 'audio' &&
+      (id.contains('transcribe') || id.contains('whisper'));
+}
+
+/// Returns true when [modelId] can translate audio to English.
+///
+/// Only the whisper family is served by `/audio/translations`.
+bool supportsTranslation(String modelId) {
+  return modelId.toLowerCase().contains('whisper');
+}
+
+/// Returns true when [info] declares audio input.
+///
+/// The input-side mirror of `declaresMediaOutput`: a caller registering a
+/// transcription model on an OpenAI-compatible provider whose name is not
+/// `*whisper*` or `*transcribe*` says so with `supports: {'media': true}`.
+bool declaresMediaInput(ModelInfo? info) {
+  return info?.supports?['media'] == true;
+}
+
+/// Capability metadata for a transcription model.
+ModelInfo transcriptionModelInfo(String modelId) {
+  return ModelInfo(
+    label: modelId,
+    supports: {
+      'media': true,
+      'output': ['text', 'json'],
+      'multiturn': false,
+      'systemRole': false,
+      'tools': false,
+    },
+  );
+}
+
+/// Returns custom options schema for transcription models.
+SchemanticType<OpenAITranscriptionOptions> transcriptionModelOptionsSchema() =>
+    OpenAITranscriptionOptions.$schema;
+
+/// Parses transcription-model options from action config.
+OpenAITranscriptionOptions parseTranscriptionModelOptions(
+  Map<String, dynamic>? config,
+) {
+  return config != null
+      ? OpenAITranscriptionOptions.$schema.parse(config)
+      : OpenAITranscriptionOptions();
+}

--- a/packages/genkit_openai/lib/src/transcription.g.dart
+++ b/packages/genkit_openai/lib/src/transcription.g.dart
@@ -1,0 +1,266 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+part of 'transcription.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+/// Transcription-specific options for OpenAI speech-to-text models.
+base class OpenAITranscriptionOptions {
+  /// Creates a [OpenAITranscriptionOptions] from a JSON map.
+  factory OpenAITranscriptionOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  OpenAITranscriptionOptions._(this._json);
+
+  OpenAITranscriptionOptions({
+    String? version,
+    String? language,
+    String? prompt,
+    double? temperature,
+    String? responseFormat,
+    List<String>? timestampGranularities,
+    Object? chunkingStrategy,
+    List<String>? include,
+    bool? translate,
+  }) {
+    _json = {
+      'version': ?version,
+      'language': ?language,
+      'prompt': ?prompt,
+      'temperature': ?temperature,
+      'responseFormat': ?responseFormat,
+      'timestampGranularities': ?timestampGranularities,
+      'chunkingStrategy': ?chunkingStrategy,
+      'include': ?include,
+      'translate': ?translate,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [OpenAITranscriptionOptions].
+  static const SchemanticType<OpenAITranscriptionOptions> $schema =
+      _OpenAITranscriptionOptionsTypeFactory();
+
+  /// Model version override (e.g., 'whisper-1').
+  String? get version {
+    return _json['version'] as String?;
+  }
+
+  /// Model version override (e.g., 'whisper-1').
+  set version(String? value) {
+    if (value == null) {
+      _json.remove('version');
+    } else {
+      _json['version'] = value;
+    }
+  }
+
+  /// ISO-639-1 code of the spoken language, e.g. 'en', 'es'.
+  ///
+  /// Supplying it improves accuracy and latency. Not accepted by the
+  /// translation endpoint, which always outputs English.
+  String? get language {
+    return _json['language'] as String?;
+  }
+
+  /// ISO-639-1 code of the spoken language, e.g. 'en', 'es'.
+  ///
+  /// Supplying it improves accuracy and latency. Not accepted by the
+  /// translation endpoint, which always outputs English.
+  set language(String? value) {
+    if (value == null) {
+      _json.remove('language');
+    } else {
+      _json['language'] = value;
+    }
+  }
+
+  /// Decoding hint: vocabulary, names, or the expected style.
+  ///
+  /// Distinct from the Genkit prompt. When unset, the text content of the
+  /// request message is used instead.
+  String? get prompt {
+    return _json['prompt'] as String?;
+  }
+
+  /// Decoding hint: vocabulary, names, or the expected style.
+  ///
+  /// Distinct from the Genkit prompt. When unset, the text content of the
+  /// request message is used instead.
+  set prompt(String? value) {
+    if (value == null) {
+      _json.remove('prompt');
+    } else {
+      _json['prompt'] = value;
+    }
+  }
+
+  /// Sampling temperature (0.0 - 1.0).
+  double? get temperature {
+    return (_json['temperature'] as num?)?.toDouble();
+  }
+
+  /// Sampling temperature (0.0 - 1.0).
+  set temperature(double? value) {
+    if (value == null) {
+      _json.remove('temperature');
+    } else {
+      _json['temperature'] = value;
+    }
+  }
+
+  /// Transcript format. Defaults to 'json'.
+  ///
+  /// 'srt' and 'vtt' return subtitle markup, 'verbose_json' adds timing
+  /// metadata. Whatever the format, the transcript is returned as a single
+  /// text part; the untouched payload is available on `ModelResponse.raw`.
+  String? get responseFormat {
+    return _json['responseFormat'] as String?;
+  }
+
+  /// Transcript format. Defaults to 'json'.
+  ///
+  /// 'srt' and 'vtt' return subtitle markup, 'verbose_json' adds timing
+  /// metadata. Whatever the format, the transcript is returned as a single
+  /// text part; the untouched payload is available on `ModelResponse.raw`.
+  set responseFormat(String? value) {
+    if (value == null) {
+      _json.remove('responseFormat');
+    } else {
+      _json['responseFormat'] = value;
+    }
+  }
+
+  /// Timestamp detail to include: 'word' and/or 'segment'.
+  ///
+  /// Requires `responseFormat: 'verbose_json'`, and is only supported by
+  /// `whisper-1`.
+  List<String>? get timestampGranularities {
+    return (_json['timestampGranularities'] as List?)?.cast<String>();
+  }
+
+  /// Timestamp detail to include: 'word' and/or 'segment'.
+  ///
+  /// Requires `responseFormat: 'verbose_json'`, and is only supported by
+  /// `whisper-1`.
+  set timestampGranularities(List<String>? value) {
+    if (value == null) {
+      _json.remove('timestampGranularities');
+    } else {
+      _json['timestampGranularities'] = value;
+    }
+  }
+
+  /// How to split long audio: the string 'auto', or a map such as
+  /// `{'type': 'server_vad', 'prefix_padding_ms': 300}`.
+  ///
+  /// Only supported by the `gpt-4o-transcribe` family.
+  Object? get chunkingStrategy {
+    return _json['chunkingStrategy'] as Object?;
+  }
+
+  /// How to split long audio: the string 'auto', or a map such as
+  /// `{'type': 'server_vad', 'prefix_padding_ms': 300}`.
+  ///
+  /// Only supported by the `gpt-4o-transcribe` family.
+  set chunkingStrategy(Object? value) {
+    if (value == null) {
+      _json.remove('chunkingStrategy');
+    } else {
+      _json['chunkingStrategy'] = value;
+    }
+  }
+
+  /// Extra fields to include in the response, e.g. `['logprobs']`.
+  List<String>? get include {
+    return (_json['include'] as List?)?.cast<String>();
+  }
+
+  /// Extra fields to include in the response, e.g. `['logprobs']`.
+  set include(List<String>? value) {
+    if (value == null) {
+      _json.remove('include');
+    } else {
+      _json['include'] = value;
+    }
+  }
+
+  /// Translate the audio into English instead of transcribing it verbatim.
+  ///
+  /// Routes to `/audio/translations`, which only `whisper-1` supports.
+  bool? get translate {
+    return _json['translate'] as bool?;
+  }
+
+  /// Translate the audio into English instead of transcribing it verbatim.
+  ///
+  /// Routes to `/audio/translations`, which only `whisper-1` supports.
+  set translate(bool? value) {
+    if (value == null) {
+      _json.remove('translate');
+    } else {
+      _json['translate'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [OpenAITranscriptionOptions] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _OpenAITranscriptionOptionsTypeFactory
+    extends SchemanticType<OpenAITranscriptionOptions> {
+  const _OpenAITranscriptionOptionsTypeFactory();
+
+  @override
+  OpenAITranscriptionOptions parse(Object? json) {
+    return OpenAITranscriptionOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'OpenAITranscriptionOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'version': $Schema.string(),
+            'language': $Schema.string(),
+            'prompt': $Schema.string(),
+            'temperature': $Schema.number(minimum: 0.0, maximum: 1.0),
+            'responseFormat': $Schema.string(
+              enumValues: ['json', 'text', 'srt', 'verbose_json', 'vtt'],
+            ),
+            'timestampGranularities': $Schema.list(items: $Schema.string()),
+            'chunkingStrategy': $Schema.any(),
+            'include': $Schema.list(items: $Schema.string()),
+            'translate': $Schema.boolean(),
+          },
+        )
+        .value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:genkit/genkit.dart';
@@ -282,6 +283,88 @@ void main() {
       expect(result.usage?.inputTokens, greaterThan(0));
       expect(result.usage?.outputTokens, greaterThan(0));
       expect(result.usage?.totalTokens, greaterThan(0));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('generates speech with gpt-4o-mini-tts', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final response = await ai.generate(
+        model: openAI.speechModel('gpt-4o-mini-tts'),
+        prompt: 'Genkit is an amazing AI framework.',
+        config: OpenAISpeechOptions(
+          voice: 'sage',
+          instructions: 'Speak in a calm, warm tone.',
+        ),
+      );
+
+      final media = response.media;
+      expect(media, isNotNull);
+      expect(media!.contentType, 'audio/mpeg');
+      expect(media.url, startsWith('data:audio/mpeg;base64,'));
+
+      final bytes = base64Decode(media.url.split(',').last);
+      expect(bytes, isNotEmpty);
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('gpt-4o-mini-tts tolerates speed being set', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // gpt-4o-mini-tts rejects `speed`, so the plugin strips it. This guards
+      // that assumption from both directions: if OpenAI starts accepting the
+      // field, dropping it silently discards a caller's setting; if it still
+      // rejects it, a regression that stopped stripping would 400 here.
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final response = await ai.generate(
+        model: openAI.speechModel('gpt-4o-mini-tts'),
+        prompt: 'Speed should be ignored for this model.',
+        config: OpenAISpeechOptions(voice: 'sage', speed: 1.5),
+      );
+
+      expect(response.media, isNotNull);
+      expect(base64Decode(response.media!.url.split(',').last), isNotEmpty);
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('responseFormat wav returns real WAV bytes', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // contentType is derived from the requested format rather than from the
+      // response, so this checks the bytes really are what we label them.
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final response = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Genkit Dart now speaks.',
+        config: OpenAISpeechOptions(
+          voice: 'nova',
+          responseFormat: 'wav',
+          speed: 1.1,
+        ),
+      );
+
+      final media = response.media;
+      expect(media, isNotNull);
+      expect(media!.contentType, 'audio/wav');
+
+      final bytes = base64Decode(media.url.split(',').last);
+      expect(bytes.length, greaterThan(12));
+      // RIFF....WAVE container magic.
+      expect(String.fromCharCodes(bytes.sublist(0, 4)), 'RIFF');
+      expect(String.fromCharCodes(bytes.sublist(8, 12)), 'WAVE');
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
   });
 }

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -366,6 +366,175 @@ void main() {
       expect(String.fromCharCodes(bytes.sublist(0, 4)), 'RIFF');
       expect(String.fromCharCodes(bytes.sublist(8, 12)), 'WAVE');
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('speech round trip: tts-1 then whisper-1', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // No audio fixtures live in this repo, so the transcription input is
+      // generated on the fly by the speech model.
+      const sentence = 'The quick brown fox jumps over the lazy dog.';
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: sentence,
+        config: OpenAISpeechOptions(voice: 'nova'),
+      );
+      expect(spoken.media, isNotNull);
+
+      final heard = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [MediaPart(media: spoken.media!)],
+        config: OpenAITranscriptionOptions(language: 'en'),
+      );
+
+      expect(heard.text.toLowerCase(), contains('quick brown fox'));
+      expect(heard.text.toLowerCase(), contains('lazy dog'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('whisper-1 translates non-English audio to English', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'El zorro marron rapido salta sobre el perro perezoso.',
+        config: OpenAISpeechOptions(voice: 'nova'),
+      );
+
+      final translated = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [MediaPart(media: spoken.media!)],
+        config: OpenAITranscriptionOptions(translate: true),
+      );
+
+      expect(translated.text.toLowerCase(), contains('fox'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('srt response format returns subtitle markup', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // The SDK path could not do this at all: its create() always
+      // JSON-decodes the body.
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Genkit Dart now listens.',
+      );
+
+      final subtitles = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [MediaPart(media: spoken.media!)],
+        config: OpenAITranscriptionOptions(responseFormat: 'srt'),
+      );
+
+      expect(subtitles.text, contains('-->'));
+      expect(subtitles.text.trim(), startsWith('1'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('verbose_json accepts repeated timestamp granularities', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // timestamp_granularities is sent as repeated form fields. No mock can
+      // prove OpenAI accepts that encoding, so it is checked here.
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Genkit Dart now listens.',
+      );
+
+      final verbose = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [MediaPart(media: spoken.media!)],
+        config: OpenAITranscriptionOptions(
+          responseFormat: 'verbose_json',
+          timestampGranularities: ['word', 'segment'],
+        ),
+      );
+
+      expect(verbose.text.toLowerCase(), contains('listens'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('gpt-4o-transcribe accepts chunking strategy and include', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // chunking_strategy and include[] are encoded by hand as form fields,
+      // the same risk class as timestamp_granularities. Only the live API can
+      // confirm the encoding. This is also the only live coverage of the
+      // gpt-4o-transcribe family, whose constraints differ from whisper-1.
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Genkit Dart handles long audio.',
+      );
+
+      final heard = await ai.generate(
+        model: openAI.transcriptionModel('gpt-4o-transcribe'),
+        promptParts: [MediaPart(media: spoken.media!)],
+        config: OpenAITranscriptionOptions(
+          chunkingStrategy: 'auto',
+          include: ['logprobs'],
+        ),
+      );
+
+      expect(heard.text.toLowerCase(), contains('long audio'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('an object chunking strategy is accepted', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // The object form is JSON-encoded into the form field; verifies the
+      // server parses it rather than treating it as a literal string.
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Server side chunking works.',
+      );
+
+      final heard = await ai.generate(
+        model: openAI.transcriptionModel('gpt-4o-mini-transcribe'),
+        promptParts: [MediaPart(media: spoken.media!)],
+        config: OpenAITranscriptionOptions(
+          chunkingStrategy: {
+            'type': 'server_vad',
+            'prefix_padding_ms': 300,
+            'silence_duration_ms': 400,
+            'threshold': 0.5,
+          },
+        ),
+      );
+
+      expect(heard.text.toLowerCase(), contains('chunking'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
   });
 }
 

--- a/packages/genkit_openai/test/openai_plugin_speech_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_speech_test.dart
@@ -1,0 +1,418 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:genkit_openai/src/speech.dart'
+    show isSpeechModel, speechModelInfo, speechModelRejectsSpeed;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Audio bytes the fake `/audio/speech` endpoint hands back. Kept tiny and
+/// fixed so tests can assert on the exact base64 in the resulting data URL.
+final Uint8List fakeAudio = Uint8List.fromList([1, 2, 3, 4]);
+
+/// Captures every `/audio/speech` request body the plugin puts on the wire and
+/// replies with raw audio bytes, so tests assert on the actual JSON sent
+/// rather than on plugin internals.
+MockClient speechWireClient(
+  List<Map<String, dynamic>> capturedBodies, {
+  String contentType = 'audio/mpeg',
+}) {
+  return MockClient((request) async {
+    if (request.url.path.endsWith('/models')) {
+      return http.Response(
+        jsonEncode({
+          'object': 'list',
+          'data': [
+            {
+              'id': 'gpt-4o',
+              'object': 'model',
+              'created': 0,
+              'owned_by': 'openai',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (request.url.path.endsWith('/audio/speech')) {
+      capturedBodies.add(
+        (jsonDecode(request.body) as Map).cast<String, dynamic>(),
+      );
+      return http.Response.bytes(
+        fakeAudio,
+        200,
+        headers: {'content-type': contentType},
+      );
+    }
+    return http.Response('not found', 404);
+  });
+}
+
+Genkit speechGenkit(List<Map<String, dynamic>> captured) => Genkit(
+  plugins: [openAI(apiKey: 'test-key', httpClient: speechWireClient(captured))],
+);
+
+void main() {
+  group('speech model classification', () {
+    test('recognizes text-to-speech models', () {
+      expect(isSpeechModel('tts-1'), isTrue);
+      expect(isSpeechModel('tts-1-hd'), isTrue);
+      expect(isSpeechModel('gpt-4o-mini-tts'), isTrue);
+    });
+
+    test('does not claim other audio models', () {
+      // These all classify as 'audio' too, so the tts check is what keeps
+      // transcription and realtime models out of the speech path.
+      expect(getModelType('whisper-1'), 'audio');
+      expect(isSpeechModel('whisper-1'), isFalse);
+      expect(isSpeechModel('gpt-4o-transcribe'), isFalse);
+      expect(isSpeechModel('gpt-4o-realtime-preview'), isFalse);
+      expect(isSpeechModel('gpt-audio-1.5'), isFalse);
+      expect(isSpeechModel('gpt-4o'), isFalse);
+    });
+
+    test('only gpt-4o-mini-tts rejects speed', () {
+      expect(speechModelRejectsSpeed('gpt-4o-mini-tts'), isTrue);
+      expect(speechModelRejectsSpeed('tts-1'), isFalse);
+      expect(speechModelRejectsSpeed('tts-1-hd'), isFalse);
+    });
+
+    test('advertises media output and nothing conversational', () {
+      final supports = speechModelInfo('tts-1').supports!;
+      expect(supports['output'], ['media']);
+      expect(supports['media'], isFalse);
+      expect(supports['multiturn'], isFalse);
+      expect(supports['systemRole'], isFalse);
+      expect(supports['tools'], isFalse);
+    });
+  });
+
+  group('speech wire-level request assembly', () {
+    test('sends only model, input and voice by default', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      await ai.generate(model: openAI.speechModel('tts-1'), prompt: 'Hello');
+
+      expect(captured, hasLength(1));
+      expect(captured.single, {
+        'model': 'tts-1',
+        'input': 'Hello',
+        'voice': 'alloy',
+      });
+
+      await ai.shutdown();
+    });
+
+    test('voice and instructions reach the wire', () async {
+      // The SDK's SpeechRequest caps voice at six legacy values and has no
+      // instructions field at all; this asserts the toJson override that
+      // works around both.
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      await ai.generate(
+        model: openAI.speechModel('gpt-4o-mini-tts'),
+        prompt: 'Hello',
+        config: OpenAISpeechOptions(
+          voice: 'sage',
+          instructions: 'Speak in a calm, warm tone.',
+        ),
+      );
+
+      final body = captured.single;
+      expect(body['voice'], 'sage');
+      expect(body['instructions'], 'Speak in a calm, warm tone.');
+
+      await ai.shutdown();
+    });
+
+    test('speed is sent for tts-1 but dropped for gpt-4o-mini-tts', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Hello',
+        config: OpenAISpeechOptions(speed: 1.5),
+      );
+      expect(captured.single['speed'], 1.5);
+
+      captured.clear();
+      await ai.generate(
+        model: openAI.speechModel('gpt-4o-mini-tts'),
+        prompt: 'Hello',
+        config: OpenAISpeechOptions(speed: 1.5),
+      );
+      expect(
+        captured.single.containsKey('speed'),
+        isFalse,
+        reason: 'gpt-4o-mini-tts rejects the speed parameter outright',
+      );
+
+      await ai.shutdown();
+    });
+
+    test('version overrides the model id on the wire', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Hello',
+        config: OpenAISpeechOptions(version: 'tts-1-1106'),
+      );
+
+      expect(captured.single['model'], 'tts-1-1106');
+
+      await ai.shutdown();
+    });
+
+    test('response_format is omitted unless requested', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      await ai.generate(model: openAI.speechModel('tts-1'), prompt: 'Hello');
+      expect(captured.single.containsKey('response_format'), isFalse);
+
+      captured.clear();
+      await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Hello',
+        config: OpenAISpeechOptions(responseFormat: 'wav'),
+      );
+      expect(captured.single['response_format'], 'wav');
+
+      await ai.shutdown();
+    });
+  });
+
+  group('speech response conversion', () {
+    test('returns a single audio media part as a base64 data URL', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      final response = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Hello',
+      );
+
+      final content = response.message!.content;
+      expect(content, hasLength(1));
+      final media = response.media!;
+      expect(media.contentType, 'audio/mpeg');
+      expect(media.url, 'data:audio/mpeg;base64,${base64Encode(fakeAudio)}');
+      expect(media.url, 'data:audio/mpeg;base64,AQIDBA==');
+      expect(response.finishReason, FinishReason.stop);
+
+      await ai.shutdown();
+    });
+
+    test('content type follows the requested response format', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      final response = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: 'Hello',
+        config: OpenAISpeechOptions(responseFormat: 'wav'),
+      );
+
+      expect(response.media!.contentType, 'audio/wav');
+      expect(response.media!.url, startsWith('data:audio/wav;base64,'));
+
+      await ai.shutdown();
+    });
+  });
+
+  group('speech model registration', () {
+    test('known speech models register even when /models omits them', () async {
+      // The fake /models endpoint only advertises gpt-4o, mirroring the fact
+      // that OpenAI does not reliably list TTS models.
+      final ai = speechGenkit([]);
+
+      final actions = await ai.registry.listActions();
+      final names = actions
+          .where((a) => a.actionType == .model)
+          .map((a) => a.name)
+          .toSet();
+
+      expect(
+        names,
+        containsAll([
+          'openai/tts-1',
+          'openai/tts-1-hd',
+          'openai/gpt-4o-mini-tts',
+        ]),
+      );
+
+      await ai.shutdown();
+    });
+
+    test('registered speech models carry media-output metadata', () async {
+      final ai = speechGenkit([]);
+
+      final action = await ai.registry.lookupAction(
+        .model,
+        'openai/gpt-4o-mini-tts',
+      );
+
+      expect(action, isNotNull);
+      final info = (action!.metadata['model'] as Map).cast<String, dynamic>();
+      final supports = (info['supports'] as Map).cast<String, dynamic>();
+      expect(supports['output'], ['media']);
+      expect(supports['multiturn'], isFalse);
+
+      await ai.shutdown();
+    });
+
+    test('an unlisted tts model still resolves as a speech model', () async {
+      // resolve() must route by name, so a future model works without a
+      // plugin release.
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      final response = await ai.generate(
+        model: openAI.speechModel('tts-9-ultra'),
+        prompt: 'Hello',
+      );
+
+      expect(captured.single['model'], 'tts-9-ultra');
+      expect(response.media, isNotNull);
+
+      await ai.shutdown();
+    });
+
+    test('chat models are untouched by speech routing', () async {
+      final ai = speechGenkit([]);
+
+      final action = await ai.registry.lookupAction(.model, 'openai/gpt-4o');
+      expect(action, isNotNull);
+      final info = (action!.metadata['model'] as Map).cast<String, dynamic>();
+      final supports = (info['supports'] as Map).cast<String, dynamic>();
+      expect(supports['multiturn'], isTrue);
+      expect(supports.containsKey('output'), isFalse);
+
+      await ai.shutdown();
+    });
+  });
+
+  group('custom speech models from compatible providers', () {
+    test('a custom model declaring media output is routed to speech', () async {
+      // A provider whose speech model is not named '*tts*'. The declared
+      // supports.output is the only signal that it generates audio.
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'voicecorp',
+            apiKey: 'test-key',
+            baseUrl: 'https://api.voicecorp.test/v1',
+            httpClient: speechWireClient(captured),
+            models: [
+              CustomModelDefinition(
+                name: 'voicebox-1',
+                info: ModelInfo(
+                  label: 'Voicebox 1',
+                  supports: {
+                    'output': ['media'],
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final response = await ai.generate(
+        model: openAI.speechModel('voicebox-1', namespace: 'voicecorp'),
+        prompt: 'Hello',
+        config: OpenAISpeechOptions(voice: 'sage'),
+      );
+
+      expect(
+        captured,
+        hasLength(1),
+        reason: 'must hit /audio/speech, not /chat/completions',
+      );
+      expect(captured.single['model'], 'voicebox-1');
+      expect(response.media, isNotNull);
+
+      await ai.shutdown();
+    });
+
+    test('a custom text model is still routed to chat', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'textcorp',
+            apiKey: 'test-key',
+            baseUrl: 'https://api.textcorp.test/v1',
+            httpClient: speechWireClient(captured),
+            models: [
+              CustomModelDefinition(
+                name: 'chatbox-1',
+                info: ModelInfo(
+                  label: 'Chatbox 1',
+                  supports: {
+                    'output': ['text'],
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final action = await ai.registry.lookupAction(
+        .model,
+        'textcorp/chatbox-1',
+      );
+      final info = (action!.metadata['model'] as Map).cast<String, dynamic>();
+      expect((info['supports'] as Map)['output'], ['text']);
+      expect(captured, isEmpty);
+
+      await ai.shutdown();
+    });
+  });
+
+  group('speech input validation', () {
+    test('rejects a blank prompt before hitting the network', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = speechGenkit(captured);
+
+      await expectLater(
+        ai.generate(model: openAI.speechModel('tts-1'), prompt: '   '),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+      expect(captured, isEmpty);
+
+      await ai.shutdown();
+    });
+  });
+}

--- a/packages/genkit_openai/test/openai_plugin_transcription_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_transcription_test.dart
@@ -1,0 +1,688 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:genkit_openai/src/transcription.dart'
+    show
+        audioFilenameFor,
+        declaresMediaInput,
+        isTranscriptionModel,
+        supportsTranslation,
+        transcriptionModelInfo;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// One captured multipart upload.
+class CapturedUpload {
+  CapturedUpload({
+    required this.path,
+    required this.fields,
+    required this.repeated,
+    required this.filename,
+    required this.fileBytes,
+    required this.headers,
+  });
+
+  final String path;
+
+  /// HTTP headers the plugin put on the upload.
+  final Map<String, String> headers;
+
+  /// Single-valued form fields.
+  final Map<String, String> fields;
+
+  /// Fields that appeared more than once, e.g. `timestamp_granularities[]`.
+  final Map<String, List<String>> repeated;
+
+  final String? filename;
+  final List<int> fileBytes;
+}
+
+/// Parses a `multipart/form-data` body into its parts.
+///
+/// Hand-rolled because the plugin builds the upload itself rather than going
+/// through the SDK, so the tests need to see exactly what went on the wire.
+CapturedUpload parseMultipart(http.Request request) {
+  final contentType = request.headers['content-type'] ?? '';
+  final boundary = RegExp(r'boundary=(.*)$').firstMatch(contentType)!.group(1)!;
+  final body = latin1.decode(request.bodyBytes);
+
+  final fields = <String, String>{};
+  final repeated = <String, List<String>>{};
+  String? filename;
+  var fileBytes = <int>[];
+
+  for (final section in body.split('--$boundary')) {
+    final split = section.indexOf('\r\n\r\n');
+    if (split == -1) continue;
+    final headers = section.substring(0, split);
+    final nameMatch = RegExp('name="([^"]*)"').firstMatch(headers);
+    if (nameMatch == null) continue;
+
+    final name = nameMatch.group(1)!;
+    final value = section
+        .substring(split + 4)
+        .replaceFirst(RegExp(r'\r\n$'), '');
+
+    final fileMatch = RegExp('filename="([^"]*)"').firstMatch(headers);
+    if (fileMatch != null) {
+      filename = fileMatch.group(1);
+      fileBytes = latin1.encode(value);
+      continue;
+    }
+
+    if (fields.containsKey(name)) {
+      repeated.putIfAbsent(name, () => [fields[name]!]).add(value);
+    } else {
+      fields[name] = value;
+    }
+  }
+
+  return CapturedUpload(
+    path: request.url.path,
+    fields: fields,
+    repeated: repeated,
+    filename: filename,
+    fileBytes: fileBytes,
+    headers: request.headers,
+  );
+}
+
+/// Serves canned transcription responses and captures each upload.
+MockClient transcriptionWireClient(
+  List<CapturedUpload> captured, {
+  String body = '{"text":"The quick brown fox."}',
+  int status = 200,
+}) {
+  return MockClient((request) async {
+    if (request.url.path.endsWith('/models')) {
+      return http.Response(
+        jsonEncode({
+          'object': 'list',
+          'data': [
+            {
+              'id': 'gpt-4o',
+              'object': 'model',
+              'created': 0,
+              'owned_by': 'openai',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (request.url.path.endsWith('/audio/transcriptions') ||
+        request.url.path.endsWith('/audio/translations')) {
+      captured.add(parseMultipart(request));
+      return http.Response(body, status);
+    }
+    return http.Response('not found', 404);
+  });
+}
+
+Genkit transcriptionGenkit(
+  List<CapturedUpload> captured, {
+  String body = '{"text":"The quick brown fox."}',
+  int status = 200,
+}) => Genkit(
+  plugins: [
+    openAI(
+      apiKey: 'test-key',
+      httpClient: transcriptionWireClient(captured, body: body, status: status),
+    ),
+  ],
+);
+
+/// A short audio payload as callers would supply it.
+MediaPart audioPart({String contentType = 'audio/mpeg'}) => MediaPart(
+  media: Media(
+    contentType: contentType,
+    url: 'data:$contentType;base64,${base64Encode([1, 2, 3, 4])}',
+  ),
+);
+
+void main() {
+  group('transcription model classification', () {
+    test('recognizes speech-to-text models', () {
+      expect(isTranscriptionModel('whisper-1'), isTrue);
+      expect(isTranscriptionModel('gpt-4o-transcribe'), isTrue);
+      expect(isTranscriptionModel('gpt-4o-mini-transcribe'), isTrue);
+    });
+
+    test('leaves other audio models alone', () {
+      // All of these are also getModelType() == 'audio'.
+      expect(isTranscriptionModel('tts-1'), isFalse);
+      expect(isTranscriptionModel('gpt-4o-mini-tts'), isFalse);
+      expect(isTranscriptionModel('gpt-4o-realtime-preview'), isFalse);
+      expect(isTranscriptionModel('gpt-4o-audio-preview'), isFalse);
+      expect(isTranscriptionModel('gpt-4o'), isFalse);
+    });
+
+    test('only whisper can translate', () {
+      expect(supportsTranslation('whisper-1'), isTrue);
+      expect(supportsTranslation('gpt-4o-transcribe'), isFalse);
+    });
+
+    test('declaresMediaInput reads the supports map', () {
+      expect(declaresMediaInput(ModelInfo(supports: {'media': true})), isTrue);
+      expect(
+        declaresMediaInput(ModelInfo(supports: {'media': false})),
+        isFalse,
+      );
+      expect(declaresMediaInput(ModelInfo()), isFalse);
+      expect(declaresMediaInput(null), isFalse);
+    });
+
+    test('advertises media input and text output', () {
+      final supports = transcriptionModelInfo('whisper-1').supports!;
+      expect(supports['media'], isTrue);
+      expect(supports['output'], ['text', 'json']);
+      expect(supports['multiturn'], isFalse);
+    });
+
+    test('maps audio mime types to usable filenames', () {
+      // OpenAI reads the codec off this filename, so a generic
+      // type/subtype split would break x-m4a.
+      expect(audioFilenameFor('audio/mpeg'), 'input.mp3');
+      expect(audioFilenameFor('audio/wav'), 'input.wav');
+      expect(audioFilenameFor('audio/x-m4a'), 'input.m4a');
+      expect(audioFilenameFor('audio/webm'), 'input.webm');
+      expect(audioFilenameFor('audio/flac'), 'input.flac');
+      expect(audioFilenameFor('audio/unknown'), 'input');
+    });
+  });
+
+  group('transcription wire-level request assembly', () {
+    test('uploads the audio with model and response_format', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+      );
+
+      expect(captured, hasLength(1));
+      final upload = captured.single;
+      expect(upload.path, endsWith('/audio/transcriptions'));
+      expect(upload.fields['model'], 'whisper-1');
+      expect(upload.fields['response_format'], 'json');
+      expect(upload.filename, 'input.mp3');
+      expect(upload.fileBytes, [1, 2, 3, 4]);
+      // Nothing the caller did not ask for.
+      expect(upload.fields.containsKey('language'), isFalse);
+      expect(upload.fields.containsKey('temperature'), isFalse);
+      expect(upload.fields.containsKey('prompt'), isFalse);
+
+      await ai.shutdown();
+    });
+
+    test('forwards language, temperature and chunking strategy', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('gpt-4o-transcribe'),
+        promptParts: [audioPart()],
+        config: OpenAITranscriptionOptions(
+          language: 'es',
+          temperature: 0.2,
+          chunkingStrategy: 'auto',
+          include: ['logprobs'],
+        ),
+      );
+
+      final upload = captured.single;
+      expect(upload.fields['language'], 'es');
+      expect(upload.fields['temperature'], '0.2');
+      expect(upload.fields['chunking_strategy'], 'auto');
+      expect(upload.fields['include[]'], 'logprobs');
+
+      await ai.shutdown();
+    });
+
+    test('encodes an object chunking strategy as JSON', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('gpt-4o-transcribe'),
+        promptParts: [audioPart()],
+        config: OpenAITranscriptionOptions(
+          chunkingStrategy: {'type': 'server_vad', 'threshold': 0.5},
+        ),
+      );
+
+      expect(jsonDecode(captured.single.fields['chunking_strategy']!), {
+        'type': 'server_vad',
+        'threshold': 0.5,
+      });
+
+      await ai.shutdown();
+    });
+
+    test('sends repeated timestamp granularity fields', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+        config: OpenAITranscriptionOptions(
+          responseFormat: 'verbose_json',
+          timestampGranularities: ['word', 'segment'],
+        ),
+      );
+
+      final upload = captured.single;
+      expect(upload.repeated['timestamp_granularities[]'], ['word', 'segment']);
+
+      await ai.shutdown();
+    });
+
+    test('sends multiple include values as repeated fields', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('gpt-4o-transcribe'),
+        promptParts: [audioPart()],
+        config: OpenAITranscriptionOptions(include: ['logprobs', 'usage']),
+      );
+
+      expect(captured.single.repeated['include[]'], ['logprobs', 'usage']);
+
+      await ai.shutdown();
+    });
+
+    test('uses the message text as the decoding prompt', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [
+          TextPart(text: 'Genkit, Dart, Firebase'),
+          audioPart(),
+        ],
+      );
+
+      expect(captured.single.fields['prompt'], 'Genkit, Dart, Firebase');
+
+      await ai.shutdown();
+    });
+
+    test('an explicit prompt option wins over the message text', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [
+          TextPart(text: 'ignored'),
+          audioPart(),
+        ],
+        config: OpenAITranscriptionOptions(prompt: 'Genkit'),
+      );
+
+      expect(captured.single.fields['prompt'], 'Genkit');
+
+      await ai.shutdown();
+    });
+
+    test('version overrides the model id', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+        config: OpenAITranscriptionOptions(version: 'whisper-2'),
+      );
+
+      expect(captured.single.fields['model'], 'whisper-2');
+
+      await ai.shutdown();
+    });
+  });
+
+  group('translation', () {
+    test('translate routes whisper to the translations endpoint', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+        config: OpenAITranscriptionOptions(translate: true, language: 'es'),
+      );
+
+      final upload = captured.single;
+      expect(upload.path, endsWith('/audio/translations'));
+      expect(
+        upload.fields.containsKey('language'),
+        isFalse,
+        reason: 'the translations endpoint rejects language',
+      );
+
+      await ai.shutdown();
+    });
+
+    test(
+      'translate is ignored by models without a translations endpoint',
+      () async {
+        final captured = <CapturedUpload>[];
+        final ai = transcriptionGenkit(captured);
+
+        await ai.generate(
+          model: openAI.transcriptionModel('gpt-4o-transcribe'),
+          promptParts: [audioPart()],
+          config: OpenAITranscriptionOptions(translate: true),
+        );
+
+        expect(captured.single.path, endsWith('/audio/transcriptions'));
+
+        await ai.shutdown();
+      },
+    );
+  });
+
+  group('transcription request headers', () {
+    test('authorization and custom headers reach the upload', () async {
+      // Chat and TTS get header handling from the SDK; the multipart upload
+      // is built by hand, so it needs its own coverage.
+      final captured = <CapturedUpload>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            apiKey: 'test-key',
+            headers: {'X-Custom-Header': 'value', 'X-Trace': 'abc'},
+            httpClient: transcriptionWireClient(captured),
+          ),
+        ],
+      );
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+      );
+
+      final headers = captured.single.headers;
+      expect(headers['authorization'], 'Bearer test-key');
+      expect(headers['x-custom-header'], 'value');
+      expect(headers['x-trace'], 'abc');
+
+      await ai.shutdown();
+    });
+
+    test('an async apiKeyProvider is honored', () async {
+      final captured = <CapturedUpload>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            apiKeyProvider: () async => 'provided-key',
+            httpClient: transcriptionWireClient(captured),
+          ),
+        ],
+      );
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+      );
+
+      expect(captured.single.headers['authorization'], 'Bearer provided-key');
+
+      await ai.shutdown();
+    });
+
+    test('a missing API key uploads nothing', () async {
+      // The key is checked during plugin init, so this fails before the
+      // transcription path runs. What matters here is that no audio leaves
+      // the process.
+      final captured = <CapturedUpload>[];
+      final ai = Genkit(
+        plugins: [openAI(httpClient: transcriptionWireClient(captured))],
+      );
+
+      await expectLater(
+        ai.generate(
+          model: openAI.transcriptionModel('whisper-1'),
+          promptParts: [audioPart()],
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.toString(),
+            'message',
+            contains('API key is required'),
+          ),
+        ),
+      );
+      expect(captured, isEmpty);
+
+      await ai.shutdown();
+    });
+  });
+
+  group('transcription response conversion', () {
+    test('unwraps a json transcript', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      final response = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+      );
+
+      expect(response.text, 'The quick brown fox.');
+      expect(response.finishReason, FinishReason.stop);
+
+      await ai.shutdown();
+    });
+
+    test('passes srt markup through verbatim', () async {
+      // This is the case the SDK path could not serve at all: its create()
+      // always JSON-decodes the body.
+      const srt = '1\n00:00:00,000 --> 00:00:02,000\nThe quick brown fox.\n';
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured, body: srt);
+
+      final response = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+        config: OpenAITranscriptionOptions(responseFormat: 'srt'),
+      );
+
+      expect(captured.single.fields['response_format'], 'srt');
+      expect(response.text, srt);
+
+      await ai.shutdown();
+    });
+
+    test('surfaces API errors with a mapped status', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(
+        captured,
+        body: '{"error":{"message":"bad audio"}}',
+        status: 400,
+      );
+
+      await expectLater(
+        ai.generate(
+          model: openAI.transcriptionModel('whisper-1'),
+          promptParts: [audioPart()],
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+
+      await ai.shutdown();
+    });
+  });
+
+  group('transcription input validation', () {
+    test('rejects a request with no audio', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await expectLater(
+        ai.generate(
+          model: openAI.transcriptionModel('whisper-1'),
+          prompt: 'no audio here',
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+      expect(captured, isEmpty);
+
+      await ai.shutdown();
+    });
+
+    test('rejects a non-data audio URL', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await expectLater(
+        ai.generate(
+          model: openAI.transcriptionModel('whisper-1'),
+          promptParts: [
+            MediaPart(
+              media: Media(
+                contentType: 'audio/mpeg',
+                url: 'https://example.com/audio.mp3',
+              ),
+            ),
+          ],
+        ),
+        throwsA(isA<GenkitException>()),
+      );
+      expect(captured, isEmpty);
+
+      await ai.shutdown();
+    });
+
+    test('rejects a response format that cannot satisfy json output', () async {
+      final captured = <CapturedUpload>[];
+      final ai = transcriptionGenkit(captured);
+
+      await expectLater(
+        ai.generate(
+          model: openAI.transcriptionModel('whisper-1'),
+          promptParts: [audioPart()],
+          config: OpenAITranscriptionOptions(responseFormat: 'srt'),
+          outputFormat: 'json',
+        ),
+        throwsA(isA<GenkitException>()),
+      );
+      expect(captured, isEmpty);
+
+      await ai.shutdown();
+    });
+  });
+
+  group('transcription model registration', () {
+    test('known transcription models are registered', () async {
+      final ai = transcriptionGenkit([]);
+
+      final actions = await ai.registry.listActions();
+      final names = actions
+          .where((a) => a.actionType == .model)
+          .map((a) => a.name)
+          .toSet();
+
+      expect(
+        names,
+        containsAll([
+          'openai/whisper-1',
+          'openai/gpt-4o-transcribe',
+          'openai/gpt-4o-mini-transcribe',
+        ]),
+      );
+
+      await ai.shutdown();
+    });
+
+    test('registered models carry media-input metadata', () async {
+      final ai = transcriptionGenkit([]);
+
+      final action = await ai.registry.lookupAction(.model, 'openai/whisper-1');
+      final info = (action!.metadata['model'] as Map).cast<String, dynamic>();
+      final supports = (info['supports'] as Map).cast<String, dynamic>();
+      expect(supports['media'], isTrue);
+      expect(supports['output'], ['text', 'json']);
+
+      await ai.shutdown();
+    });
+
+    test(
+      'a custom model declaring media input is routed to transcription',
+      () async {
+        final captured = <CapturedUpload>[];
+        final ai = Genkit(
+          plugins: [
+            openAI(
+              name: 'earcorp',
+              apiKey: 'test-key',
+              baseUrl: 'https://api.earcorp.test/v1',
+              httpClient: transcriptionWireClient(captured),
+              models: [
+                CustomModelDefinition(
+                  name: 'earbox-1',
+                  info: ModelInfo(supports: {'media': true}),
+                ),
+              ],
+            ),
+          ],
+        );
+
+        final response = await ai.generate(
+          model: openAI.transcriptionModel('earbox-1', namespace: 'earcorp'),
+          promptParts: [audioPart()],
+        );
+
+        expect(captured.single.path, endsWith('/audio/transcriptions'));
+        expect(response.text, 'The quick brown fox.');
+
+        await ai.shutdown();
+      },
+    );
+
+    test('tts models still route to speech, not transcription', () async {
+      final ai = transcriptionGenkit([]);
+
+      final action = await ai.registry.lookupAction(.model, 'openai/tts-1');
+      final info = (action!.metadata['model'] as Map).cast<String, dynamic>();
+      final supports = (info['supports'] as Map).cast<String, dynamic>();
+      expect(supports['output'], ['media']);
+      expect(supports['media'], isFalse);
+
+      await ai.shutdown();
+    });
+  });
+}

--- a/packages/genkit_openai/test/openai_plugin_transcription_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_transcription_test.dart
@@ -431,6 +431,36 @@ void main() {
       await ai.shutdown();
     });
 
+    test('a custom content-type cannot break the multipart boundary', () async {
+      // MultipartRequest.finalize() sets content-type (with the boundary)
+      // after any headers we add, and BaseRequest.headers is case-insensitive,
+      // so a plugin-level content-type is replaced rather than honored.
+      final captured = <CapturedUpload>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            apiKey: 'test-key',
+            headers: {'Content-Type': 'application/json'},
+            httpClient: transcriptionWireClient(captured),
+          ),
+        ],
+      );
+
+      await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [audioPart()],
+      );
+
+      final upload = captured.single;
+      expect(upload.headers['content-type'], startsWith('multipart/form-data'));
+      expect(upload.headers['content-type'], contains('boundary='));
+      // The upload still parsed, which it could not have without a boundary.
+      expect(upload.fields['model'], 'whisper-1');
+      expect(upload.filename, 'input.mp3');
+
+      await ai.shutdown();
+    });
+
     test('an async apiKeyProvider is honored', () async {
       final captured = <CapturedUpload>[];
       final ai = Genkit(

--- a/testapps/openai_sample/lib/speech_to_text.dart
+++ b/testapps/openai_sample/lib/speech_to_text.dart
@@ -1,0 +1,122 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+
+/// Defines a flow that transcribes audio supplied as a base64 `data:` URL.
+///
+/// Audio goes in through `promptParts` as a [MediaPart]; the transcript comes
+/// back as ordinary response text.
+Flow<String, String, void, void> defineTranscribeFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'transcribeAudio',
+    inputSchema: .string(),
+    outputSchema: .string(),
+    fn: (dataUrl, _) async {
+      if (!dataUrl.startsWith('data:')) {
+        throw Exception(
+          'Expected a base64 data URL, e.g. data:audio/mpeg;base64,...',
+        );
+      }
+
+      final response = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [
+          MediaPart(
+            media: Media(
+              contentType: Uri.parse(dataUrl).data?.mimeType,
+              url: dataUrl,
+            ),
+          ),
+        ],
+        config: OpenAITranscriptionOptions(language: 'en'),
+      );
+
+      return response.text;
+    },
+  );
+}
+
+/// Defines a flow that speaks a sentence and then transcribes it back.
+///
+/// Self-contained: it needs no audio file, which also makes it the easiest way
+/// to exercise the transcription path from the Dev UI.
+Flow<String, String, void, void> defineSpeechRoundTripFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'speechRoundTrip',
+    inputSchema: .string(
+      defaultValue: 'The quick brown fox jumps over the lazy dog.',
+    ),
+    outputSchema: .string(),
+    fn: (sentence, _) async {
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: sentence,
+        config: OpenAISpeechOptions(voice: 'nova'),
+      );
+
+      final audio = spoken.media;
+      if (audio == null) {
+        throw Exception('No audio generated');
+      }
+
+      final heard = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [MediaPart(media: audio)],
+        config: OpenAITranscriptionOptions(language: 'en'),
+      );
+
+      return heard.text;
+    },
+  );
+}
+
+/// Defines a flow that returns SRT subtitles for spoken audio.
+///
+/// `srt` and `vtt` return subtitle markup rather than a JSON object; the
+/// plugin hands the body back untouched as the response text.
+Flow<String, String, void, void> defineSubtitlesFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'subtitles',
+    inputSchema: .string(defaultValue: 'Genkit Dart now listens.'),
+    outputSchema: .string(),
+    fn: (sentence, _) async {
+      final spoken = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: sentence,
+      );
+
+      final subtitles = await ai.generate(
+        model: openAI.transcriptionModel('whisper-1'),
+        promptParts: [MediaPart(media: spoken.media!)],
+        config: OpenAITranscriptionOptions(responseFormat: 'srt'),
+      );
+
+      return subtitles.text;
+    },
+  );
+}
+
+void main() {
+  final ai = Genkit(
+    plugins: [openAI(apiKey: Platform.environment['OPENAI_API_KEY'])],
+  );
+
+  defineTranscribeFlow(ai);
+  defineSpeechRoundTripFlow(ai);
+  defineSubtitlesFlow(ai);
+}

--- a/testapps/openai_sample/lib/text_to_speech.dart
+++ b/testapps/openai_sample/lib/text_to_speech.dart
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+
+/// Defines a flow that turns text into speech with an OpenAI TTS model.
+///
+/// Returns a [Media] part whose `url` is a base64 `data:` URL holding the
+/// audio. Note `openAI.speechModel` rather than `openAI.model`: speech models
+/// take [OpenAISpeechOptions] and answer with audio instead of text.
+Flow<String, Media, void, void> defineTextToSpeechFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'textToSpeech',
+    inputSchema: .string(
+      defaultValue: 'Say that Genkit is an amazing AI framework',
+    ),
+    outputSchema: Media.$schema,
+    fn: (prompt, _) async {
+      final response = await ai.generate(
+        model: openAI.speechModel('gpt-4o-mini-tts'),
+        prompt: prompt,
+        config: OpenAISpeechOptions(
+          voice: 'sage',
+          instructions: 'Speak in a calm, warm tone.',
+        ),
+      );
+
+      final media = response.media;
+      if (media == null) {
+        throw Exception('No audio generated');
+      }
+      return media;
+    },
+  );
+}
+
+/// Defines a flow that renders speech as a WAV file with the classic `tts-1`
+/// model, showing `responseFormat` and `speed`.
+///
+/// `speed` is deliberately used here and not in [defineTextToSpeechFlow]:
+/// `gpt-4o-mini-tts` rejects it, so the plugin drops it for that model.
+Flow<String, Media, void, void> defineTextToSpeechWavFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'textToSpeechWav',
+    inputSchema: .string(defaultValue: 'Genkit Dart now speaks.'),
+    outputSchema: Media.$schema,
+    fn: (prompt, _) async {
+      final response = await ai.generate(
+        model: openAI.speechModel('tts-1'),
+        prompt: prompt,
+        config: OpenAISpeechOptions(
+          voice: 'nova',
+          responseFormat: 'wav',
+          speed: 1.1,
+        ),
+      );
+
+      final media = response.media;
+      if (media == null) {
+        throw Exception('No audio generated');
+      }
+      return media;
+    },
+  );
+}
+
+void main() {
+  final ai = Genkit(
+    plugins: [openAI(apiKey: Platform.environment['OPENAI_API_KEY'])],
+  );
+
+  defineTextToSpeechFlow(ai);
+  defineTextToSpeechWavFlow(ai);
+}


### PR DESCRIPTION
## Summary

Adds OpenAI speech-to-text to `genkit_openai`, the input-side counterpart to the
TTS support in #405. `whisper-1`, `gpt-4o-transcribe` and `gpt-4o-mini-transcribe`
were classified as `'audio'` by `getModelType()` but skipped or routed to chat by
every registration path, so audio could not be transcribed at all.

```dart
final response = await ai.generate(
  model: openAI.transcriptionModel('whisper-1'),
  promptParts: [MediaPart(media: recording)],
  config: OpenAITranscriptionOptions(language: 'en'),
);
print(response.text);
```

`whisper-1` also accepts `translate: true`, routing to `/audio/translations` for
English output from audio in any language.

> [!NOTE]
> Stacked on #405 — this PR targets `feat/openai-tts-support`, so its diff is STT
> only. Review #405 first. GitHub will retarget this to `main` once #405 merges.

## Why the request is hand-built

Unlike TTS, this path does not go through `openai_dart`. Two blockers:

- `TranscriptionRequest` has no `toJson()` and the multipart builder is private,
  so the `toJson()` subclass trick used for TTS is unavailable.
- `transcriptions.create()` unconditionally runs `jsonDecode(response.body)`, so
  `response_format: text|srt|vtt` throws a `FormatException` instead of returning
  subtitles.

Hand-building the upload also unlocks `chunking_strategy` (needed for long audio
on the `gpt-4o-transcribe` family), `include[]`, and a future `stream: true`.
Auth, error mapping and `baseUrl`/`headers` are resolved through the existing
`_resolveClientConfig()`, so behaviour matches the SDK paths.

## Parity with the JS plugin

Ports `compat-oai/src/audio.ts`, `src/openai/whisper.ts` and `src/translate.ts`.
Two deliberate differences: a blank `prompt` is omitted rather than sent as `''`,
and `response_format` defaults to `json` rather than `text`.

## Testing

29 unit/wire tests and 6 live tests (`skip`-gated on `OPENAI_API_KEY`).

`MockClient` never encodes a real multipart body, so the wiring was also checked
against a local `HttpServer`. Two things a mock would have missed:

- `audio/x-m4a` → `input.m4a` — a generic `split('/').last` would send `x-m4a`,
  which OpenAI rejects
- `timestamp_granularities[]` sent as genuinely repeated fields — the encoding
  `openai_dart` gets wrong with indexed `[$i]` keys, which its own source comment
  admits is unverified

Live tests cover TTS→STT round trip, Spanish→English translation, SRT subtitles
and `verbose_json` with timestamp granularities — all passing against the real
API. Two further tests exercising `chunking_strategy` (string and object form) on
the `gpt-4o-transcribe` family are included but have not yet been run.

No audio fixtures are committed — the live tests generate their input with `tts-1`.
