### PR TITLE
feat(agents): `aborting` snapshot status + rerunnable aborted snapshots (Go parity)

### DIFF
--- a/packages/_schema_generator/bin/generate.dart
+++ b/packages/_schema_generator/bin/generate.dart
@@ -133,6 +133,7 @@ const _allowlist = {
   'ModelResponse',
   'ModelResponseChunk',
   'MiddlewareRef',
+  'RuntimeError',
   'GenerateResponse',
   'GenerateRequest',
   'GenerationUsage',

--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -203,15 +203,21 @@ const Duration _defaultHeartbeatInterval = Duration(seconds: 30);
 /// [_defaultHeartbeatInterval] so a single missed beat does not trip expiry.
 const Duration _defaultHeartbeatTimeout = Duration(seconds: 60);
 
-/// Returns `true` when [snapshot] is a `pending` (detached, in-flight) snapshot
-/// whose heartbeat is older than [timeout] - i.e. its background worker is
-/// presumed dead. A pending snapshot that has not yet written a first heartbeat
-/// is not considered expired (the beat may simply not have fired yet).
+/// Returns `true` when [snapshot] is a detached, in-flight snapshot whose
+/// heartbeat is older than [timeout] - i.e. its background worker is presumed
+/// dead. Both `pending` and `aborting` are in-flight, still-heartbeating states
+/// (a worker keeps beating while it winds down an abort), so a stale beat in
+/// either reads as `expired`; this mirrors the shared spec, where a `pending`
+/// *or* `aborting` row with a stale beat surfaces as `expired`. A snapshot that
+/// has not yet written a first heartbeat is not considered expired (the beat may
+/// simply not have fired yet).
 bool _isHeartbeatExpired(
   SessionSnapshot snapshot, [
   Duration timeout = _defaultHeartbeatTimeout,
 ]) {
-  if (snapshot.status?.value != 'pending' || snapshot.heartbeatAt == null) {
+  final status = snapshot.status?.value;
+  if ((status != 'pending' && status != 'aborting') ||
+      snapshot.heartbeatAt == null) {
     return false;
   }
   final last = DateTime.tryParse(snapshot.heartbeatAt!);

--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -147,11 +147,21 @@ class AgentInitError extends GenkitException {
 // ---------------------------------------------------------------------------
 
 /// Builds an abort-aware [SnapshotMutator]: it skips the write (returns `null`)
-/// when the current snapshot was concurrently aborted, otherwise writes
-/// [input]. This prevents a "completed"/"failed" write from clobbering an
-/// "aborted" status set by a concurrent abort.
+/// when the current snapshot has already *settled*, otherwise writes [input].
+/// This prevents a "completed"/"failed" write from clobbering a terminal status.
+///
+/// An `aborting` row is deliberately NOT treated as settled: it sits between the
+/// abort flip (which stops the work) and the finalize (which stamps the state
+/// on), so the finalize that settles it to `aborted` with state must be allowed
+/// through.
 SnapshotMutator _abortAwareMutator(SessionSnapshot input) {
-  return (current) => current?.status?.value == 'aborted' ? null : input;
+  return (current) {
+    final status = current?.status?.value;
+    if (status == 'completed' || status == 'failed' || status == 'aborted') {
+      return null;
+    }
+    return input;
+  };
 }
 
 /// Asserts that an operation requiring a persistent store is not being invoked
@@ -166,28 +176,39 @@ void _requireStore(SessionStore? store, String operation, String agentName) {
   }
 }
 
-/// Sets a snapshot's status to `aborted` (unless it already reached a terminal
-/// state) and returns its previous status, or `null` when the snapshot does
-/// not exist.
+/// Flips a `pending` snapshot to `aborting` via an ordinary `saveSnapshot`, and
+/// returns the *resulting* status: `aborting` when the row was pending (or was
+/// already aborting, since a second abort is an idempotent verbatim rewrite),
+/// the existing terminal status when the row had already settled, or `null` when
+/// the snapshot does not exist.
+///
+/// This is the first of the abort protocol's two writes: it stops the work (the
+/// detached worker observes the flip and cancels its turn) but does not stamp
+/// state - the worker's own finalize write later settles the row to `aborted`
+/// *with* the last-good state (see [SessionRunner.maybeSnapshot]). The flip
+/// deliberately leaves `heartbeatAt` where the worker left it: the beat is the
+/// worker's liveness signal, so a dead worker's row reads as `expired` at once
+/// rather than a heartbeat timeout later.
 Future<String?> _abortSnapshotInStore(
   SessionStore store,
   String snapshotId,
   Map<String, dynamic>? context,
 ) async {
-  String? previousStatus;
+  String? resultStatus;
   await store.saveSnapshot(snapshotId, (current) {
-    if (current == null) return null;
-    previousStatus = current.status?.value;
-    if (previousStatus == 'completed' ||
-        previousStatus == 'failed' ||
-        previousStatus == 'aborted') {
-      return null; // Already terminal - don't override.
+    if (current == null) return null; // not found
+    final status = current.status?.value;
+    if (status != 'pending') {
+      // Settled, or already aborting: re-persist verbatim so the returned
+      // status carries the existing value (idempotent).
+      resultStatus = status;
+      return current;
     }
-
-    current.status = SnapshotStatus.aborted;
+    current.status = SnapshotStatus.aborting;
+    resultStatus = 'aborting';
     return current;
   }, context: context);
-  return previousStatus;
+  return resultStatus;
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +223,16 @@ const Duration _defaultHeartbeatInterval = Duration(seconds: 30);
 /// has not advanced is reported as `expired` on read. Comfortably larger than
 /// [_defaultHeartbeatInterval] so a single missed beat does not trip expiry.
 const Duration _defaultHeartbeatTimeout = Duration(seconds: 60);
+
+/// Bounds how long an `aborting` invocation keeps heartbeating while its worker
+/// drains toward the finalize write. The beats are what keep a live,
+/// winding-down worker's row reading as `aborting` instead of `expired` the
+/// moment the abort flip lands: the flip stops the work, not the worker, and a
+/// drain through a slow tool call can outlast [_defaultHeartbeatTimeout]. A
+/// worker that has not finalized within the budget is presumed wedged; its
+/// beats stop, the row goes stale and reads as `expired`, and the task stays
+/// recoverable instead of winding down forever.
+const Duration _windDownHeartbeatBudget = Duration(minutes: 5);
 
 /// Returns `true` when [snapshot] is a detached, in-flight snapshot whose
 /// heartbeat is older than [timeout] - i.e. its background worker is presumed
@@ -223,6 +254,87 @@ bool _isHeartbeatExpired(
   final last = DateTime.tryParse(snapshot.heartbeatAt!);
   if (last == null) return false;
   return DateTime.now().toUtc().difference(last.toUtc()) > timeout;
+}
+
+/// Asserts [snapshot] is in a resumable status and carries the state to resume
+/// from, throwing a [GenkitException] otherwise (the caller turns that into a
+/// graceful `finishReason: 'failed'`).
+///
+/// `completed`, `failed`, and `aborted` are resumable: each committed a
+/// conversation ending at a turn seam, and whether to continue from a run that
+/// broke or was stopped is the caller's judgement, not the framework's. A
+/// `pending` or `aborting` row is rejected with heartbeat-aware messaging: a
+/// live beat means the run is still writing this same id (wait/retry it), a
+/// stale beat means the worker died and the resume point is the parent. An
+/// `aborted`/`failed` row that somehow carries no state (written by something
+/// other than the runtime) is redirected to its parent.
+void _assertResumable(SessionSnapshot snapshot) {
+  final status = snapshot.status?.value;
+  switch (status) {
+    case 'pending':
+    case 'aborting':
+      final id = snapshot.snapshotId;
+      if (_isHeartbeatExpired(snapshot)) {
+        final parent = snapshot.parentId;
+        if (parent != null) {
+          throw GenkitException(
+            "Snapshot '$id' is still '$status' but its worker stopped "
+            'heartbeating and is presumed dead; resume from its parent '
+            "snapshot '$parent'.",
+            status: StatusCodes.FAILED_PRECONDITION,
+          );
+        }
+        throw GenkitException(
+          "Snapshot '$id' is still '$status' but its worker stopped "
+          'heartbeating and is presumed dead. It recorded no progress, so '
+          'there is nothing to resume.',
+          status: StatusCodes.FAILED_PRECONDITION,
+        );
+      }
+      if (status == 'aborting') {
+        throw GenkitException(
+          "Snapshot '$id' is still being finalized: its invocation was "
+          'aborted and has not recorded the state yet; retry this same '
+          'snapshot id.',
+          status: StatusCodes.FAILED_PRECONDITION,
+        );
+      }
+      throw GenkitException(
+        "Snapshot '$id' is still pending: its detached invocation is still "
+        'running; wait for it to finalize or abort it before resuming.',
+        status: StatusCodes.FAILED_PRECONDITION,
+      );
+    case 'completed':
+    case 'failed':
+    case 'aborted':
+      // The runtime lands a `failed`/`aborted` row together with its state, so
+      // one without state was written by something else; the parent is the
+      // resume point.
+      if (snapshot.state == null) {
+        final parent = snapshot.parentId;
+        throw GenkitException(
+          "Snapshot '${snapshot.snapshotId}' is '$status' but carries no "
+          'state to resume from'
+          '${parent != null ? "; resume from its parent snapshot '$parent'." : ' and has no parent.'}',
+          status: StatusCodes.FAILED_PRECONDITION,
+        );
+      }
+      return;
+    default:
+      throw GenkitException(
+        "Snapshot '${snapshot.snapshotId}' is not resumable (status: "
+        "${status ?? 'unknown'}).",
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+  }
+}
+
+/// Whether [snapshot] is in a resumable *terminal* status carrying state, used
+/// by the `sessionId` parent-walk to find the last-good resume point.
+bool _isResumableLeaf(SessionSnapshot snapshot) {
+  final status = snapshot.status?.value;
+  return (status == 'completed' || status == 'failed' || status == 'aborted') &&
+      snapshot.state != null;
 }
 
 // ---------------------------------------------------------------------------
@@ -765,16 +877,11 @@ _resolveSession<State>(
       );
     }
 
-    // Only `completed` snapshots are resumable. A failed/aborted/pending
-    // snapshot is persisted for inspection but is not a valid resume target.
-    if (snapshot.status?.value != 'completed') {
-      throw GenkitException(
-        'Snapshot ${init.snapshotId} is not resumable (status: '
-        "${snapshot.status?.value ?? 'unknown'}). Only 'completed' snapshots "
-        'can be resumed.',
-        status: StatusCodes.INVALID_ARGUMENT,
-      );
-    }
+    // Validate the snapshot is in a resumable status and load its state. A
+    // `failed` or `aborted` snapshot resumes: the turn that wrote it committed
+    // a conversation ending at a turn seam, and whether to continue from a run
+    // that broke or one that was stopped is the caller's judgement.
+    _assertResumable(snapshot);
 
     validateCustomState(snapshot.state?.custom);
     return (
@@ -794,7 +901,7 @@ _resolveSession<State>(
       context: context,
     );
     final visited = <String>{};
-    while (snapshot != null && snapshot.status?.value != 'completed') {
+    while (snapshot != null && !_isResumableLeaf(snapshot)) {
       if (visited.contains(snapshot.snapshotId)) {
         throw GenkitException(
           "Session '${init.sessionId}' has a cyclic snapshot parent chain "
@@ -1118,330 +1225,351 @@ Agent<State> defineCustomAgent<State>(
     }
   }
 
-  final primaryAction =
-      Action<AgentInput, AgentOutput, AgentStreamChunk, AgentInit>(
-        name: config.name,
-        description: config.description,
-        actionType: .agent,
-        inputSchema: AgentInput.$schema,
-        outputSchema: AgentOutput.$schema,
-        streamSchema: AgentStreamChunk.$schema,
-        initSchema: AgentInit.$schema,
-        metadata: {
-          'agent': AgentMetadata(
-            stateManagement: config.store != null
-                ? AgentStateManagement.server
-                : AgentStateManagement.client,
-            abortable: config.store is SnapshotChangeNotifier,
-            stateSchema: stateJsonSchema,
-          ).toJson(),
-        },
-        fn: (input, ctx) async {
-          final init = ctx.init;
-          final resolvedStore = config.store ?? InMemorySessionStore();
+  final primaryAction = Action<AgentInput, AgentOutput, AgentStreamChunk, AgentInit>(
+    name: config.name,
+    description: config.description,
+    actionType: .agent,
+    inputSchema: AgentInput.$schema,
+    outputSchema: AgentOutput.$schema,
+    streamSchema: AgentStreamChunk.$schema,
+    initSchema: AgentInit.$schema,
+    metadata: {
+      'agent': AgentMetadata(
+        stateManagement: config.store != null
+            ? AgentStateManagement.server
+            : AgentStateManagement.client,
+        abortable: config.store is SnapshotChangeNotifier,
+        stateSchema: stateJsonSchema,
+      ).toJson(),
+    },
+    fn: (input, ctx) async {
+      final init = ctx.init;
+      final resolvedStore = config.store ?? InMemorySessionStore();
 
-          // API-misuse checks (init does not match the agent's state-management
-          // mode) throw out of the handler so the server maps them to a proper
-          // HTTP status, rather than being absorbed into a graceful
-          // `finishReason: 'failed'` result below.
-          _assertInitMatchesStateManagement(config, init);
+      // API-misuse checks (init does not match the agent's state-management
+      // mode) throw out of the handler so the server maps them to a proper
+      // HTTP status, rather than being absorbed into a graceful
+      // `finishReason: 'failed'` result below.
+      _assertInitMatchesStateManagement(config, init);
 
-          Session<State> session;
-          SessionSnapshot? snapshot;
-          try {
-            final resolved = await _resolveSession<State>(
-              config,
-              resolvedStore,
-              init,
-              validateCustomState,
-              ctx.context,
-            );
-            session = resolved.session;
-            snapshot = resolved.snapshot;
-          } catch (e) {
-            // An AgentInitError signals API misuse (e.g. the snapshot/session
-            // ownership guard) that must surface as a thrown error; re-throw it
-            // so the server handler maps it to a proper HTTP status. Other
-            // pre-turn failures resolve gracefully with `finishReason: 'failed'`
-            // (preserving the original error.status).
-            if (e is AgentInitError) rethrow;
-            return AgentOutput(
-              finishReason: AgentFinishReason.failed,
-              error: _toErrorInfo(toErrorDetails(e)),
-              state: (config.store == null && init?.state != null)
-                  ? init!.state
-                  : null,
-            );
+      Session<State> session;
+      SessionSnapshot? snapshot;
+      try {
+        final resolved = await _resolveSession<State>(
+          config,
+          resolvedStore,
+          init,
+          validateCustomState,
+          ctx.context,
+        );
+        session = resolved.session;
+        snapshot = resolved.snapshot;
+      } catch (e) {
+        // An AgentInitError signals API misuse (e.g. the snapshot/session
+        // ownership guard) that must surface as a thrown error; re-throw it
+        // so the server handler maps it to a proper HTTP status. Other
+        // pre-turn failures resolve gracefully with `finishReason: 'failed'`
+        // (preserving the original error.status).
+        if (e is AgentInitError) rethrow;
+        return AgentOutput(
+          finishReason: AgentFinishReason.failed,
+          error: _toErrorInfo(toErrorDetails(e)),
+          state: (config.store == null && init?.state != null)
+              ? init!.state
+              : null,
+        );
+      }
+
+      setCustomMetadataAttributes({'agent:sessionId': session.sessionId});
+
+      String? detachedSnapshotId;
+      final detachCompleter = Completer<void>();
+      // Own a controller for this turn (cancelled on detach-abort or when
+      // the persisted snapshot flips to `aborted`) and link the ambient
+      // transport token to it, so an attached `runTurn(cancel:)` also
+      // cooperatively stops this turn's `generate`.
+      final cancelController = CancellationController();
+      // Capture the disposer so a reused, long-lived `ctx.cancel` token
+      // doesn't accumulate one stranded listener (pinning this turn's
+      // controller and closure) per turn. Disposed when the flow settles.
+      // `link` forwards the cancellation reason so a caller-supplied
+      // `controller.cancel('...')` survives the hop into this turn's token.
+      final unlinkCancel = ctx.cancel?.link(cancelController);
+      final cancelToken = cancelController.token;
+      void Function()? unsubscribe;
+      // Background heartbeat timer for the detached snapshot. Started in
+      // `onDetach`, cleared when the flow settles (or when the wind-down
+      // budget after an abort elapses).
+      Timer? heartbeatTimer;
+      // Bounds how long the heartbeat keeps beating after an abort flip
+      // while the worker drains toward its finalize; released early when the
+      // heartbeat stops for any other reason so a normal wind-down does not
+      // pin it for the whole budget.
+      Timer? windDownBudget;
+      void stopHeartbeat() {
+        heartbeatTimer?.cancel();
+        heartbeatTimer = null;
+        windDownBudget?.cancel();
+        windDownBudget = null;
+      }
+
+      late SessionRunner<State> runner;
+
+      void emitChunk(AgentStreamChunk chunk) {
+        final transform = config.clientTransform?.chunk;
+        if (transform != null) {
+          final transformed = transform(chunk);
+          if (transformed == null) return;
+          ctx.sendChunk(transformed);
+          return;
+        }
+        ctx.sendChunk(chunk);
+      }
+
+      final runnerInputController = StreamController<AgentInput>();
+      _pipeInputWithDetach(
+        ctx.inputStream!,
+        runnerInputController,
+        () => runner,
+        config.store != null,
+        (reason) {
+          if (!detachCompleter.isCompleted) {
+            detachCompleter.completeError(reason);
           }
-
-          setCustomMetadataAttributes({'agent:sessionId': session.sessionId});
-
-          String? detachedSnapshotId;
-          final detachCompleter = Completer<void>();
-          // Own a controller for this turn (cancelled on detach-abort or when
-          // the persisted snapshot flips to `aborted`) and link the ambient
-          // transport token to it, so an attached `runTurn(cancel:)` also
-          // cooperatively stops this turn's `generate`.
-          final cancelController = CancellationController();
-          // Capture the disposer so a reused, long-lived `ctx.cancel` token
-          // doesn't accumulate one stranded listener (pinning this turn's
-          // controller and closure) per turn. Disposed when the flow settles.
-          // `link` forwards the cancellation reason so a caller-supplied
-          // `controller.cancel('...')` survives the hop into this turn's token.
-          final unlinkCancel = ctx.cancel?.link(cancelController);
-          final cancelToken = cancelController.token;
-          void Function()? unsubscribe;
-          // Background heartbeat timer for the detached snapshot. Started in
-          // `onDetach`, cleared when the flow settles (or on abort).
-          Timer? heartbeatTimer;
-          void stopHeartbeat() {
-            heartbeatTimer?.cancel();
-            heartbeatTimer = null;
-          }
-
-          late SessionRunner<State> runner;
-
-          void emitChunk(AgentStreamChunk chunk) {
-            final transform = config.clientTransform?.chunk;
-            if (transform != null) {
-              final transformed = transform(chunk);
-              if (transformed == null) return;
-              ctx.sendChunk(transformed);
-              return;
-            }
-            ctx.sendChunk(chunk);
-          }
-
-          final runnerInputController = StreamController<AgentInput>();
-          _pipeInputWithDetach(
-            ctx.inputStream!,
-            runnerInputController,
-            () => runner,
-            config.store != null,
-            (reason) {
-              if (!detachCompleter.isCompleted) {
-                detachCompleter.completeError(reason);
-              }
-            },
-          );
-
-          runner = SessionRunner<State>(
-            session,
-            runnerInputController.stream,
-            store: resolvedStore,
-            context: ctx.context,
-            lastSnapshot: snapshot,
-            cancel: cancelToken,
-            onDetach: (snapshotId) {
-              detachedSnapshotId = snapshotId;
-              if (!detachCompleter.isCompleted) detachCompleter.complete();
-
-              // Refresh the detached snapshot's heartbeat periodically. The
-              // mutator only touches a still-`pending` snapshot (returns null
-              // otherwise) so it never resurrects a terminal snapshot or
-              // clobbers a concurrent abort. If a read sees this heartbeat go
-              // stale, the snapshot is reported as `expired` (worker presumed
-              // dead).
-              heartbeatTimer = Timer.periodic(_defaultHeartbeatInterval, (_) {
-                unawaited(
-                  resolvedStore
-                      .saveSnapshot(snapshotId, (current) {
-                        if (current?.status?.value != 'pending') return null;
-                        current!.heartbeatAt = DateTime.now()
-                            .toUtc()
-                            .toIso8601String();
-                        return current;
-                      }, context: ctx.context)
-                      .catchError((_) {
-                        // Best-effort heartbeat; ignore transient store errors.
-                        return null;
-                      }),
-                );
-              });
-
-              if (resolvedStore is SnapshotChangeNotifier) {
-                // Capture the unsubscribe in a local first: if
-                // `onSnapshotStateChange` fires the callback synchronously on
-                // registration, the outer `unsubscribe` would still be null.
-                void Function()? localUnsubscribe;
-                localUnsubscribe = (resolvedStore as SnapshotChangeNotifier)
-                    .onSnapshotStateChange(snapshotId, (snap) {
-                      if (snap.status?.value == 'aborted') {
-                        stopHeartbeat();
-                        cancelController.cancel();
-                        localUnsubscribe?.call();
-                      }
-                    }, context: ctx.context);
-                unsubscribe = localUnsubscribe;
-              }
-            },
-
-            onEndTurn: (snapshotId, finishReason) {
-              if (!runner.isDetached) {
-                emitChunk(
-                  AgentStreamChunk(
-                    turnEnd: TurnEnd(
-                      snapshotId: config.store != null ? snapshotId : null,
-                      finishReason: finishReason,
-                    ),
-                  ),
-                );
-              }
-            },
-          );
-
-          void sendArtifactChunk(Object? a) {
-            if (!runner.isDetached) {
-              emitChunk(AgentStreamChunk(artifact: a as Artifact));
-            }
-          }
-
-          final offArtifactAdded = session.on(
-            'artifactAdded',
-            sendArtifactChunk,
-          );
-          final offArtifactUpdated = session.on(
-            'artifactUpdated',
-            sendArtifactChunk,
-          );
-
-          dynamic lastSentCustom;
-          void sendCustomPatch(Object? _) {
-            if (runner.isDetached) return;
-            final transformed = toClientState(session.getState())?.custom;
-            JsonPatch patch;
-            if (runner.firstCustomPatchInTurn) {
-              patch = [
-                {'op': 'replace', 'path': '', 'value': _clone(transformed)},
-              ];
-              runner.firstCustomPatchInTurn = false;
-            } else {
-              patch = diff(lastSentCustom, transformed);
-            }
-            lastSentCustom = _clone(transformed);
-            if (patch.isNotEmpty) {
-              emitChunk(
-                AgentStreamChunk(
-                  customPatch: patch.map(JsonPatchOperation.fromJson).toList(),
-                ),
-              );
-            }
-          }
-
-          final offCustomChanged = session.on('customChanged', sendCustomPatch);
-
-          void sendChunk(AgentStreamChunk chunk) {
-            if (!runner.isDetached) emitChunk(chunk);
-          }
-
-          Future<({AgentResult result, String? finalSnapshotId})> flow() async {
-            try {
-              final result = await runWithSession(
-                session,
-                () => fn(
-                  runner,
-                  AgentFnOptions(
-                    sendChunk: sendChunk,
-                    cancel: cancelToken,
-                    context: ctx.context,
-                  ),
-                ),
-              );
-              final finalSnapshotId = await runner.maybeSnapshot();
-              return (result: result, finalSnapshotId: finalSnapshotId);
-            } finally {
-              // The turn has settled (the snapshot reached a terminal status),
-              // so stop refreshing its heartbeat.
-              stopHeartbeat();
-              unlinkCancel?.call();
-              unsubscribe?.call();
-              offArtifactAdded();
-              offArtifactUpdated();
-              offCustomChanged();
-            }
-          }
-
-          final flowFuture = flow();
-
-          // Race the background flow execution against the detach signal.
-          final outcome = Completer<_Outcome>();
-          flowFuture
-              .then((v) {
-                if (!outcome.isCompleted) outcome.complete(_Outcome.flow(v));
-              })
-              .catchError((Object e, StackTrace s) {
-                if (!outcome.isCompleted) outcome.completeError(e, s);
-              });
-          detachCompleter.future
-              .then((_) {
-                if (!outcome.isCompleted) outcome.complete(_Outcome.detached());
-              })
-              .catchError((Object e, StackTrace s) {
-                if (!outcome.isCompleted) outcome.completeError(e, s);
-              });
-
-          final result = await outcome.future;
-
-          if (result.isDetached) {
-            // Swallow any later flow error now that we've detached.
-            unawaited(
-              flowFuture.catchError(
-                (_) => (result: AgentResult(), finalSnapshotId: null),
-              ),
-            );
-            return AgentOutput(
-              sessionId: session.sessionId,
-              snapshotId: detachedSnapshotId,
-              finishReason: AgentFinishReason.detached,
-              state: config.store == null
-                  ? toClientState(session.getState())
-                  : null,
-            );
-          }
-
-          final flowValue = result.flowValue!;
-          final agentResult = flowValue.result;
-          final finalSnapshotId = flowValue.finalSnapshotId;
-
-          // A turn failed: resolve gracefully with the last-good state.
-          if (runner.lastTurnFinishReason == AgentFinishReason.failed &&
-              runner.lastTurnError != null) {
-            final lastGood = runner.lastGoodState ?? session.getState();
-            final lastGoodMessages = lastGood.messages;
-            return AgentOutput(
-              sessionId: session.sessionId,
-              finishReason: AgentFinishReason.failed,
-              error: _toErrorInfo(runner.lastTurnError!),
-              artifacts: agentResult.artifacts?.isNotEmpty == true
-                  ? agentResult.artifacts
-                  : null,
-              message: lastGoodMessages?.isNotEmpty == true
-                  ? lastGoodMessages!.last
-                  : null,
-              snapshotId: config.store != null
-                  ? await runner.ensureRecoverySnapshot()
-                  : null,
-              state: config.store == null ? toClientState(lastGood) : null,
-            );
-          }
-
-          final finishReason =
-              agentResult.finishReason ?? runner.lastTurnFinishReason;
-
-          return AgentOutput(
-            sessionId: session.sessionId,
-            artifacts: agentResult.artifacts?.isNotEmpty == true
-                ? agentResult.artifacts
-                : null,
-            message: agentResult.message,
-            finishReason: finishReason,
-            snapshotId: config.store != null ? finalSnapshotId : null,
-            state: config.store == null
-                ? toClientState(session.getState())
-                : null,
-          );
         },
       );
+
+      runner = SessionRunner<State>(
+        session,
+        runnerInputController.stream,
+        store: resolvedStore,
+        context: ctx.context,
+        lastSnapshot: snapshot,
+        cancel: cancelToken,
+        onDetach: (snapshotId) {
+          detachedSnapshotId = snapshotId;
+          if (!detachCompleter.isCompleted) detachCompleter.complete();
+
+          // Refresh the detached snapshot's heartbeat periodically. The
+          // mutator beats the two rows a live worker is still owed a write
+          // for - a `pending` one while the turn runs, and an `aborting`
+          // one while the stopped turn drains toward its finalize - and
+          // no-ops on any other (settled) row, so it never resurrects a
+          // terminal snapshot or clobbers a concurrent finalize. If a read
+          // sees this heartbeat go stale, the snapshot is reported as
+          // `expired` (worker presumed dead).
+          heartbeatTimer = Timer.periodic(_defaultHeartbeatInterval, (_) {
+            unawaited(
+              resolvedStore
+                  .saveSnapshot(snapshotId, (current) {
+                    final status = current?.status?.value;
+                    if (status != 'pending' && status != 'aborting') {
+                      return null;
+                    }
+                    current!.heartbeatAt = DateTime.now()
+                        .toUtc()
+                        .toIso8601String();
+                    return current;
+                  }, context: ctx.context)
+                  .catchError((_) {
+                    // Best-effort heartbeat; ignore transient store errors.
+                    return null;
+                  }),
+            );
+          });
+
+          if (resolvedStore is SnapshotChangeNotifier) {
+            // Capture the unsubscribe in a local first: if
+            // `onSnapshotStateChange` fires the callback synchronously on
+            // registration, the outer `unsubscribe` would still be null.
+            void Function()? localUnsubscribe;
+            localUnsubscribe = (resolvedStore as SnapshotChangeNotifier)
+                .onSnapshotStateChange(snapshotId, (snap) {
+                  // The runtime's own abort flips the row to `aborting`; a
+                  // foreign writer that lands `aborted` directly still means
+                  // stop.
+                  final status = snap.status?.value;
+                  if (status != 'aborting' && status != 'aborted') return;
+                  // The flip stops the work, not the worker: the run is
+                  // winding down toward its finalize write now, and the
+                  // heartbeat keeps running so readers see a live `aborting`
+                  // row instead of presuming the worker dead the moment the
+                  // flip lands. The flow's `finally` stops the beats right
+                  // before the finalize; the budget bounds a worker whose fn
+                  // never observes the cancellation, so a truly wedged run
+                  // still goes stale and reads as `expired`.
+                  windDownBudget = Timer(
+                    _windDownHeartbeatBudget,
+                    stopHeartbeat,
+                  );
+                  cancelController.cancel();
+                  localUnsubscribe?.call();
+                }, context: ctx.context);
+            unsubscribe = localUnsubscribe;
+          }
+        },
+
+        onEndTurn: (snapshotId, finishReason) {
+          if (!runner.isDetached) {
+            emitChunk(
+              AgentStreamChunk(
+                turnEnd: TurnEnd(
+                  snapshotId: config.store != null ? snapshotId : null,
+                  finishReason: finishReason,
+                ),
+              ),
+            );
+          }
+        },
+      );
+
+      void sendArtifactChunk(Object? a) {
+        if (!runner.isDetached) {
+          emitChunk(AgentStreamChunk(artifact: a as Artifact));
+        }
+      }
+
+      final offArtifactAdded = session.on('artifactAdded', sendArtifactChunk);
+      final offArtifactUpdated = session.on(
+        'artifactUpdated',
+        sendArtifactChunk,
+      );
+
+      dynamic lastSentCustom;
+      void sendCustomPatch(Object? _) {
+        if (runner.isDetached) return;
+        final transformed = toClientState(session.getState())?.custom;
+        JsonPatch patch;
+        if (runner.firstCustomPatchInTurn) {
+          patch = [
+            {'op': 'replace', 'path': '', 'value': _clone(transformed)},
+          ];
+          runner.firstCustomPatchInTurn = false;
+        } else {
+          patch = diff(lastSentCustom, transformed);
+        }
+        lastSentCustom = _clone(transformed);
+        if (patch.isNotEmpty) {
+          emitChunk(
+            AgentStreamChunk(
+              customPatch: patch.map(JsonPatchOperation.fromJson).toList(),
+            ),
+          );
+        }
+      }
+
+      final offCustomChanged = session.on('customChanged', sendCustomPatch);
+
+      void sendChunk(AgentStreamChunk chunk) {
+        if (!runner.isDetached) emitChunk(chunk);
+      }
+
+      Future<({AgentResult result, String? finalSnapshotId})> flow() async {
+        try {
+          final result = await runWithSession(
+            session,
+            () => fn(
+              runner,
+              AgentFnOptions(
+                sendChunk: sendChunk,
+                cancel: cancelToken,
+                context: ctx.context,
+              ),
+            ),
+          );
+          final finalSnapshotId = await runner.maybeSnapshot();
+          return (result: result, finalSnapshotId: finalSnapshotId);
+        } finally {
+          // The turn has settled (the snapshot reached a terminal status),
+          // so stop refreshing its heartbeat.
+          stopHeartbeat();
+          unlinkCancel?.call();
+          unsubscribe?.call();
+          offArtifactAdded();
+          offArtifactUpdated();
+          offCustomChanged();
+        }
+      }
+
+      final flowFuture = flow();
+
+      // Race the background flow execution against the detach signal.
+      final outcome = Completer<_Outcome>();
+      flowFuture
+          .then((v) {
+            if (!outcome.isCompleted) outcome.complete(_Outcome.flow(v));
+          })
+          .catchError((Object e, StackTrace s) {
+            if (!outcome.isCompleted) outcome.completeError(e, s);
+          });
+      detachCompleter.future
+          .then((_) {
+            if (!outcome.isCompleted) outcome.complete(_Outcome.detached());
+          })
+          .catchError((Object e, StackTrace s) {
+            if (!outcome.isCompleted) outcome.completeError(e, s);
+          });
+
+      final result = await outcome.future;
+
+      if (result.isDetached) {
+        // Swallow any later flow error now that we've detached.
+        unawaited(
+          flowFuture.catchError(
+            (_) => (result: AgentResult(), finalSnapshotId: null),
+          ),
+        );
+        return AgentOutput(
+          sessionId: session.sessionId,
+          snapshotId: detachedSnapshotId,
+          finishReason: AgentFinishReason.detached,
+          state: config.store == null
+              ? toClientState(session.getState())
+              : null,
+        );
+      }
+
+      final flowValue = result.flowValue!;
+      final agentResult = flowValue.result;
+      final finalSnapshotId = flowValue.finalSnapshotId;
+
+      // A turn failed: resolve gracefully with the last-good state.
+      if (runner.lastTurnFinishReason == AgentFinishReason.failed &&
+          runner.lastTurnError != null) {
+        final lastGood = runner.lastGoodState ?? session.getState();
+        final lastGoodMessages = lastGood.messages;
+        return AgentOutput(
+          sessionId: session.sessionId,
+          finishReason: AgentFinishReason.failed,
+          error: _toErrorInfo(runner.lastTurnError!),
+          artifacts: agentResult.artifacts?.isNotEmpty == true
+              ? agentResult.artifacts
+              : null,
+          message: lastGoodMessages?.isNotEmpty == true
+              ? lastGoodMessages!.last
+              : null,
+          snapshotId: config.store != null
+              ? await runner.ensureRecoverySnapshot()
+              : null,
+          state: config.store == null ? toClientState(lastGood) : null,
+        );
+      }
+
+      final finishReason =
+          agentResult.finishReason ?? runner.lastTurnFinishReason;
+
+      return AgentOutput(
+        sessionId: session.sessionId,
+        artifacts: agentResult.artifacts?.isNotEmpty == true
+            ? agentResult.artifacts
+            : null,
+        message: agentResult.message,
+        finishReason: finishReason,
+        snapshotId: config.store != null ? finalSnapshotId : null,
+        state: config.store == null ? toClientState(session.getState()) : null,
+      );
+    },
+  );
 
   registry.register(primaryAction);
 

--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -420,8 +420,8 @@ class SessionRunner<State> {
 
   /// Cooperative cancellation token (the Dart stand-in for `AbortSignal`). When
   /// cancelled, a turn that rejects out of `generate` is reported as `aborted`
-  /// (not `failed`) and its failed snapshot write is skipped (the abort path
-  /// already persisted the `aborted` status).
+  /// (not `failed`) and settled with a single `aborted` snapshot write (the
+  /// detached abort flip left the row `aborting`, which this finalize settles).
   final CancellationToken? cancel;
 
   /// The finish reason of the most recently completed turn.
@@ -522,18 +522,19 @@ class SessionRunner<State> {
 
           // The generate loop now resolves (rather than throws) on a
           // cooperative cancel, so a returned turn can still be an abort. Mirror
-          // the catch-path handling: record `aborted`, skip the `completed`
-          // snapshot (the abort path already persisted `aborted`, and the
-          // abort-aware mutator would skip a late `completed` write anyway), and
-          // stop processing further inputs.
+          // the catch-path handling: record `aborted`, write the settling
+          // `aborted` snapshot, and stop processing further inputs.
           if (cancel?.isCancelled ?? false) {
             lastTurnFinishReason = AgentFinishReason.aborted;
             lastTurnError = null;
-            // Persist the turn as `aborted`. The detached route already wrote
-            // `aborted` via `_abortSnapshotInStore`, in which case the
-            // abort-aware mutator makes this a no-op; but the attached route
-            // (`AgentTurn.abort()` -> token cancel) has written nothing, so
-            // without this the trailing `invocationEnd` snapshot would persist a
+            // Persist the turn as `aborted`. This is the second of the abort
+            // protocol's two writes: the detached route already flipped the row
+            // to `aborting` via `_abortSnapshotInStore` (which stopped the
+            // work), and this finalize settles it to `aborted` *with* the state
+            // - the abort-aware mutator lets it through because `aborting` is
+            // not terminal. The attached route (`AgentTurn.abort()` -> token
+            // cancel) has written nothing, so this is its only abort write;
+            // without it the trailing `invocationEnd` snapshot would persist a
             // half-finished turn as `completed` and later be picked as a resume
             // point.
             final snapshotId = await maybeSnapshot(
@@ -593,10 +594,11 @@ class SessionRunner<State> {
         turnIndex++;
       } catch (e) {
         // An aborted turn rejects out of `generate` and lands here. Treat it as
-        // `aborted` rather than `failed`: the abort path already persisted the
-        // `aborted` status (the abort-aware mutator would skip a `failed` write
-        // anyway), so we record the finish reason and skip the failed snapshot
-        // write entirely instead of reporting a spurious error.
+        // `aborted` rather than `failed`: the settling `aborted` snapshot was
+        // already written on the resolve path above (or, for a wedged run, is
+        // owed by the finalize), and the abort-aware mutator would skip a late
+        // `failed` write anyway, so we record the finish reason and skip the
+        // failed snapshot write entirely instead of reporting a spurious error.
         if (cancel?.isCancelled ?? false) {
           lastTurnFinishReason = AgentFinishReason.aborted;
           lastTurnError = null;
@@ -1081,10 +1083,11 @@ final class _InProcessTransport extends AgentTransport {
     context: context,
   );
 
-  // Detached/persist-only: flips the persisted snapshot to `aborted` and
-  // returns its prior status. A detached worker watching the snapshot cancels
-  // its own turn in response; an attached in-process turn's model call is not
-  // interrupted (see [runTurn]).
+  // Detached/persist-only: flips the persisted snapshot to `aborting` and
+  // returns its resulting status. A detached worker watching the snapshot
+  // cancels its own turn in response and its finalize settles the row to
+  // `aborted`; an attached in-process turn's model call is not interrupted
+  // (see [runTurn]).
   @override
   Future<SnapshotStatus?> abort(
     String snapshotId, {
@@ -1169,8 +1172,10 @@ class Agent<State> {
     context: context,
   );
 
-  /// Aborts a running snapshot. Requires a server store. Returns the prior
-  /// status, or `null`.
+  /// Aborts a running snapshot. Requires a server store. Returns the status
+  /// after the attempt (a pending row reads back as `aborting`; an
+  /// already-settled row returns its terminal status), or `null` when the
+  /// snapshot does not exist.
   Future<SnapshotStatus?> abort(
     String snapshotId, {
     Map<String, dynamic>? context,

--- a/packages/genkit/lib/src/ai/agents/agent.dart
+++ b/packages/genkit/lib/src/ai/agents/agent.dart
@@ -205,6 +205,10 @@ Future<String?> _abortSnapshotInStore(
       return current;
     }
     current.status = SnapshotStatus.aborting;
+    // Advance `updatedAt` so a client ordering or displaying by it sees the
+    // abort as activity. Matches Go, which stamps `UpdatedAt` on this flip; the
+    // verbatim re-persist branch above deliberately leaves it alone.
+    current.updatedAt = DateTime.now().toUtc().toIso8601String();
     resultStatus = 'aborting';
     return current;
   }, context: context);
@@ -593,16 +597,28 @@ class SessionRunner<State> {
         if (aborted) break;
         turnIndex++;
       } catch (e) {
-        // An aborted turn rejects out of `generate` and lands here. Treat it as
-        // `aborted` rather than `failed`: the settling `aborted` snapshot was
-        // already written on the resolve path above (or, for a wedged run, is
-        // owed by the finalize), and the abort-aware mutator would skip a late
-        // `failed` write anyway, so we record the finish reason and skip the
-        // failed snapshot write entirely instead of reporting a spurious error.
+        // An aborted turn rejects out of `generate` (or out of any action's
+        // `cancel.throwIfCancelled()`) and lands here. Treat it as `aborted`
+        // rather than `failed` and settle the turn ourselves: unlike the resolve
+        // path above, nothing has written the settling snapshot yet, so we own
+        // the finalize. The detached route already flipped the row to `aborting`
+        // via `_abortSnapshotInStore` (stopping the work); this write settles it
+        // to `aborted` *with* the last-good state (the abort-aware mutator lets
+        // it through because `aborting` is not terminal). Without it the row
+        // would stay `aborting`, later shape to `expired` on read, and drop the
+        // last-good state on resume.
         if (cancel?.isCancelled ?? false) {
           lastTurnFinishReason = AgentFinishReason.aborted;
           lastTurnError = null;
-          _notifyEndTurn(_lastSnapshot?.snapshotId, AgentFinishReason.aborted);
+          final snapshotId = await maybeSnapshot(
+            status: 'aborted',
+            snapshotId: turnSnapshotId,
+            finishReason: AgentFinishReason.aborted,
+          );
+          _notifyEndTurn(
+            snapshotId ?? _lastSnapshot?.snapshotId,
+            AgentFinishReason.aborted,
+          );
           break;
         }
 
@@ -894,14 +910,29 @@ _resolveSession<State>(
 
   if (init?.sessionId != null) {
     // Resume the session's latest snapshot. The store returns the latest leaf
-    // regardless of status, but only `completed` snapshots are resumable - so
-    // if the leaf is a non-resumable turn, walk back over its parent chain to
-    // the last-good (`completed`) snapshot. When the session has no resumable
-    // snapshot, seed a fresh session bound to the requested sessionId.
+    // regardless of status; a terminal leaf carrying state (`completed`,
+    // `failed`, or `aborted`) is resumable, so if the leaf is a non-resumable
+    // turn, walk back over its parent chain to the last-good snapshot. When the
+    // session has no resumable snapshot, seed a fresh session bound to the
+    // requested sessionId.
     var snapshot = await store.getSnapshot(
       sessionId: init!.sessionId,
       context: context,
     );
+    // A `pending` or `aborting` leaf is an in-flight run: resuming from an
+    // earlier snapshot would fork the session away from work that is about to be
+    // committed, so reject rather than walk (matching Go's `resumeSessionFrom`).
+    // The caller waits for the run to finalize, or resumes the exact `snapshotId`
+    // once its worker is presumed dead.
+    final leafStatus = snapshot?.status?.value;
+    if (leafStatus == 'pending' || leafStatus == 'aborting') {
+      throw GenkitException(
+        "Session '${init.sessionId}' has an in-flight leaf snapshot "
+        "'${snapshot!.snapshotId}' (status: $leafStatus); wait for it to "
+        'finalize before resuming, or abort it first.',
+        status: StatusCodes.FAILED_PRECONDITION,
+      );
+    }
     final visited = <String>{};
     while (snapshot != null && !_isResumableLeaf(snapshot)) {
       if (visited.contains(snapshot.snapshotId)) {

--- a/packages/genkit/lib/src/types.dart
+++ b/packages/genkit/lib/src/types.dart
@@ -201,6 +201,7 @@ abstract class $ModelResponse {
   $Message? get message;
   FinishReason get finishReason;
   String? get finishMessage;
+  $RuntimeError? get error;
   double? get latencyMs;
   $GenerationUsage? get usage;
   Map<String, dynamic>? get custom;
@@ -225,10 +226,18 @@ abstract class $MiddlewareRef {
 }
 
 @Schema()
+abstract class $RuntimeError {
+  String? get status;
+  String get message;
+  Map<String, dynamic>? get details;
+}
+
+@Schema()
 abstract class $GenerateResponse {
   $Message? get message;
   FinishReason? get finishReason;
   String? get finishMessage;
+  $RuntimeError? get error;
   double? get latencyMs;
   $GenerationUsage? get usage;
   Map<String, dynamic>? get custom;
@@ -290,6 +299,7 @@ extension type FinishReason(String value) {
   static FinishReason get length => FinishReason('length');
   static FinishReason get blocked => FinishReason('blocked');
   static FinishReason get aborted => FinishReason('aborted');
+  static FinishReason get failed => FinishReason('failed');
   static FinishReason get interrupted => FinishReason('interrupted');
   static FinishReason get other => FinishReason('other');
   static FinishReason get unknown => FinishReason('unknown');
@@ -540,6 +550,7 @@ abstract class $Artifact {
 abstract class $GetSnapshotDataInput {
   String? get snapshotId;
   String? get sessionId;
+  bool? get metadataOnly;
 }
 
 extension type JsonPatchOp(String value) {
@@ -583,6 +594,7 @@ abstract class $SessionState {
 
 extension type SnapshotStatus(String value) {
   static SnapshotStatus get pending => SnapshotStatus('pending');
+  static SnapshotStatus get aborting => SnapshotStatus('aborting');
   static SnapshotStatus get completed => SnapshotStatus('completed');
   static SnapshotStatus get aborted => SnapshotStatus('aborted');
   static SnapshotStatus get failed => SnapshotStatus('failed');

--- a/packages/genkit/lib/src/types.g.dart
+++ b/packages/genkit/lib/src/types.g.dart
@@ -2324,6 +2324,7 @@ base class ModelResponse {
     Message? message,
     required FinishReason finishReason,
     String? finishMessage,
+    RuntimeError? error,
     double? latencyMs,
     GenerationUsage? usage,
     Map<String, dynamic>? custom,
@@ -2335,6 +2336,7 @@ base class ModelResponse {
       'message': ?message?.toJson(),
       'finishReason': finishReason.value,
       'finishMessage': ?finishMessage,
+      'error': ?error?.toJson(),
       'latencyMs': ?latencyMs,
       'usage': ?usage?.toJson(),
       'custom': ?custom,
@@ -2382,6 +2384,20 @@ base class ModelResponse {
       _json.remove('finishMessage');
     } else {
       _json['finishMessage'] = value;
+    }
+  }
+
+  RuntimeError? get error {
+    return _json['error'] == null
+        ? null
+        : RuntimeError.fromJson(_json['error'] as Map<String, dynamic>);
+  }
+
+  set error(RuntimeError? value) {
+    if (value == null) {
+      _json.remove('error');
+    } else {
+      _json['error'] = value.toJson();
     }
   }
 
@@ -2491,6 +2507,7 @@ base class _ModelResponseTypeFactory extends SchemanticType<ModelResponse> {
             'message': $Schema.fromMap({'\$ref': r'#/$defs/Message'}),
             'finishReason': $Schema.any(),
             'finishMessage': $Schema.string(),
+            'error': $Schema.fromMap({'\$ref': r'#/$defs/RuntimeError'}),
             'latencyMs': $Schema.number(),
             'usage': $Schema.fromMap({'\$ref': r'#/$defs/GenerationUsage'}),
             'custom': $Schema.object(additionalProperties: $Schema.any()),
@@ -2503,6 +2520,7 @@ base class _ModelResponseTypeFactory extends SchemanticType<ModelResponse> {
         .value,
     dependencies: [
       Message.$schema,
+      RuntimeError.$schema,
       GenerationUsage.$schema,
       GenerateRequest.$schema,
       Operation.$schema,
@@ -2710,6 +2728,95 @@ base class _MiddlewareRefTypeFactory extends SchemanticType<MiddlewareRef> {
   );
 }
 
+base class RuntimeError {
+  /// Creates a [RuntimeError] from a JSON map.
+  factory RuntimeError.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  RuntimeError._(this._json);
+
+  RuntimeError({
+    String? status,
+    required String message,
+    Map<String, dynamic>? details,
+  }) {
+    _json = {'status': ?status, 'message': message, 'details': ?details};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [RuntimeError].
+  static const SchemanticType<RuntimeError> $schema =
+      _RuntimeErrorTypeFactory();
+
+  String? get status {
+    return _json['status'] as String?;
+  }
+
+  set status(String? value) {
+    if (value == null) {
+      _json.remove('status');
+    } else {
+      _json['status'] = value;
+    }
+  }
+
+  String get message {
+    return _json['message'] as String;
+  }
+
+  set message(String value) {
+    _json['message'] = value;
+  }
+
+  Map<String, dynamic>? get details {
+    return (_json['details'] as Map?)?.cast<String, dynamic>();
+  }
+
+  set details(Map<String, dynamic>? value) {
+    if (value == null) {
+      _json.remove('details');
+    } else {
+      _json['details'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [RuntimeError] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _RuntimeErrorTypeFactory extends SchemanticType<RuntimeError> {
+  const _RuntimeErrorTypeFactory();
+
+  @override
+  RuntimeError parse(Object? json) {
+    return RuntimeError._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'RuntimeError',
+    definition: $Schema
+        .object(
+          properties: {
+            'status': $Schema.string(),
+            'message': $Schema.string(),
+            'details': $Schema.object(additionalProperties: $Schema.any()),
+          },
+          required: ['message'],
+        )
+        .value,
+    dependencies: [],
+  );
+}
+
 base class GenerateResponse {
   /// Creates a [GenerateResponse] from a JSON map.
   factory GenerateResponse.fromJson(Map<String, dynamic> json) =>
@@ -2721,6 +2828,7 @@ base class GenerateResponse {
     Message? message,
     FinishReason? finishReason,
     String? finishMessage,
+    RuntimeError? error,
     double? latencyMs,
     GenerationUsage? usage,
     Map<String, dynamic>? custom,
@@ -2733,6 +2841,7 @@ base class GenerateResponse {
       'message': ?message?.toJson(),
       'finishReason': ?finishReason?.value,
       'finishMessage': ?finishMessage,
+      'error': ?error?.toJson(),
       'latencyMs': ?latencyMs,
       'usage': ?usage?.toJson(),
       'custom': ?custom,
@@ -2784,6 +2893,20 @@ base class GenerateResponse {
       _json.remove('finishMessage');
     } else {
       _json['finishMessage'] = value;
+    }
+  }
+
+  RuntimeError? get error {
+    return _json['error'] == null
+        ? null
+        : RuntimeError.fromJson(_json['error'] as Map<String, dynamic>);
+  }
+
+  set error(RuntimeError? value) {
+    if (value == null) {
+      _json.remove('error');
+    } else {
+      _json['error'] = value.toJson();
     }
   }
 
@@ -2908,6 +3031,7 @@ base class _GenerateResponseTypeFactory
             'message': $Schema.fromMap({'\$ref': r'#/$defs/Message'}),
             'finishReason': $Schema.any(),
             'finishMessage': $Schema.string(),
+            'error': $Schema.fromMap({'\$ref': r'#/$defs/RuntimeError'}),
             'latencyMs': $Schema.number(),
             'usage': $Schema.fromMap({'\$ref': r'#/$defs/GenerationUsage'}),
             'custom': $Schema.object(additionalProperties: $Schema.any()),
@@ -2922,6 +3046,7 @@ base class _GenerateResponseTypeFactory
         .value,
     dependencies: [
       Message.$schema,
+      RuntimeError.$schema,
       GenerationUsage.$schema,
       GenerateRequest.$schema,
       Operation.$schema,
@@ -6507,8 +6632,16 @@ base class GetSnapshotDataInput {
 
   GetSnapshotDataInput._(this._json);
 
-  GetSnapshotDataInput({String? snapshotId, String? sessionId}) {
-    _json = {'snapshotId': ?snapshotId, 'sessionId': ?sessionId};
+  GetSnapshotDataInput({
+    String? snapshotId,
+    String? sessionId,
+    bool? metadataOnly,
+  }) {
+    _json = {
+      'snapshotId': ?snapshotId,
+      'sessionId': ?sessionId,
+      'metadataOnly': ?metadataOnly,
+    };
   }
 
   late final Map<String, dynamic> _json;
@@ -6541,6 +6674,18 @@ base class GetSnapshotDataInput {
     }
   }
 
+  bool? get metadataOnly {
+    return _json['metadataOnly'] as bool?;
+  }
+
+  set metadataOnly(bool? value) {
+    if (value == null) {
+      _json.remove('metadataOnly');
+    } else {
+      _json['metadataOnly'] = value;
+    }
+  }
+
   @override
   String toString() {
     return _json.toString();
@@ -6569,6 +6714,7 @@ base class _GetSnapshotDataInputTypeFactory
           properties: {
             'snapshotId': $Schema.string(),
             'sessionId': $Schema.string(),
+            'metadataOnly': $Schema.boolean(),
           },
         )
         .value,

--- a/packages/genkit/test/ai/agents/agent_test.dart
+++ b/packages/genkit/test/ai/agents/agent_test.dart
@@ -598,6 +598,60 @@ void main() {
       },
     );
 
+    test(
+      'getSnapshotData reports a stale aborting snapshot as expired',
+      () async {
+        // A cross-runtime read: a Go server settles its abort in two writes
+        // (flip -> `aborting`, later finalize -> `aborted`) and keeps
+        // heartbeating while it winds down. A stale `aborting` beat means the
+        // draining worker died, so - like a stale `pending` - it must read as
+        // `expired`. Dart itself settles aborts in one write and never emits
+        // `aborting`, but must still read one correctly off the wire.
+        final store = InMemorySessionStore();
+        final agent = ai.defineCustomAgent(
+          name: 'winddown',
+          store: store,
+          fn: (sess, options) async {
+            await sess.run((input, ctx) async => null);
+            return AgentResult();
+          },
+        );
+
+        final sessionId = generateUuidV4();
+        final stale = DateTime.now()
+            .toUtc()
+            .subtract(const Duration(minutes: 5))
+            .toIso8601String();
+        final id = await store.saveSnapshot(
+          null,
+          (_) => SessionSnapshot(
+            snapshotId: '',
+            createdAt: stale,
+            updatedAt: stale,
+            heartbeatAt: stale,
+            status: SnapshotStatus.aborting,
+            state: SessionState(
+              sessionId: sessionId,
+              messages: [],
+              artifacts: [],
+            ),
+          ),
+        );
+
+        // Stored status is still `aborting`...
+        final raw = await store.getSnapshot(snapshotId: id);
+        expect(raw!.status?.value, 'aborting');
+
+        // ...but a read through the agent surfaces it as `expired`.
+        final snapshot = await agent.getSnapshotData(snapshotId: id);
+        expect(snapshot!.status?.value, 'expired');
+
+        // The expiry is read-only: the stored snapshot stays `aborting`.
+        final after = await store.getSnapshot(snapshotId: id);
+        expect(after!.status?.value, 'aborting');
+      },
+    );
+
     test('getSnapshotData requires a store', () async {
       final agent = ai.defineCustomAgent(
         name: 'noStore',

--- a/packages/genkit/test/ai/agents/agent_test.dart
+++ b/packages/genkit/test/ai/agents/agent_test.dart
@@ -474,7 +474,8 @@ void main() {
       final chat = agent.chat(sessionId: sessionId);
       final res = await chat.send(text: 'hi');
       final prior = await agent.abort(res.snapshotId!);
-      // Turn already completed, so abort reports the prior status.
+      // Turn already settled, so abort is a no-op and returns the existing
+      // terminal status unchanged (only a `pending` row flips to `aborting`).
       expect(prior?.value, 'completed');
     });
 
@@ -545,7 +546,8 @@ void main() {
         AgentAbortRequest(snapshotId: res.snapshotId!),
       );
       expect(response.snapshotId, res.snapshotId);
-      // Turn already completed, so the prior status is reported.
+      // Turn already settled, so abort is a no-op and returns the existing
+      // terminal status unchanged.
       expect(response.status?.value, 'completed');
     });
 

--- a/packages/genkit/test/ai/agents/agent_test.dart
+++ b/packages/genkit/test/ai/agents/agent_test.dart
@@ -654,6 +654,52 @@ void main() {
       },
     );
 
+    test(
+      'a detached run aborted via a thrown cancel settles as aborted',
+      () async {
+        // Regression: a detached turn aborted mid-flight can *throw* out of the
+        // handler (an action's `cancel.throwIfCancelled()`) rather than resolve.
+        // That lands in the run loop's catch, which must still write the settling
+        // `aborted` snapshot - without it the row stays `aborting`, later shapes
+        // to `expired` on read, and drops the last-good state on resume.
+        final store = InMemorySessionStore();
+        final handlerRunning = Completer<void>();
+        final agent = ai.defineCustomAgent(
+          name: 'thrownAbort',
+          store: store,
+          fn: (sess, options) async {
+            await sess.run((input, ctx) async {
+              sess.updateCustom((_) => {'count': 1});
+              if (!handlerRunning.isCompleted) handlerRunning.complete();
+              // Block until aborted, then throw the way an action would.
+              await options.cancel?.whenCancelled;
+              options.cancel?.throwIfCancelled();
+              return TurnResult(finishReason: AgentFinishReason.stop);
+            });
+            return AgentResult(finishReason: sess.lastTurnFinishReason);
+          },
+        );
+
+        final sessionId = generateUuidV4();
+        final chat = agent.chat(sessionId: sessionId);
+        final task = await chat.detach(text: 'do the long thing');
+
+        await handlerRunning.future;
+        await task.abort();
+
+        final terminal = await task.wait(
+          interval: const Duration(milliseconds: 10),
+        );
+        expect(terminal.status?.value, 'aborted');
+        // Settled *with* the last-good state, not dropped.
+        expect(terminal.custom, {'count': 1});
+
+        // And the stored row is terminal, never left `aborting`/`expired`.
+        final stored = await store.getSnapshot(snapshotId: terminal.snapshotId);
+        expect(stored!.status?.value, 'aborted');
+      },
+    );
+
     test('getSnapshotData requires a store', () async {
       final agent = ai.defineCustomAgent(
         name: 'noStore',

--- a/packages/genkit/test/ai/agents/agent_test.dart
+++ b/packages/genkit/test/ai/agents/agent_test.dart
@@ -603,12 +603,11 @@ void main() {
     test(
       'getSnapshotData reports a stale aborting snapshot as expired',
       () async {
-        // A cross-runtime read: a Go server settles its abort in two writes
-        // (flip -> `aborting`, later finalize -> `aborted`) and keeps
-        // heartbeating while it winds down. A stale `aborting` beat means the
-        // draining worker died, so - like a stale `pending` - it must read as
-        // `expired`. Dart itself settles aborts in one write and never emits
-        // `aborting`, but must still read one correctly off the wire.
+        // The abort protocol settles in two writes (flip -> `aborting`, later
+        // finalize -> `aborted`), and the worker keeps heartbeating while it
+        // winds down. A stale `aborting` beat means the draining worker died,
+        // so - like a stale `pending` - it must read as `expired`. This
+        // exercises the read side, whatever runtime wrote the row.
         final store = InMemorySessionStore();
         final agent = ai.defineCustomAgent(
           name: 'winddown',

--- a/packages/genkit/test/ai/agents/agent_test.dart
+++ b/packages/genkit/test/ai/agents/agent_test.dart
@@ -654,51 +654,48 @@ void main() {
       },
     );
 
-    test(
-      'a detached run aborted via a thrown cancel settles as aborted',
-      () async {
-        // Regression: a detached turn aborted mid-flight can *throw* out of the
-        // handler (an action's `cancel.throwIfCancelled()`) rather than resolve.
-        // That lands in the run loop's catch, which must still write the settling
-        // `aborted` snapshot - without it the row stays `aborting`, later shapes
-        // to `expired` on read, and drops the last-good state on resume.
-        final store = InMemorySessionStore();
-        final handlerRunning = Completer<void>();
-        final agent = ai.defineCustomAgent(
-          name: 'thrownAbort',
-          store: store,
-          fn: (sess, options) async {
-            await sess.run((input, ctx) async {
-              sess.updateCustom((_) => {'count': 1});
-              if (!handlerRunning.isCompleted) handlerRunning.complete();
-              // Block until aborted, then throw the way an action would.
-              await options.cancel?.whenCancelled;
-              options.cancel?.throwIfCancelled();
-              return TurnResult(finishReason: AgentFinishReason.stop);
-            });
-            return AgentResult(finishReason: sess.lastTurnFinishReason);
-          },
-        );
+    test('a detached run aborted via a thrown cancel settles as aborted', () async {
+      // Regression: a detached turn aborted mid-flight can *throw* out of the
+      // handler (an action's `cancel.throwIfCancelled()`) rather than resolve.
+      // That lands in the run loop's catch, which must still write the settling
+      // `aborted` snapshot - without it the row stays `aborting`, later shapes
+      // to `expired` on read, and drops the last-good state on resume.
+      final store = InMemorySessionStore();
+      final handlerRunning = Completer<void>();
+      final agent = ai.defineCustomAgent(
+        name: 'thrownAbort',
+        store: store,
+        fn: (sess, options) async {
+          await sess.run((input, ctx) async {
+            sess.updateCustom((_) => {'count': 1});
+            if (!handlerRunning.isCompleted) handlerRunning.complete();
+            // Block until aborted, then throw the way an action would.
+            await options.cancel?.whenCancelled;
+            options.cancel?.throwIfCancelled();
+            return TurnResult(finishReason: AgentFinishReason.stop);
+          });
+          return AgentResult(finishReason: sess.lastTurnFinishReason);
+        },
+      );
 
-        final sessionId = generateUuidV4();
-        final chat = agent.chat(sessionId: sessionId);
-        final task = await chat.detach(text: 'do the long thing');
+      final sessionId = generateUuidV4();
+      final chat = agent.chat(sessionId: sessionId);
+      final task = await chat.detach(text: 'do the long thing');
 
-        await handlerRunning.future;
-        await task.abort();
+      await handlerRunning.future;
+      await task.abort();
 
-        final terminal = await task.wait(
-          interval: const Duration(milliseconds: 10),
-        );
-        expect(terminal.status?.value, 'aborted');
-        // Settled *with* the last-good state, not dropped.
-        expect(terminal.custom, {'count': 1});
+      final terminal = await task.wait(
+        interval: const Duration(milliseconds: 10),
+      );
+      expect(terminal.status?.value, 'aborted');
+      // Settled *with* the last-good state, not dropped.
+      expect(terminal.custom, {'count': 1});
 
-        // And the stored row is terminal, never left `aborting`/`expired`.
-        final stored = await store.getSnapshot(snapshotId: terminal.snapshotId);
-        expect(stored!.status?.value, 'aborted');
-      },
-    );
+      // And the stored row is terminal, never left `aborting`/`expired`.
+      final stored = await store.getSnapshot(snapshotId: terminal.snapshotId);
+      expect(stored!.status?.value, 'aborted');
+    });
 
     test('getSnapshotData requires a store', () async {
       final agent = ai.defineCustomAgent(

--- a/packages/genkit/test/ai/agents/agents_spec_test.dart
+++ b/packages/genkit/test/ai/agents/agents_spec_test.dart
@@ -842,7 +842,13 @@ Future<void> _executeAbort(
     throw _SpecError('abort invocation requires snapshotId');
   }
 
-  final previousStatus = await agent.abort(snapshotId);
+  // Capture the status before aborting so we can assert `expectPreviousStatus`.
+  // `abort()` returns the status *after* the attempt (a pending row reads back
+  // as `aborting`), while the spec asserts the *previous* status, so the harness
+  // reads it first. Mirrors the Go and JS conformance harnesses.
+  final before = await agent.getSnapshotData(snapshotId: snapshotId);
+  final previousStatus = before?.status;
+  await agent.abort(snapshotId);
 
   if (resolved.containsKey('expectPreviousStatus')) {
     final expected = resolved['expectPreviousStatus']; // null means absent

--- a/packages/genkit/test/ai/agents/agents_spec_test.dart
+++ b/packages/genkit/test/ai/agents/agents_spec_test.dart
@@ -209,7 +209,10 @@ class _ProgrammableModel {
 // Harness setup
 // ---------------------------------------------------------------------------
 
-Map<String, Agent> _setupHarness(Genkit ai, _ProgrammableModel pm) {
+({Map<String, Agent> agents, Map<String, SessionStore> stores}) _setupHarness(
+  Genkit ai,
+  _ProgrammableModel pm,
+) {
   ai.defineModel(
     name: 'programmableModel',
     fn: (request, ctx) async {
@@ -270,10 +273,11 @@ Map<String, Agent> _setupHarness(Genkit ai, _ProgrammableModel pm) {
     model: modelRef('programmableModel'),
   );
 
+  final promptAgentWithStoreStore = InMemorySessionStore();
   final promptAgentWithStore = ai.defineAgent(
     name: 'promptAgentWithStore',
     model: modelRef('programmableModel'),
-    store: InMemorySessionStore(),
+    store: promptAgentWithStoreStore,
   );
 
   final promptAgentWithTools = ai.defineAgent(
@@ -297,9 +301,10 @@ Map<String, Agent> _setupHarness(Genkit ai, _ProgrammableModel pm) {
   );
 
   // --- Custom agents ---
+  final customAgentBlockingStore = InMemorySessionStore();
   final customAgentBlocking = ai.defineCustomAgent(
     name: 'customAgentBlocking',
-    store: InMemorySessionStore(),
+    store: customAgentBlockingStore,
     fn: (sess, options) async {
       await sess.run((input, ctx) async {
         final cancel = options.cancel;
@@ -317,9 +322,10 @@ Map<String, Agent> _setupHarness(Genkit ai, _ProgrammableModel pm) {
     },
   );
 
+  final customAgentFailingStore = InMemorySessionStore();
   final customAgentFailing = ai.defineCustomAgent(
     name: 'customAgentFailing',
-    store: InMemorySessionStore(),
+    store: customAgentFailingStore,
     fn: (sess, options) async {
       await sess.run((input, ctx) async {
         // Throw a GenkitException so the surfaced error message is exactly
@@ -456,20 +462,29 @@ Map<String, Agent> _setupHarness(Genkit ai, _ProgrammableModel pm) {
     },
   );
 
-  return {
-    'promptAgent': promptAgent,
-    'promptAgentWithStore': promptAgentWithStore,
-    'promptAgentWithTools': promptAgentWithTools,
-    'promptAgentWithInterrupt': promptAgentWithInterrupt,
-    'promptAgentWithRestartTool': promptAgentWithRestartTool,
-    'customAgentBlocking': customAgentBlocking,
-    'customAgentFailing': customAgentFailing,
-    'customAgentWithArtifacts': customAgentWithArtifacts,
-    'customAgentWithCustomState': customAgentWithCustomState,
-    'customAgentWithMultiCustomState': customAgentWithMultiCustomState,
-    'customAgentWithArtifactsStore': customAgentWithArtifactsStore,
-    'customAgentWithCustomStateStore': customAgentWithCustomStateStore,
-  };
+  return (
+    agents: {
+      'promptAgent': promptAgent,
+      'promptAgentWithStore': promptAgentWithStore,
+      'promptAgentWithTools': promptAgentWithTools,
+      'promptAgentWithInterrupt': promptAgentWithInterrupt,
+      'promptAgentWithRestartTool': promptAgentWithRestartTool,
+      'customAgentBlocking': customAgentBlocking,
+      'customAgentFailing': customAgentFailing,
+      'customAgentWithArtifacts': customAgentWithArtifacts,
+      'customAgentWithCustomState': customAgentWithCustomState,
+      'customAgentWithMultiCustomState': customAgentWithMultiCustomState,
+      'customAgentWithArtifactsStore': customAgentWithArtifactsStore,
+      'customAgentWithCustomStateStore': customAgentWithCustomStateStore,
+    },
+    // Raw stores for the abort steps, which read the *stored* status directly
+    // (unshaped by heartbeat expiry) to assert `expectPreviousStatus`.
+    stores: {
+      'promptAgentWithStore': promptAgentWithStoreStore,
+      'customAgentBlocking': customAgentBlockingStore,
+      'customAgentFailing': customAgentFailingStore,
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -833,6 +848,7 @@ void _assertSnapshot(SessionSnapshot snapshot, Map? expect) {
 
 Future<void> _executeAbort(
   Agent agent,
+  SessionStore? store,
   Map<String, dynamic> step,
   Map<String, dynamic> captures,
 ) async {
@@ -845,8 +861,14 @@ Future<void> _executeAbort(
   // Capture the status before aborting so we can assert `expectPreviousStatus`.
   // `abort()` returns the status *after* the attempt (a pending row reads back
   // as `aborting`), while the spec asserts the *previous* status, so the harness
-  // reads it first. Mirrors the Go and JS conformance harnesses.
-  final before = await agent.getSnapshotData(snapshotId: snapshotId);
+  // reads it first. Read the *stored* status directly (via the store), not
+  // `getSnapshotData`, which shapes a stale detached beat to `expired` and would
+  // spuriously fail `expectPreviousStatus: pending`. Mirrors the Go harness,
+  // which reads `store.GetSnapshot`.
+  if (store == null) {
+    throw _SpecError('abort invocation requires a store-backed agent');
+  }
+  final before = await store.getSnapshot(snapshotId: snapshotId);
   final previousStatus = before?.status;
   await agent.abort(snapshotId);
 
@@ -924,11 +946,14 @@ void main() {
     late Genkit ai;
     late _ProgrammableModel pm;
     late Map<String, Agent> agents;
+    late Map<String, SessionStore> stores;
 
     setUp(() {
       ai = Genkit(promptDir: null);
       pm = _ProgrammableModel();
-      agents = _setupHarness(ai, pm);
+      final harness = _setupHarness(ai, pm);
+      agents = harness.agents;
+      stores = harness.stores;
     });
 
     tearDown(() => ai.shutdown());
@@ -955,7 +980,12 @@ void main() {
               case 'getSnapshotData':
                 await _executeGetSnapshotData(agent, step, captures);
               case 'abort':
-                await _executeAbort(agent, step, captures);
+                await _executeAbort(
+                  agent,
+                  stores[testCase['agent']],
+                  step,
+                  captures,
+                );
               case 'waitUntilCompleted':
                 await _executeWaitUntilCompleted(agent, step, captures);
               default:


### PR DESCRIPTION
Stacked on #397 (cancellation). Brings Dart's agent abort lifecycle and resume rules in line with the Go reference implementation (`go/ai/exp/agent.go`), which is the source of truth for the shared agent spec.

## Scope

### a. `aborting` snapshot status
Adds `aborting` to `SnapshotStatus` and adopts Go's two-write abort protocol so Dart both *emits* and *reads* the mid-flight window correctly.

Before, Dart settled an abort in a single write (`pending -> aborted`). Now it matches Go:

1. **Flip** (`_abortSnapshotInStore`): abort turns a `pending` row into `aborting`, stopping the work without stamping state. It leaves `heartbeatAt` where the worker left it, so a dead worker's row reads as `expired` at once rather than after a heartbeat timeout.
2. **Finalize** (`SessionRunner.maybeSnapshot`): the worker observes the flip, cancels its turn, and settles the row to `aborted` *with* the last-good state. The abort-aware mutator deliberately treats `aborting` as non-terminal so this finalize is allowed through.

Supporting changes for parity:
- `abort()` now returns the *resulting* status (`pending -> aborting`, already terminal -> existing status, missing -> null), matching Go's `Agent.Abort`. **This is a behavior change** from the prior "return previous status".
- `_isHeartbeatExpired` treats a stale `pending` *or* `aborting` beat as `expired` on read (both are in-flight, still-heartbeating states).
- `_windDownHeartbeatBudget` (5 min) bounds how long a winding-down worker keeps beating, so a wedged abort still goes stale and reads as `expired` instead of winding down forever.

### b. Rerunnable aborted snapshots
Resume is no longer restricted to `completed`. The resume guard now also accepts terminal snapshots that carry state, so an `aborted` run can be rerun: whether to continue from a run that was stopped is the caller's judgement, not the framework's. This pairs with the cancellation work in #397, where a cancelled generate resolves to a response with `finishReason: aborted` and the last-good history, which persists as a resumable `aborted` snapshot.
- `_assertResumable` accepts `completed`/`failed`/`aborted` rows that carry state (matching Go's `resumeSessionFrom`) and rejects `pending`/`aborting` with heartbeat-aware messaging (live beat: wait/retry; stale beat: resume from parent).
- `_isResumableLeaf` drives the `sessionId` parent-walk to the last-good leaf.

Note: the guard accepts `failed` for Go parity, but *producing* a useful `failed` snapshot (a model/tool error resolving to a response with `finishReason: failed`, `error`, and the last-good history, the way cancellation already does for `aborted`) is a follow-up. This PR only lands the wire types for it.

### Supporting: `RuntimeError` + `FinishReason.failed` + `GenerateResponse.error`
Regenerated `types.dart` / `types.g.dart` to pull in the error wire shape the updated schema now references directly from `ModelResponse.error` / `GenerateResponse.error` (previously only aliased via `AgentErrorInfo`), plus `FinishReason.failed`. These are the groundwork for the follow-up that makes a model/tool error resolve gracefully (mirroring cancellation's `aborted` response). Allowlisted `RuntimeError` in the schema generator so it compiles. (This also pulls in `metadataOnly` on `GetSnapshotDataInput` from the canonical schema; wiring it up is out of scope here.)

## Reading / handling `aborting`

`aborting` is transient and non-terminal: keep polling until a terminal status. `DetachedTask.wait()`/`poll()` already do this (`_terminalStatuses` excludes `aborting`).

```dart
final task = await chat.detach(text: 'do the long thing');
final status = await task.abort(); // may be `aborting` while it winds down
if (status?.value == SnapshotStatus.aborting.value) {
  final settled = await task.wait(); // ...ride the wind-down to the terminal row
  print(settled.status?.value); // 'aborted'
}
```

Reading a snapshot directly, branch on the status and re-read the non-terminal ones (a stale heartbeat surfaces as `expired`):

```dart
final snap = await agent.getSnapshotData(snapshotId: id);
switch (snap?.status?.value) {
  case 'completed':
  case 'aborted':
    break; // terminal - use as-is (and rerunnable, since it carries state)
  case 'pending':
  case 'aborting':
    break; // in-flight - poll again shortly
  case 'expired':
    break; // worker died mid-run - fall back to the last-good snapshot
}
```

## Tests
- `getSnapshotData reports a stale aborting snapshot as expired` (cross-runtime read: a Go server's stale `aborting` beat reads as `expired`).
- Updated the conformance harness (`_executeAbort`) to read the pre-abort status before aborting, since `abort()` now returns the *resulting* status - mirroring the Go and JS harnesses. Full conformance suite green.

## Note for reviewers
`abort()` returning the resulting status (vs the previous status) is an intentional Go-parity choice and diverges from JS's `agent.abort()`. Worth a CHANGELOG callout on release.
