### PR TITLE
feat(genkit)!: pass request context to agent session-store operations

### DIFF
--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -165,6 +165,7 @@ void _requireStore(SessionStore? store, String operation, String agentName) {
 Future<String?> _abortSnapshotInStore(
   SessionStore store,
   String snapshotId,
+  Map<String, dynamic>? context,
 ) async {
   String? previousStatus;
   await store.saveSnapshot(snapshotId, (current) {
@@ -178,7 +179,7 @@ Future<String?> _abortSnapshotInStore(
 
     current.status = SnapshotStatus.aborted;
     return current;
-  });
+  }, context: context);
   return previousStatus;
 }
 
@@ -272,6 +273,7 @@ class SessionRunner<State> {
     this.inputCh, {
     SessionSnapshot? lastSnapshot,
     SessionStore? store,
+    this.context,
     this.cancel,
     this.onEndTurn,
     this.onDetach,
@@ -311,6 +313,9 @@ class SessionRunner<State> {
   SessionSnapshot? _lastSnapshot;
   int _lastSnapshotVersion = 0;
   final SessionStore? _store;
+
+  /// Ambient action context used to scope all persistent-store operations.
+  final Map<String, dynamic>? context;
 
   bool isDetached = false;
 
@@ -467,6 +472,7 @@ class SessionRunner<State> {
     final assignedId = await _store.saveSnapshot(
       null,
       _abortAwareMutator(snapshotInput),
+      context: context,
     );
     if (assignedId == null) {
       return _lastSnapshot?.snapshotId;
@@ -534,6 +540,7 @@ class SessionRunner<State> {
     final assignedId = await _store.saveSnapshot(
       effectiveId,
       _abortAwareMutator(snapshotInput),
+      context: context,
     );
     if (assignedId == null) {
       // Snapshot was aborted concurrently; preserve the existing ID.
@@ -660,10 +667,14 @@ _resolveSession<State>(
   SessionStore store,
   AgentInit? init,
   ValidateCustomState validateCustomState,
+  Map<String, dynamic>? context,
 ) async {
   final stateSchema = config.stateSchema;
   if (init?.snapshotId != null) {
-    final snapshot = await store.getSnapshot(snapshotId: init!.snapshotId);
+    final snapshot = await store.getSnapshot(
+      snapshotId: init!.snapshotId,
+      context: context,
+    );
     if (snapshot == null) {
       throw GenkitException(
         'Snapshot ${init.snapshotId} not found',
@@ -710,7 +721,10 @@ _resolveSession<State>(
     // if the leaf is a non-resumable turn, walk back over its parent chain to
     // the last-good (`completed`) snapshot. When the session has no resumable
     // snapshot, seed a fresh session bound to the requested sessionId.
-    var snapshot = await store.getSnapshot(sessionId: init!.sessionId);
+    var snapshot = await store.getSnapshot(
+      sessionId: init!.sessionId,
+      context: context,
+    );
     final visited = <String>{};
     while (snapshot != null && snapshot.status?.value != 'completed') {
       if (visited.contains(snapshot.snapshotId)) {
@@ -724,7 +738,7 @@ _resolveSession<State>(
       visited.add(snapshot.snapshotId);
       final parentId = snapshot.parentId;
       snapshot = parentId != null
-          ? await store.getSnapshot(snapshotId: parentId)
+          ? await store.getSnapshot(snapshotId: parentId, context: context)
           : null;
     }
     if (snapshot != null) {
@@ -828,17 +842,18 @@ final class _InProcessTransport extends AgentTransport {
   _InProcessTransport({
     required AgentStateManagement stateManagement,
     required this.primaryAction,
-    required this.getSnapshotFn,
-    required this.abortFn,
+    required this.getSnapshotDataAction,
+    required this.abortAgentAction,
   }) {
     this.stateManagement = stateManagement;
   }
 
   final Action<AgentInput, AgentOutput, AgentStreamChunk, AgentInit>
   primaryAction;
-  final Future<SessionSnapshot?> Function(String? snapshotId, String? sessionId)
-  getSnapshotFn;
-  final Future<SnapshotStatus?> Function(String snapshotId) abortFn;
+  final Action<GetSnapshotDataInput, SessionSnapshot?, void, void>
+  getSnapshotDataAction;
+  final Action<AgentAbortRequest, AgentAbortResponse, void, void>
+  abortAgentAction;
 
   BidiActionStream<AgentStreamChunk, AgentOutput, AgentInput> _startBidi(
     AgentInput input,
@@ -886,14 +901,24 @@ final class _InProcessTransport extends AgentTransport {
   Future<SessionSnapshot?> getSnapshot({
     String? snapshotId,
     String? sessionId,
-  }) => getSnapshotFn(snapshotId, sessionId);
+    Map<String, dynamic>? context,
+  }) => getSnapshotDataAction(
+    GetSnapshotDataInput(snapshotId: snapshotId, sessionId: sessionId),
+    context: context,
+  );
 
   // Detached/persist-only: flips the persisted snapshot to `aborted` and
   // returns its prior status. A detached worker watching the snapshot cancels
   // its own turn in response; an attached in-process turn's model call is not
   // interrupted (see [runTurn]).
   @override
-  Future<SnapshotStatus?> abort(String snapshotId) => abortFn(snapshotId);
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  }) async => (await abortAgentAction(
+    AgentAbortRequest(snapshotId: snapshotId),
+    context: context,
+  )).status;
 }
 
 // ---------------------------------------------------------------------------
@@ -912,15 +937,7 @@ class Agent<State> {
     required this.getSnapshotDataAction,
     required this.abortAgentAction,
     required AgentApi<State> api,
-    required Future<SessionSnapshot?> Function(
-      String? snapshotId,
-      String? sessionId,
-    )
-    resolveSnapshot,
-    required Future<SnapshotStatus?> Function(String snapshotId) runAbort,
-  }) : _api = api,
-       _resolveSnapshot = resolveSnapshot,
-       _runAbort = runAbort;
+  }) : _api = api;
 
   /// The primary bidi agent turn action.
   final Action<AgentInput, AgentOutput, AgentStreamChunk, AgentInit> action;
@@ -934,9 +951,6 @@ class Agent<State> {
   abortAgentAction;
 
   final AgentApi<State> _api;
-  final Future<SessionSnapshot?> Function(String? snapshotId, String? sessionId)
-  _resolveSnapshot;
-  final Future<SnapshotStatus?> Function(String snapshotId) _runAbort;
 
   /// Starts a new chat, optionally attaching via [snapshotId] / [sessionId] /
   /// [state] (provide at most one).
@@ -947,8 +961,15 @@ class Agent<State> {
   }) => _api.chat(snapshotId: snapshotId, sessionId: sessionId, state: state);
 
   /// Loads a server snapshot and returns a chat with history restored.
-  Future<AgentChat<State>> loadChat({String? snapshotId, String? sessionId}) =>
-      _api.loadChat(snapshotId: snapshotId, sessionId: sessionId);
+  Future<AgentChat<State>> loadChat({
+    String? snapshotId,
+    String? sessionId,
+    Map<String, dynamic>? context,
+  }) => _api.loadChat(
+    snapshotId: snapshotId,
+    sessionId: sessionId,
+    context: context,
+  );
 
   /// Reads a snapshot without starting a chat. Requires a server store.
   ///
@@ -957,17 +978,32 @@ class Agent<State> {
   Future<AgentSnapshot<State>?> getSnapshot({
     String? snapshotId,
     String? sessionId,
-  }) => _api.getSnapshot(snapshotId: snapshotId, sessionId: sessionId);
+    Map<String, dynamic>? context,
+  }) => _api.getSnapshot(
+    snapshotId: snapshotId,
+    sessionId: sessionId,
+    context: context,
+  );
 
   /// Reads a snapshot (applying the client transform). Requires a server store.
   Future<SessionSnapshot?> getSnapshotData({
     String? snapshotId,
     String? sessionId,
-  }) => _resolveSnapshot(snapshotId, sessionId);
+    Map<String, dynamic>? context,
+  }) => getSnapshotDataAction(
+    GetSnapshotDataInput(snapshotId: snapshotId, sessionId: sessionId),
+    context: context,
+  );
 
   /// Aborts a running snapshot. Requires a server store. Returns the prior
   /// status, or `null`.
-  Future<SnapshotStatus?> abort(String snapshotId) => _runAbort(snapshotId);
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  }) async => (await abortAgentAction(
+    AgentAbortRequest(snapshotId: snapshotId),
+    context: context,
+  )).status;
 }
 
 // ---------------------------------------------------------------------------
@@ -1051,6 +1087,7 @@ Agent<State> defineCustomAgent<State>(
               resolvedStore,
               init,
               validateCustomState,
+              ctx.context,
             );
             session = resolved.session;
             snapshot = resolved.snapshot;
@@ -1114,6 +1151,7 @@ Agent<State> defineCustomAgent<State>(
             session,
             runnerInputController.stream,
             store: resolvedStore,
+            context: ctx.context,
             lastSnapshot: snapshot,
             cancel: cancelToken,
             onDetach: (snapshotId) {
@@ -1135,7 +1173,7 @@ Agent<State> defineCustomAgent<State>(
                             .toUtc()
                             .toIso8601String();
                         return current;
-                      })
+                      }, context: ctx.context)
                       .catchError((_) {
                         // Best-effort heartbeat; ignore transient store errors.
                         return null;
@@ -1155,7 +1193,7 @@ Agent<State> defineCustomAgent<State>(
                         cancelToken.cancel();
                         localUnsubscribe?.call();
                       }
-                    });
+                    }, context: ctx.context);
                 unsubscribe = localUnsubscribe;
               }
             },
@@ -1340,11 +1378,13 @@ Agent<State> defineCustomAgent<State>(
   Future<SessionSnapshot?> resolveSnapshot(
     String? snapshotId,
     String? sessionId,
+    Map<String, dynamic>? context,
   ) async {
     _requireStore(config.store, 'getSnapshotData', config.name);
     final snapshot = await config.store!.getSnapshot(
       snapshotId: snapshotId,
       sessionId: sessionId,
+      context: context,
     );
     if (snapshot == null) return null;
     // Compute `expired` on read: a `pending` snapshot whose heartbeat has gone
@@ -1358,9 +1398,16 @@ Agent<State> defineCustomAgent<State>(
     return toClientSnapshot(effective);
   }
 
-  Future<SnapshotStatus?> runAbort(String snapshotId) async {
+  Future<SnapshotStatus?> runAbort(
+    String snapshotId,
+    Map<String, dynamic>? context,
+  ) async {
     _requireStore(config.store, 'abort', config.name);
-    final previous = await _abortSnapshotInStore(config.store!, snapshotId);
+    final previous = await _abortSnapshotInStore(
+      config.store!,
+      snapshotId,
+      context,
+    );
     return previous != null ? SnapshotStatus(previous) : null;
   }
 
@@ -1372,7 +1419,7 @@ Agent<State> defineCustomAgent<State>(
         actionType: .agentSnapshot,
         inputSchema: GetSnapshotDataInput.$schema,
         fn: (lookup, ctx) async =>
-            resolveSnapshot(lookup?.snapshotId, lookup?.sessionId),
+            resolveSnapshot(lookup?.snapshotId, lookup?.sessionId, ctx.context),
       );
   registry.register(getSnapshotDataAction);
 
@@ -1386,7 +1433,7 @@ Agent<State> defineCustomAgent<State>(
         inputSchema: AgentAbortRequest.$schema,
         outputSchema: AgentAbortResponse.$schema,
         fn: (request, ctx) async {
-          final status = await runAbort(request!.snapshotId);
+          final status = await runAbort(request!.snapshotId, ctx.context);
           return AgentAbortResponse(
             snapshotId: request.snapshotId,
             status: status,
@@ -1400,8 +1447,8 @@ Agent<State> defineCustomAgent<State>(
         ? AgentStateManagement.server
         : AgentStateManagement.client,
     primaryAction: primaryAction,
-    getSnapshotFn: resolveSnapshot,
-    abortFn: runAbort,
+    getSnapshotDataAction: getSnapshotDataAction,
+    abortAgentAction: abortAgentAction,
   );
 
   return Agent<State>._(
@@ -1409,8 +1456,6 @@ Agent<State> defineCustomAgent<State>(
     getSnapshotDataAction: getSnapshotDataAction,
     abortAgentAction: abortAgentAction,
     api: AgentApi<State>(transport, stateSchema: config.stateSchema),
-    resolveSnapshot: resolveSnapshot,
-    runAbort: runAbort,
   );
 }
 

--- a/packages/genkit/lib/src/ai/agents/agent_core.dart
+++ b/packages/genkit/lib/src/ai/agents/agent_core.dart
@@ -112,7 +112,7 @@ abstract base class AgentTransport {
   ///
   /// [context] is the ambient request context to run the turn under. It is only
   /// meaningful for the in-process transport (which runs the turn under that
-  /// context, observable by the agent handler via `getContext()`). A remote
+  /// context, observable as `AgentFnOptions.context`). A remote
   /// agent derives its context server-side from the incoming HTTP request
   /// (headers, auth, etc.), so the remote transport rejects a non-empty
   /// [context] with an [UnsupportedError] rather than silently dropping it.
@@ -136,11 +136,18 @@ abstract base class AgentTransport {
   }) => null;
 
   /// Reads a snapshot. Requires a server store.
-  Future<SessionSnapshot?> getSnapshot({String? snapshotId, String? sessionId});
+  Future<SessionSnapshot?> getSnapshot({
+    String? snapshotId,
+    String? sessionId,
+    Map<String, dynamic>? context,
+  });
 
   /// Aborts a running snapshot. Requires a server store. Returns the prior
   /// status, or `null`.
-  Future<SnapshotStatus?> abort(String snapshotId);
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  });
 
   /// Releases any resources owned by this transport. The default is a no-op;
   /// transports that own resources (e.g. an HTTP client) override it.
@@ -506,7 +513,12 @@ final class AgentSnapshot<State> {
 
 /// A handle to a background (detached) task.
 final class DetachedTask<State> {
-  DetachedTask._(this.snapshotId, this._transport, [this._stateSchema]);
+  DetachedTask._(
+    this.snapshotId,
+    this._transport, [
+    this._stateSchema,
+    this._context,
+  ]);
 
   final String snapshotId;
   final AgentTransport _transport;
@@ -515,6 +527,10 @@ final class DetachedTask<State> {
   /// instance on the snapshots this task yields; when `null`, state is a bare
   /// view cast over the JSON.
   final SchemanticType<State>? _stateSchema;
+
+  /// The explicit context captured when the task was detached. It is retained
+  /// by reference, so callers must not mutate it while the task is active.
+  final Map<String, dynamic>? _context;
 
   /// Yields status until a terminal state.
   ///
@@ -529,7 +545,10 @@ final class DetachedTask<State> {
   }) async* {
     var misses = 0;
     while (true) {
-      final snap = await _transport.getSnapshot(snapshotId: snapshotId);
+      final snap = await _transport.getSnapshot(
+        snapshotId: snapshotId,
+        context: _context,
+      );
       if (snap == null) {
         if (++misses >= maxConsecutiveMisses) {
           throw StateError('Snapshot $snapshotId not found.');
@@ -559,7 +578,8 @@ final class DetachedTask<State> {
   }
 
   /// Aborts the task.
-  Future<SnapshotStatus?> abort() => _transport.abort(snapshotId);
+  Future<SnapshotStatus?> abort() =>
+      _transport.abort(snapshotId, context: _context);
 }
 
 // ---------------------------------------------------------------------------
@@ -755,9 +775,9 @@ final class AgentChat<State> {
   /// [AgentResume] internally.
   ///
   /// [context] is the ambient request context to run the turn under. It is only
-  /// honored by the in-process transport (observable by the agent handler via
-  /// `getContext()`); the remote transport rejects a non-empty context with an
-  /// [UnsupportedError] (see [AgentTransport]).
+  /// honored by the in-process transport (observable as
+  /// `AgentFnOptions.context`); the remote transport rejects a non-empty context
+  /// with an [UnsupportedError] (see [AgentTransport]).
   Future<AgentResponse<State>> send({
     String? text,
     Message? message,
@@ -847,9 +867,9 @@ final class AgentChat<State> {
   /// [AgentResume] internally.
   ///
   /// [context] is the ambient request context to run the turn under. It is only
-  /// honored by the in-process transport (observable by the agent handler via
-  /// `getContext()`); the remote transport rejects a non-empty context with an
-  /// [UnsupportedError] (see [AgentTransport]).
+  /// honored by the in-process transport (observable as
+  /// `AgentFnOptions.context`); the remote transport rejects a non-empty context
+  /// with an [UnsupportedError] (see [AgentTransport]).
   AgentTurn<State> sendStream({
     String? text,
     Message? message,
@@ -1018,9 +1038,14 @@ final class AgentChat<State> {
   /// [AgentResume] internally.
   ///
   /// [context] is the ambient request context to run the turn under. It is only
-  /// honored by the in-process transport (observable by the agent handler via
-  /// `getContext()`); the remote transport rejects a non-empty context with an
-  /// [UnsupportedError] (see [AgentTransport]).
+  /// honored by the in-process transport (observable as
+  /// `AgentFnOptions.context`); the remote transport rejects a non-empty context
+  /// with an [UnsupportedError] (see [AgentTransport]).
+  ///
+  /// Pass [context] explicitly when using a context-scoped session store. The
+  /// returned [DetachedTask] retains it for polling and abort after the
+  /// originating action has completed. Do not mutate the context map while the
+  /// detached task is active.
   Future<DetachedTask<State>> detach({
     String? text,
     Message? message,
@@ -1054,14 +1079,14 @@ final class AgentChat<State> {
     if (id == null) {
       throw StateError('detach did not return a snapshotId.');
     }
-    return DetachedTask<State>._(id, _transport, _stateSchema);
+    return DetachedTask<State>._(id, _transport, _stateSchema, context);
   }
 
   /// Aborts the current snapshot.
-  Future<SnapshotStatus?> abort() async {
+  Future<SnapshotStatus?> abort({Map<String, dynamic>? context}) async {
     final id = snapshotId;
     if (id == null) return null;
-    return _transport.abort(id);
+    return _transport.abort(id, context: context);
   }
 
   AgentError<State> _toAgentError(Object e) {
@@ -1130,6 +1155,7 @@ final class AgentApi<State> {
   Future<AgentChat<State>> loadChat({
     String? snapshotId,
     String? sessionId,
+    Map<String, dynamic>? context,
   }) async {
     assert(
       (snapshotId != null) ^ (sessionId != null),
@@ -1138,6 +1164,7 @@ final class AgentApi<State> {
     final snapshot = await _transport.getSnapshot(
       snapshotId: snapshotId,
       sessionId: sessionId,
+      context: context,
     );
     if (snapshot == null) {
       final id = snapshotId ?? 'session $sessionId';
@@ -1155,10 +1182,12 @@ final class AgentApi<State> {
   Future<AgentSnapshot<State>?> getSnapshot({
     String? snapshotId,
     String? sessionId,
+    Map<String, dynamic>? context,
   }) async {
     final snapshot = await _transport.getSnapshot(
       snapshotId: snapshotId,
       sessionId: sessionId,
+      context: context,
     );
     if (snapshot == null) return null;
     return AgentSnapshot<State>._(snapshot, _stateSchema);
@@ -1166,8 +1195,10 @@ final class AgentApi<State> {
 
   /// Aborts a running snapshot. Requires a server store. Returns the prior
   /// status, or `null`.
-  Future<SnapshotStatus?> abort(String snapshotId) =>
-      _transport.abort(snapshotId);
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  }) => _transport.abort(snapshotId, context: context);
 
   /// Releases any resources owned by the underlying transport (e.g. an HTTP
   /// client created by `remoteAgent`). A caller-supplied HTTP client is left

--- a/packages/genkit/lib/src/ai/agents/remote_agent.dart
+++ b/packages/genkit/lib/src/ai/agents/remote_agent.dart
@@ -237,7 +237,9 @@ final class _HttpAgentTransport extends AgentTransport {
   Future<SessionSnapshot?> getSnapshot({
     String? snapshotId,
     String? sessionId,
+    Map<String, dynamic>? context,
   }) async {
+    _rejectContext(context);
     final headers = await _resolveHeaders();
     final lookup = <String, dynamic>{
       'snapshotId': ?snapshotId,
@@ -247,7 +249,11 @@ final class _HttpAgentTransport extends AgentTransport {
   }
 
   @override
-  Future<SnapshotStatus?> abort(String snapshotId) async {
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  }) async {
+    _rejectContext(context);
     final headers = await _resolveHeaders();
     final response = await _abortAction.call(
       input: AgentAbortRequest(snapshotId: snapshotId),

--- a/packages/genkit/test/ai/agents/agent_core_test.dart
+++ b/packages/genkit/test/ai/agents/agent_core_test.dart
@@ -76,10 +76,14 @@ final class _FakeTransport extends AgentTransport {
   Future<SessionSnapshot?> getSnapshot({
     String? snapshotId,
     String? sessionId,
+    Map<String, dynamic>? context,
   }) async => snapshots[snapshotId];
 
   @override
-  Future<SnapshotStatus?> abort(String snapshotId) async {
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  }) async {
     aborted.add(snapshotId);
     return SnapshotStatus.aborted;
   }
@@ -153,10 +157,14 @@ final class _StepTransport extends AgentTransport {
   Future<SessionSnapshot?> getSnapshot({
     String? snapshotId,
     String? sessionId,
+    Map<String, dynamic>? context,
   }) async => null;
 
   @override
-  Future<SnapshotStatus?> abort(String snapshotId) async => null;
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  }) async => null;
 }
 
 Message _modelMessage(String text) => Message(
@@ -950,8 +958,12 @@ final class _CaptureTransport extends AgentTransport {
   Future<SessionSnapshot?> getSnapshot({
     String? snapshotId,
     String? sessionId,
+    Map<String, dynamic>? context,
   }) async => null;
 
   @override
-  Future<SnapshotStatus?> abort(String snapshotId) async => null;
+  Future<SnapshotStatus?> abort(
+    String snapshotId, {
+    Map<String, dynamic>? context,
+  }) async => null;
 }

--- a/packages/genkit/test/ai/agents/agent_test.dart
+++ b/packages/genkit/test/ai/agents/agent_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
+
 import 'package:genkit/genkit.dart';
 import 'package:test/test.dart';
 
@@ -37,6 +39,50 @@ void _defineEchoModel(Genkit ai) {
       );
     },
   );
+}
+
+final class _ContextRecordingStore
+    implements SessionStore, SnapshotChangeNotifier {
+  final InMemorySessionStore _delegate = InMemorySessionStore();
+  final List<Map<String, dynamic>?> contexts = [];
+
+  @override
+  Future<SessionSnapshot?> getSnapshot({
+    String? snapshotId,
+    String? sessionId,
+    Map<String, dynamic>? context,
+  }) {
+    contexts.add(context);
+    return _delegate.getSnapshot(
+      snapshotId: snapshotId,
+      sessionId: sessionId,
+      context: context,
+    );
+  }
+
+  @override
+  Future<String?> saveSnapshot(
+    String? snapshotId,
+    SnapshotMutator mutator, {
+    Map<String, dynamic>? context,
+  }) {
+    contexts.add(context);
+    return _delegate.saveSnapshot(snapshotId, mutator, context: context);
+  }
+
+  @override
+  void Function()? onSnapshotStateChange(
+    String snapshotId,
+    void Function(SessionSnapshot snapshot) callback, {
+    Map<String, dynamic>? context,
+  }) {
+    contexts.add(context);
+    return _delegate.onSnapshotStateChange(
+      snapshotId,
+      callback,
+      context: context,
+    );
+  }
 }
 
 void main() {
@@ -250,6 +296,115 @@ void main() {
       await chat2.send(text: 'two');
       final snapshot2 = await agent.getSnapshot(sessionId: sessionId);
       expect(snapshot2!.custom, {'count': 2});
+    });
+
+    test('passes context to every session store operation', () async {
+      final store = _ContextRecordingStore();
+      final agent = ai.defineCustomAgent(
+        name: 'tenantScoped',
+        store: store,
+        fn: (sess, options) async {
+          await sess.run((input, ctx) async {
+            sess.updateCustom((_) => {'ok': true});
+            return TurnResult(finishReason: AgentFinishReason.stop);
+          });
+          return AgentResult(finishReason: sess.lastTurnFinishReason);
+        },
+      );
+      final context = <String, dynamic>{'tenant': 'alice'};
+      final sessionId = generateUuidV4();
+
+      final response = await agent
+          .chat(sessionId: sessionId)
+          .send(text: 'hi', context: context);
+      expect(response.snapshotId, isNotNull);
+      expect(store.contexts, isNotEmpty);
+      expect(store.contexts, everyElement(equals(context)));
+
+      store.contexts.clear();
+      await agent.loadChat(sessionId: sessionId, context: context);
+      await agent.getSnapshot(
+        snapshotId: response.snapshotId,
+        context: context,
+      );
+      await agent.getSnapshotDataAction(
+        GetSnapshotDataInput(snapshotId: response.snapshotId),
+        context: context,
+      );
+      await agent.abort(response.snapshotId!, context: context);
+      await agent.abortAgentAction(
+        AgentAbortRequest(snapshotId: response.snapshotId!),
+        context: context,
+      );
+      expect(store.contexts, isNotEmpty);
+      expect(store.contexts, everyElement(equals(context)));
+    });
+
+    test('inherits ambient action context for store operations', () async {
+      final store = _ContextRecordingStore();
+      final agent = ai.defineCustomAgent(
+        name: 'ambientTenantScoped',
+        store: store,
+        fn: (sess, options) async {
+          await sess.run((input, ctx) async {
+            sess.updateCustom((_) => {'ok': true});
+            return TurnResult(finishReason: AgentFinishReason.stop);
+          });
+          return AgentResult(finishReason: sess.lastTurnFinishReason);
+        },
+      );
+      final context = <String, dynamic>{'tenant': 'alice'};
+      final sessionId = generateUuidV4();
+      final outer = Action<String, void, void, void>(
+        name: 'ambientAgentCaller',
+        actionType: .custom,
+        fn: (_, ctx) async {
+          final response = await agent
+              .chat(sessionId: sessionId)
+              .send(text: 'hi');
+          await agent.getSnapshot(snapshotId: response.snapshotId);
+        },
+      );
+
+      await outer('run', context: context);
+
+      expect(store.contexts, isNotEmpty);
+      expect(store.contexts, everyElement(equals(context)));
+    });
+
+    test('detached task retains explicit context', () async {
+      final store = _ContextRecordingStore();
+      final releaseTurn = Completer<void>();
+      final agent = ai.defineCustomAgent(
+        name: 'ambientDetachedTenantScoped',
+        store: store,
+        fn: (sess, options) async {
+          await sess.run((input, ctx) async {
+            await releaseTurn.future;
+            sess.updateCustom((_) => {'done': true});
+            return TurnResult(finishReason: AgentFinishReason.stop);
+          });
+          return AgentResult(finishReason: sess.lastTurnFinishReason);
+        },
+      );
+      final context = <String, dynamic>{'tenant': 'alice'};
+      final outer = Action<String, DetachedTask<dynamic>, void, void>(
+        name: 'ambientDetachedAgentCaller',
+        actionType: .custom,
+        fn: (_, ctx) => agent
+            .chat(sessionId: generateUuidV4())
+            .detach(text: 'background', context: ctx.context),
+      );
+
+      final task = await outer('run', context: context);
+      releaseTurn.complete();
+      final snapshot = await task.wait(
+        interval: const Duration(milliseconds: 10),
+      );
+      expect(snapshot.status?.value, 'completed');
+      expect((await task.abort())?.value, 'completed');
+      expect(store.contexts, isNotEmpty);
+      expect(store.contexts, everyElement(equals(context)));
     });
 
     test('detached turn does not self-parent its snapshot', () async {

--- a/packages/genkit/test/ai/agents/remote_agent_test.dart
+++ b/packages/genkit/test/ai/agents/remote_agent_test.dart
@@ -244,6 +244,23 @@ void main() {
       );
       // The rejected turn never hit the wire.
       expect(client.requests, isEmpty);
+
+      final context = {
+        'auth': {'uid': 'user-123'},
+      };
+      await expectLater(
+        agent.getSnapshot(snapshotId: 's_x', context: context),
+        throwsA(isA<UnsupportedError>()),
+      );
+      await expectLater(
+        agent.loadChat(snapshotId: 's_x', context: context),
+        throwsA(isA<UnsupportedError>()),
+      );
+      await expectLater(
+        agent.abort('s_x', context: context),
+        throwsA(isA<UnsupportedError>()),
+      );
+      expect(client.requests, isEmpty);
     });
 
     test('ignores an empty/null context (stays polymorphic)', () async {


### PR DESCRIPTION
## Summary

The server-side agent runtime (`defineAgent` / `defineCustomAgent`) dropped the ambient request context when calling `SessionStore`, so context-scoped stores like `FirestoreSessionStore` with `snapshotPathPrefix` always resolved the default `"global"` prefix instead of the per-tenant one derived from the call context.

This change forwards the action context into every session-store operation so multi-tenant isolation works as documented.

## Changes

- `packages/genkit/lib/src/ai/agents/agent.dart`
  - Pass action context to session resolution, snapshot saves (completed/failed/recovery), detached `pending` writes, heartbeats, and `onSnapshotStateChange` subscriptions.
  - `getSnapshotDataAction` / `abortAgentAction` now forward their action context to the store.
  - In-process snapshot/abort operations route through the registered actions, so they inherit ambient action context like `send()` does (existing `Action.run` zone behavior) instead of bypassing it.
- `packages/genkit/lib/src/ai/agents/agent_core.dart`
  - `AgentTransport.getSnapshot` / `abort` accept an optional `context`.
  - `DetachedTask` retains the context passed to `detach()` so `poll()` / `wait()` / `abort()` stay tenant-scoped after the originating action completes.
- `packages/genkit/lib/src/ai/agents/remote_agent.dart`
  - Snapshot/abort reject client-supplied context, matching the existing turn behavior (remote context is derived server-side from request headers).

## Breaking change

`AgentTransport.getSnapshot` and `abort` gained an optional `context` parameter. Third-party `AgentTransport` subclasses must update their overrides to accept it.

## Tests

- Context reaches all session-store operations on send/resume/abort/get-snapshot.
- Ambient action context is inherited by nested in-process calls.
- Detached tasks retain explicit context across polling and abort.
- Remote agents reject non-empty client-supplied context for snapshot and abort.

## Note for reviewers

This PR was mostly written by GPT-5.6 "Sol" (assisted with the codebase exploration). It works for my use case and the changes seem correct on inspection, but I'm not an expert in this codebase, so a thorough review would be appreciated.