### PR TITLE
fix(genkit_openai): do not require network or an API key at startup

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -17,15 +17,13 @@ dependencies:
 ### Basic Usage
 
 ```dart
-import 'dart:io';
 import 'package:genkit/genkit.dart';
 import 'package:genkit_openai/genkit_openai.dart';
 
 void main() async {
-  // Initialize Genkit with the OpenAI plugin
-  final ai = Genkit(plugins: [
-    openAI(apiKey: Platform.environment['OPENAI_API_KEY']),
-  ]);
+  // Initialize Genkit with the OpenAI plugin. The API key is read from the
+  // OPENAI_API_KEY environment variable when not passed explicitly.
+  final ai = Genkit(plugins: [openAI()]);
 
   // Generate text
   final response = await ai.generate(
@@ -36,6 +34,23 @@ void main() async {
   print(response.text);
 }
 ```
+
+### API Key
+
+The key is resolved in this order:
+
+1. `apiKeyProvider`, if given
+2. `apiKey`, if given
+3. the `OPENAI_API_KEY` environment variable
+
+Creating the plugin does no network I/O and does not require a key, so an app
+starts up (and the Dev UI connects) offline. A missing or invalid key surfaces
+when a model is actually called.
+
+Model discovery via `GET /models` happens only when listing actions, and is
+best-effort: if it fails, the plugin falls back to a curated catalog of common
+models plus any `models:` you registered. Models outside that catalog still
+work when named explicitly, so newly released ids need no plugin update.
 
 ### With Custom Options
 

--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -47,6 +47,11 @@ Creating the plugin does no network I/O and does not require a key, so an app
 starts up (and the Dev UI connects) offline. A missing or invalid key surfaces
 when a model is actually called.
 
+This is deliberately more permissive than the other Genkit SDKs, not parity
+with them: the JS plugin throws when constructed without a key and Go panics
+in `Init`. Dart defers the requirement to call time so the Dev UI stays
+usable before a key is exported, matching `genkit_anthropic`.
+
 Model discovery via `GET /models` happens only when listing actions, and is
 best-effort: if it fails, the plugin falls back to a curated catalog of common
 models plus any `models:` you registered. Models outside that catalog still

--- a/packages/genkit_openai/lib/genkit_openai.dart
+++ b/packages/genkit_openai/lib/genkit_openai.dart
@@ -72,10 +72,9 @@ typedef OpenAIApiKeyProvider = FutureOr<String> Function();
 /// Use this to create the plugin and to reference models:
 ///
 /// ```dart
-/// // Create the plugin
-/// final ai = Genkit(plugins: [
-///   openAI(apiKey: Platform.environment['OPENAI_API_KEY']),
-/// ]);
+/// // Create the plugin. The key falls back to the OPENAI_API_KEY
+/// // environment variable when not passed explicitly.
+/// final ai = Genkit(plugins: [openAI()]);
 ///
 /// // Reference a model
 /// final response = await ai.generate(
@@ -83,6 +82,9 @@ typedef OpenAIApiKeyProvider = FutureOr<String> Function();
 ///   prompt: 'Hello!',
 /// );
 /// ```
+///
+/// Creating the plugin does no I/O and needs no key: models resolve on demand,
+/// and a missing or invalid key surfaces at generate time.
 const OpenAICompatPluginHandle openAI = OpenAICompatPluginHandle();
 
 /// Handle class for configuring and referencing OpenAI-compatible models.
@@ -99,6 +101,9 @@ class OpenAICompatPluginHandle {
   /// (e.g. `'openrouter'`, `'nanogpt'`). It defaults to
   /// [defaultOpenAINamespace] and is used as the namespace prefix for all
   /// models registered by this instance (e.g. `openrouter/gpt-4o`).
+  ///
+  /// If neither [apiKey] nor [apiKeyProvider] is given, the key is read from
+  /// the `OPENAI_API_KEY` environment variable.
   GenkitPlugin call({
     String name = defaultOpenAINamespace,
     String? apiKey,

--- a/packages/genkit_openai/lib/src/known_models.dart
+++ b/packages/genkit_openai/lib/src/known_models.dart
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Chat models the plugin curates so they stay listable without network access.
+///
+/// The plugin normally discovers models from `GET /models`, but that needs both
+/// connectivity and a valid key. This list is what gets listed when discovery
+/// is unavailable, and it is merged with the discovered set when it is.
+///
+/// It is a convenience, never a gate: the plugin resolves any model id, so a
+/// model absent from this list still works when named explicitly. That is
+/// deliberate - it keeps just-released models usable without a plugin release.
+/// Capability metadata is not duplicated here either; it comes from the
+/// heuristics behind `modelInfoFor`.
+///
+/// Curation rules, to keep this list from sprawling as OpenAI ships:
+///
+/// - Aliases only. Dated snapshots (`gpt-4o-2024-08-06`) and `-chat-latest`
+///   aliases are omitted; discovery surfaces them when online, and pinning a
+///   snapshot is an explicit act the plugin's resolver already supports.
+/// - Chat models only. Embeddings, image, audio and moderation models are not
+///   served by this plugin's chat path.
+/// - Recent generations plus what apps still pin in practice, not every
+///   generation ever shipped.
+const List<String> knownChatModels = <String>[
+  // GPT-5 family, newest first. `-pro` is the higher-reasoning tier;
+  // `-mini`/`-nano` trade capability for latency and cost.
+  'gpt-5.5',
+  'gpt-5.5-pro',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
+  'gpt-5.4-pro',
+  'gpt-5',
+  'gpt-5-mini',
+  'gpt-5-nano',
+
+  // GPT-4.1 and 4o remain widely pinned by existing apps.
+  'gpt-4.1',
+  'gpt-4.1-mini',
+  'gpt-4.1-nano',
+  'gpt-4o',
+  'gpt-4o-mini',
+
+  // o-series reasoning models.
+  'o3',
+  'o3-mini',
+  'o4-mini',
+];

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -15,6 +15,7 @@
 import 'package:genkit/plugin.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:openai_dart/openai_dart.dart' as sdk;
 
 import '../genkit_openai.dart';
@@ -25,9 +26,9 @@ final _logger = Logger('genkit_openai');
 
 /// Core Genkit plugin implementation for OpenAI-compatible APIs.
 ///
-/// Automatically discovers models from the OpenAI API (when no custom
-/// [baseUrl] is set) and registers them in the Genkit action registry.
-/// Additional models can be provided via [customModels].
+/// Registers nothing up front beyond [customModels]: [resolve] builds a model
+/// on demand for any id. Discovery runs in [list], against whichever host
+/// [baseUrl] names, and returns metadata rather than registered actions.
 class OpenAIPlugin extends GenkitPlugin {
   final String _pluginName;
 
@@ -55,6 +56,15 @@ class OpenAIPlugin extends GenkitPlugin {
   /// Optional HTTP client for dependency injection and testing.
   final http.Client? httpClient;
 
+  /// Looks up an environment variable, for the API key fallback.
+  ///
+  /// Injectable so a test can run against a known-empty environment: the
+  /// package's own suite needs `OPENAI_API_KEY` exported for
+  /// `integration_test.dart`, which would otherwise make the no-key tests
+  /// pass or fail depending on the developer's shell.
+  @visibleForTesting
+  final String? Function(String name) configVar;
+
   /// Creates an [OpenAIPlugin].
   ///
   /// Provide either [apiKey] or [apiKeyProvider], but not both.
@@ -66,6 +76,7 @@ class OpenAIPlugin extends GenkitPlugin {
     this.customModels = const [],
     this.headers,
     this.httpClient,
+    this.configVar = getConfigVar,
   }) : _pluginName = name {
     if (name.isEmpty || name.contains('/')) {
       throw GenkitException(
@@ -83,12 +94,10 @@ class OpenAIPlugin extends GenkitPlugin {
 
   /// Registers actions that need neither network access nor a key.
   ///
-  /// Deliberately does no I/O. The registry treats an `init()` failure as
-  /// fatal and does not cache it (`registry.dart:32-40`), and every
-  /// `listActions()` call initializes plugins outside its per-plugin
-  /// try/catch - so throwing here takes down the whole Dev UI, including
-  /// `/api/__health`. Model discovery belongs in [list], where a failure
-  /// degrades instead.
+  /// Deliberately does no I/O. A throw here is not cached and is not caught
+  /// per-plugin, so it fails every `listActions()` call for the whole
+  /// registry - taking down the Dev UI, `/api/__health` included. Model
+  /// discovery belongs in [list], where a failure degrades instead.
   ///
   /// Models are not registered up front: [resolve] builds them on demand for
   /// any id, so nothing is lost by staying offline here.
@@ -130,7 +139,7 @@ class OpenAIPlugin extends GenkitPlugin {
     if (config == null) {
       throw GenkitException(
         '[$_pluginName] API key is required. Provide it via apiKey or apiKeyProvider '
-        'in the plugin constructor, or set the OPENAI_API_KEY environment variable.',
+        'in the plugin constructor, or set the $_apiKeyEnvVar environment variable.',
         status: StatusCodes.INVALID_ARGUMENT,
       );
     }
@@ -140,22 +149,28 @@ class OpenAIPlugin extends GenkitPlugin {
   /// Resolves the API key from, in order: [apiKeyProvider], [apiKey], then the
   /// `OPENAI_API_KEY` environment variable.
   ///
-  /// Uses `getConfigVar` rather than `Platform.environment` so the plugin stays
-  /// usable on web and wasm, matching `genkit_google_genai`.
+  /// Reads through [configVar] — `getConfigVar` by default — rather than
+  /// `Platform.environment`, so the plugin stays usable on web and wasm,
+  /// matching `genkit_google_genai`.
   Future<String?> _resolveApiKey() async {
     final configuredApiKeyProvider = apiKeyProvider;
     if (configuredApiKeyProvider != null) {
       return await configuredApiKeyProvider();
     }
-    return apiKey ?? _apiKeyEnvVars.map(getConfigVar).nonNulls.firstOrNull;
+    // A blank apiKey is treated as absent rather than short-circuiting the
+    // fallback, so `apiKey: ''` still finds the environment variable.
+    final configured = apiKey?.trim();
+    if (configured != null && configured.isNotEmpty) return configured;
+    final fromEnv = configVar(_apiKeyEnvVar)?.trim();
+    return (fromEnv != null && fromEnv.isNotEmpty) ? fromEnv : null;
   }
 
   /// Client config for discovery, or null when no key is available.
   ///
   /// Lets [list] skip a request it knows would 401, without duplicating the
   /// key resolution that [_resolveClientConfig] does - notably without
-  /// invoking [apiKeyProvider] twice, which for a provider that mints a token
-  /// per call would double the cost of every Dev UI poll.
+  /// invoking [apiKeyProvider] twice for a single listing, which for a
+  /// provider that mints a token per call would double its cost.
   Future<_ResolvedClientConfig?> _resolveClientConfigOrNull() async {
     final configuredApiKey = await _resolveApiKey();
     if (configuredApiKey == null || configuredApiKey.trim().isEmpty) {
@@ -392,8 +407,8 @@ class OpenAIPlugin extends GenkitPlugin {
   }
 }
 
-/// Environment variables consulted for the API key, in order.
-const _apiKeyEnvVars = ['OPENAI_API_KEY'];
+/// Environment variable consulted for the API key.
+const _apiKeyEnvVar = 'OPENAI_API_KEY';
 
 final class _ResolvedClientConfig {
   final String apiKey;

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -206,9 +206,16 @@ class OpenAIPlugin extends GenkitPlugin {
 
     // Curated models are listed even when discovery omits them, and custom
     // models are always listed - they need no discovery to be valid.
+    //
+    // The curated catalog is an OpenAI catalog, so it is withheld once a
+    // baseUrl points somewhere else: a Groq or DeepSeek backend listing
+    // `groq/gpt-5.5` and `groq/o3` offers the Dev UI seventeen models that
+    // host will 404 on. Compat backends are left with whatever `GET /models`
+    // reports plus their own `models:`, and - as ever - resolve() still serves
+    // any id named explicitly, so nothing becomes unreachable.
     final ids = <String>{
       ...discovered,
-      ...knownChatModels,
+      if (baseUrl == null) ...knownChatModels,
       ...customModels.map((m) => m.name),
     };
 

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -14,10 +14,14 @@
 
 import 'package:genkit/plugin.dart';
 import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
 import 'package:openai_dart/openai_dart.dart' as sdk;
 
 import '../genkit_openai.dart';
 import 'chat.dart' as chat;
+import 'known_models.dart';
+
+final _logger = Logger('genkit_openai');
 
 /// Core Genkit plugin implementation for OpenAI-compatible APIs.
 ///
@@ -77,45 +81,26 @@ class OpenAIPlugin extends GenkitPlugin {
     }
   }
 
+  /// Registers actions that need neither network access nor a key.
+  ///
+  /// Deliberately does no I/O. The registry treats an `init()` failure as
+  /// fatal and does not cache it (`registry.dart:32-40`), and every
+  /// `listActions()` call initializes plugins outside its per-plugin
+  /// try/catch - so throwing here takes down the whole Dev UI, including
+  /// `/api/__health`. Model discovery belongs in [list], where a failure
+  /// degrades instead.
+  ///
+  /// Models are not registered up front: [resolve] builds them on demand for
+  /// any id, so nothing is lost by staying offline here.
   @override
-  Future<List<Action>> init() async {
-    final actions = <Action>[];
-
-    // Fetch and register models from OpenAI API only for default OpenAI host.
-    if (baseUrl == null) {
-      try {
-        final availableModelIds = await _fetchAvailableModels();
-
-        for (final modelId in availableModelIds) {
-          final modelType = getModelType(modelId);
-
-          if (modelType != 'chat' && modelType != 'unknown') {
-            continue;
-          }
-
-          final info = modelInfoFor(modelId);
-          actions.add(_createModel(modelId, info));
-        }
-      } catch (e) {
-        throw GenkitException(
-          'Error fetching available models from $_pluginName: $e',
-          underlyingException: e,
-        );
-      }
-    }
-
-    // Register custom models
-    for (final model in customModels) {
-      actions.add(_createModel(model.name, model.info));
-    }
-
-    return actions;
-  }
+  Future<List<Action>> init() async => [
+    for (final model in customModels) _createModel(model.name, model.info),
+  ];
 
   /// Fetch available model IDs from OpenAI API
-  Future<List<String>> _fetchAvailableModels() async {
-    final resolvedConfig = await _resolveClientConfig();
-
+  Future<List<String>> _fetchAvailableModels(
+    _ResolvedClientConfig resolvedConfig,
+  ) async {
     final client = sdk.OpenAIClient.withApiKey(
       resolvedConfig.apiKey,
       baseUrl: resolvedConfig.baseUrl,
@@ -141,14 +126,41 @@ class OpenAIPlugin extends GenkitPlugin {
   }
 
   Future<_ResolvedClientConfig> _resolveClientConfig() async {
-    final configuredApiKey = await _resolveApiKey();
-    if (configuredApiKey == null || configuredApiKey.trim().isEmpty) {
+    final config = await _resolveClientConfigOrNull();
+    if (config == null) {
       throw GenkitException(
-        '[$_pluginName] API key is required. Provide it via apiKey or apiKeyProvider in the plugin constructor.',
+        '[$_pluginName] API key is required. Provide it via apiKey or apiKeyProvider '
+        'in the plugin constructor, or set the OPENAI_API_KEY environment variable.',
         status: StatusCodes.INVALID_ARGUMENT,
       );
     }
+    return config;
+  }
 
+  /// Resolves the API key from, in order: [apiKeyProvider], [apiKey], then the
+  /// `OPENAI_API_KEY` environment variable.
+  ///
+  /// Uses `getConfigVar` rather than `Platform.environment` so the plugin stays
+  /// usable on web and wasm, matching `genkit_google_genai`.
+  Future<String?> _resolveApiKey() async {
+    final configuredApiKeyProvider = apiKeyProvider;
+    if (configuredApiKeyProvider != null) {
+      return await configuredApiKeyProvider();
+    }
+    return apiKey ?? _apiKeyEnvVars.map(getConfigVar).nonNulls.firstOrNull;
+  }
+
+  /// Client config for discovery, or null when no key is available.
+  ///
+  /// Lets [list] skip a request it knows would 401, without duplicating the
+  /// key resolution that [_resolveClientConfig] does - notably without
+  /// invoking [apiKeyProvider] twice, which for a provider that mints a token
+  /// per call would double the cost of every Dev UI poll.
+  Future<_ResolvedClientConfig?> _resolveClientConfigOrNull() async {
+    final configuredApiKey = await _resolveApiKey();
+    if (configuredApiKey == null || configuredApiKey.trim().isEmpty) {
+      return null;
+    }
     return _ResolvedClientConfig(
       apiKey: configuredApiKey.trim(),
       baseUrl: baseUrl,
@@ -156,45 +168,63 @@ class OpenAIPlugin extends GenkitPlugin {
     );
   }
 
-  Future<String?> _resolveApiKey() async {
-    final configuredApiKeyProvider = apiKeyProvider;
-    if (configuredApiKeyProvider != null) {
-      return await configuredApiKeyProvider();
-    }
-    return apiKey;
-  }
-
+  /// Lists the plugin's models, enriching the curated catalog with whatever
+  /// `GET /models` reports.
+  ///
+  /// Discovery is best-effort. Any failure - offline, bad key, a compatible
+  /// host that does not serve `/models` - degrades to the curated catalog with
+  /// a logged warning rather than throwing, so the Dev UI keeps working. A
+  /// misconfigured key still fails loudly at generate time.
   @override
   Future<List<ActionMetadata<dynamic, dynamic, dynamic, dynamic>>>
   list() async {
+    final discovered = <String>{};
+
+    // Key resolution is inside the try on purpose: an apiKeyProvider that
+    // throws must degrade like any other discovery failure, not take the
+    // catalog down with it.
     try {
-      final modelIds = await _fetchAvailableModels();
-      final modelMetadataList =
-          <ActionMetadata<dynamic, dynamic, dynamic, dynamic>>[];
-
-      for (final modelId in modelIds) {
-        final modelType = getModelType(modelId);
-        if (modelType != 'chat' && modelType != 'unknown') {
-          continue;
+      // A keyless request is a guaranteed 401, so don't spend it.
+      final config = await _resolveClientConfigOrNull();
+      if (config != null) {
+        for (final modelId in await _fetchAvailableModels(config)) {
+          final modelType = getModelType(modelId);
+          if (modelType != 'chat' && modelType != 'unknown') {
+            continue;
+          }
+          discovered.add(modelId);
         }
-
-        modelMetadataList.add(
-          modelMetadata(
-            '$_pluginName/$modelId',
-            modelInfo: modelInfoFor(modelId),
-            customOptions: chat.chatModelOptionsSchema(),
-          ),
-        );
       }
-
-      return modelMetadataList;
     } catch (e, stackTrace) {
-      throw GenkitException(
-        'Error listing models from $_pluginName: $e',
-        underlyingException: e,
-        stackTrace: stackTrace,
+      _logger.warning(
+        'Failed to list models from $_pluginName; '
+        'falling back to the curated catalog: $e',
+        e,
+        stackTrace,
       );
     }
+
+    // Curated models are listed even when discovery omits them, and custom
+    // models are always listed - they need no discovery to be valid.
+    final ids = <String>{
+      ...discovered,
+      ...knownChatModels,
+      ...customModels.map((m) => m.name),
+    };
+
+    final infoOverrides = {
+      for (final model in customModels)
+        if (model.info != null) model.name: model.info!,
+    };
+
+    return [
+      for (final id in ids)
+        modelMetadata(
+          '$_pluginName/$id',
+          modelInfo: infoOverrides[id] ?? modelInfoFor(id),
+          customOptions: chat.chatModelOptionsSchema(),
+        ),
+    ];
   }
 
   @override
@@ -354,6 +384,9 @@ class OpenAIPlugin extends GenkitPlugin {
     );
   }
 }
+
+/// Environment variables consulted for the API key, in order.
+const _apiKeyEnvVars = ['OPENAI_API_KEY'];
 
 final class _ResolvedClientConfig {
   final String apiKey;

--- a/packages/genkit_openai/lib/src/utils.dart
+++ b/packages/genkit_openai/lib/src/utils.dart
@@ -18,6 +18,9 @@ final RegExp _oSeriesPattern = RegExp(r'^o\d+(?:-|$)');
 final RegExp _gptPattern = RegExp(r'^gpt-\d+(\.\d+)?o?(?:-|$)');
 final RegExp _gptOPattern = RegExp(r'gpt-\d+(?:\.\d+)?o');
 
+/// Captures the major and optional minor version of a `gpt-N[.M]` id.
+final RegExp _gptVersionPattern = RegExp(r'^gpt-(\d+)(?:\.(\d+))?');
+
 const List<String> _nonToolKeywords = [
   'embedding',
   'tts',
@@ -120,6 +123,20 @@ bool _supportsToolsByHeuristics(String id) {
   return true;
 }
 
+/// Whether a `gpt-N[.M]` id is version 4.1 or newer.
+bool _isVisionCapableGptVersion(String id) {
+  final match = _gptVersionPattern.firstMatch(id);
+  if (match == null) return false;
+
+  final major = int.tryParse(match.group(1)!);
+  if (major == null) return false;
+  if (major >= 5) return true;
+
+  // gpt-4 with no minor is the original text-only model; 4.1 and 4.5 are not.
+  final minor = int.tryParse(match.group(2) ?? '');
+  return major == 4 && minor != null && minor >= 1;
+}
+
 bool _supportsVisionByHeuristics(String id) {
   // Explicitly named vision models.
   if (id.contains('vision')) {
@@ -128,6 +145,13 @@ bool _supportsVisionByHeuristics(String id) {
 
   // GPT-4o variants (gpt-4o, gpt-4o-mini, etc.).
   if (id.contains('gpt-4o')) {
+    return true;
+  }
+
+  // Every GPT family from 4.1 onward is multimodal, including the whole
+  // gpt-5.x line. Matching on a literal 'o' (see _gptOPattern below) misses
+  // all of them, since the version marker moved from a suffix to a number.
+  if (_isVisionCapableGptVersion(id)) {
     return true;
   }
 

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:genkit/genkit.dart';
 import 'package:genkit_openai/genkit_openai.dart';
+import 'package:genkit_openai/src/known_models.dart' show knownChatModels;
 import 'package:schemantic/schemantic.dart';
 import 'package:test/test.dart';
 
@@ -282,6 +283,62 @@ void main() {
       expect(result.usage?.inputTokens, greaterThan(0));
       expect(result.usage?.outputTokens, greaterThan(0));
       expect(result.usage?.totalTokens, greaterThan(0));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('resolves the key from OPENAI_API_KEY when none is passed', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // Note the bare openAI() - no apiKey, no apiKeyProvider. Every other
+      // live test passes the key explicitly, so this is the only coverage of
+      // the environment fallback actually authenticating a real request.
+      final ai = Genkit(plugins: [openAI()]);
+
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o-mini'),
+        prompt: 'Say "hello" and nothing else.',
+      );
+
+      expect(response.text.toLowerCase(), contains('hello'));
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('discovery enriches the curated catalog', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      // Offline, list() returns exactly knownChatModels. With a real key it
+      // must return strictly more than that - if it does not, discovery has
+      // silently stopped running and the offline fallback has swallowed it.
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final actions = await ai.registry.listActions();
+      final names = actions
+          .where((a) => a.actionType == .model)
+          .map((a) => a.name)
+          .toSet();
+
+      expect(
+        names,
+        containsAll(knownChatModels.map((id) => 'openai/$id')),
+        reason: 'the curated catalog must survive discovery',
+      );
+      expect(
+        names.length,
+        greaterThan(knownChatModels.length),
+        reason: 'discovery should contribute models beyond the catalog',
+      );
+
+      // Discovery must not smuggle in non-chat models.
+      expect(names.any((n) => n.contains('embedding')), isFalse);
+      expect(names.any((n) => n.contains('dall-e')), isFalse);
+
+      await ai.shutdown();
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
   });
 }

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -315,6 +315,9 @@ void main() {
       // Offline, list() returns exactly knownChatModels. With a real key it
       // must return strictly more than that - if it does not, discovery has
       // silently stopped running and the offline fallback has swallowed it.
+      //
+      // Not asserted: that the merged listing contains the catalog. list()
+      // merges it in unconditionally, so that holds however discovery went.
       final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
       final actions = await ai.registry.listActions();
@@ -323,10 +326,24 @@ void main() {
           .map((a) => a.name)
           .toSet();
 
+      // A baseUrl withholds the catalog, so this listing is pure discovery -
+      // the only way to see what OpenAI actually serves. An empty overlap
+      // means every curated id has been renamed or retired.
+      final probe = Genkit(
+        plugins: [openAI(apiKey: apiKey, baseUrl: 'https://api.openai.com/v1')],
+      );
+      final discovered = (await probe.registry.listActions())
+          .where((a) => a.actionType == .model)
+          .map((a) => a.name)
+          .toSet();
+      await probe.shutdown();
+
       expect(
-        names,
-        containsAll(knownChatModels.map((id) => 'openai/$id')),
-        reason: 'the curated catalog must survive discovery',
+        discovered.intersection(
+          knownChatModels.map((id) => 'openai/$id').toSet(),
+        ),
+        isNotEmpty,
+        reason: 'no curated id is served by OpenAI any more',
       );
       expect(
         names.length,

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -127,6 +127,37 @@ void main() {
       expect(hasContent, isTrue);
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
 
+    test('a schema-less tool round-trips', () async {
+      // The counterpart to the test above, which declares an inputSchema. A
+      // tool without one has to reach OpenAI as a valid empty object schema;
+      // this only fails against the real API, which is why it lives here.
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+      var toolRan = false;
+      ai.defineTool(
+        name: 'getTime',
+        description: 'Returns the current time',
+        fn: (input, ctx) async {
+          toolRan = true;
+          return .response({'time': '12:00'});
+        },
+      );
+
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Use the getTime tool to tell me the current time.',
+        toolNames: ['getTime'],
+      );
+
+      expect(response.message, isNotNull);
+      expect(toolRan, isTrue);
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
     test('o-series tool calling executes the tool', () async {
       if (apiKey == null || apiKey.isEmpty) {
         fail(

--- a/packages/genkit_openai/test/openai_plugin_startup_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_startup_test.dart
@@ -1,0 +1,461 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:genkit_openai/src/known_models.dart' show knownChatModels;
+import 'package:genkit_openai/src/openai_plugin.dart' show OpenAIPlugin;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// A client that records every request and refuses them all.
+///
+/// Startup must not touch the network, so a test that passes with this client
+/// installed proves no request was made - and [requests] shows what was tried
+/// when one is.
+class RecordingFailClient {
+  final List<String> requests = [];
+
+  MockClient get client => MockClient((request) async {
+    requests.add('${request.method} ${request.url}');
+    throw http.ClientException('network is unavailable in this test');
+  });
+}
+
+/// Rejects discovery with a 401, as a bad or expired key would.
+///
+/// Preferred over a thrown exception where a request is actually expected: the
+/// SDK retries transport errors with backoff, which makes the test slow.
+MockClient unauthorizedClient(List<String> requests) {
+  return MockClient((request) async {
+    requests.add('${request.method} ${request.url}');
+    return http.Response(
+      jsonEncode({
+        'error': {'message': 'Incorrect API key provided'},
+      }),
+      401,
+    );
+  });
+}
+
+/// Serves a `/models` list so discovery has something to find.
+MockClient discoveryClient(List<String> requests, {List<String>? ids}) {
+  return MockClient((request) async {
+    requests.add('${request.method} ${request.url}');
+    if (request.url.path.endsWith('/models')) {
+      return http.Response(
+        jsonEncode({
+          'object': 'list',
+          'data': [
+            for (final id in ids ?? const ['gpt-5-preview'])
+              {'id': id, 'object': 'model', 'created': 0, 'owned_by': 'openai'},
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('not found', 404);
+  });
+}
+
+Set<String> modelNames(List<ActionMetadata> metadata) =>
+    metadata.map((m) => m.name).toSet();
+
+void main() {
+  group('offline startup', () {
+    test('init does no I/O and does not throw without a key', () async {
+      final recorder = RecordingFailClient();
+      final plugin = OpenAIPlugin(httpClient: recorder.client);
+
+      final actions = await plugin.init();
+
+      expect(actions, isEmpty);
+      expect(
+        recorder.requests,
+        isEmpty,
+        reason: 'init() must not touch the network',
+      );
+    });
+
+    test('init registers custom models without a key', () async {
+      final recorder = RecordingFailClient();
+      final plugin = OpenAIPlugin(
+        httpClient: recorder.client,
+        customModels: [CustomModelDefinition(name: 'my-model')],
+      );
+
+      final actions = await plugin.init();
+
+      expect(actions, hasLength(1));
+      expect(actions.first.name, 'openai/my-model');
+      expect(recorder.requests, isEmpty);
+    });
+
+    test('listActions succeeds with no key and no network', () async {
+      // This is the regression: previously init() threw here, which made
+      // /api/__health and /api/actions return 500 and the Dev UI unable to
+      // connect at all.
+      final recorder = RecordingFailClient();
+      final ai = Genkit(plugins: [openAI(httpClient: recorder.client)]);
+
+      final actions = await ai.registry.listActions();
+      final names = actions
+          .where((a) => a.actionType == .model)
+          .map((a) => a.name);
+
+      expect(names, containsAll(knownChatModels.map((id) => 'openai/$id')));
+      expect(
+        recorder.requests,
+        isEmpty,
+        reason: 'discovery must be skipped when no key is available',
+      );
+
+      await ai.shutdown();
+    });
+
+    test('a model resolves and generates without startup discovery', () async {
+      final requests = <String>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            apiKey: 'test-key',
+            httpClient: MockClient((request) async {
+              requests.add(request.url.path);
+              return http.Response(
+                jsonEncode({
+                  'id': 'chatcmpl-test',
+                  'object': 'chat.completion',
+                  'created': 0,
+                  'model': 'gpt-4o',
+                  'choices': [
+                    {
+                      'index': 0,
+                      'message': {'role': 'assistant', 'content': 'ok'},
+                      'finish_reason': 'stop',
+                    },
+                  ],
+                }),
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }),
+          ),
+        ],
+      );
+
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'hi',
+      );
+
+      expect(response.text, 'ok');
+      expect(
+        requests.where((p) => p.endsWith('/models')),
+        isEmpty,
+        reason: 'a plain generate must not trigger model discovery',
+      );
+
+      await ai.shutdown();
+    });
+  });
+
+  group('list degrades instead of throwing', () {
+    test('falls back to the catalog when discovery fails', () async {
+      final requests = <String>[];
+      final plugin = OpenAIPlugin(
+        apiKey: 'test-key',
+        httpClient: unauthorizedClient(requests),
+      );
+
+      final metadata = await plugin.list();
+
+      expect(
+        requests,
+        isNotEmpty,
+        reason: 'with a key present, discovery should be attempted',
+      );
+      expect(
+        modelNames(metadata),
+        containsAll(knownChatModels.map((id) => 'openai/$id')),
+      );
+    });
+
+    test('enriches the catalog with discovered models', () async {
+      final requests = <String>[];
+      final plugin = OpenAIPlugin(
+        apiKey: 'test-key',
+        httpClient: discoveryClient(requests, ids: ['gpt-5-preview']),
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(names, contains('openai/gpt-5-preview'));
+      expect(names, contains('openai/gpt-4o'));
+    });
+
+    test(
+      'does not duplicate a model that is both curated and discovered',
+      () async {
+        final requests = <String>[];
+        final plugin = OpenAIPlugin(
+          apiKey: 'test-key',
+          httpClient: discoveryClient(requests, ids: ['gpt-4o']),
+        );
+
+        final metadata = await plugin.list();
+        final matching = metadata.where((m) => m.name == 'openai/gpt-4o');
+
+        expect(matching, hasLength(1));
+      },
+    );
+
+    test('custom models are listed', () async {
+      // Previously list() omitted them entirely.
+      final plugin = OpenAIPlugin(
+        apiKey: 'test-key',
+        httpClient: unauthorizedClient(<String>[]),
+        customModels: [
+          CustomModelDefinition(
+            name: 'llama-3.3-70b',
+            info: ModelInfo(label: 'Llama 3.3 70B'),
+          ),
+        ],
+      );
+
+      final metadata = await plugin.list();
+      final custom = metadata.firstWhere(
+        (m) => m.name == 'openai/llama-3.3-70b',
+      );
+
+      expect(
+        (custom.metadata['model'] as Map)['label'],
+        'Llama 3.3 70B',
+        reason: 'the caller-supplied ModelInfo should win over heuristics',
+      );
+    });
+
+    test('non-chat discovered models are still filtered out', () async {
+      final requests = <String>[];
+      final plugin = OpenAIPlugin(
+        apiKey: 'test-key',
+        httpClient: discoveryClient(
+          requests,
+          ids: ['gpt-4o', 'text-embedding-3-small', 'dall-e-3'],
+        ),
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(names, contains('openai/gpt-4o'));
+      expect(names, isNot(contains('openai/text-embedding-3-small')));
+      expect(names, isNot(contains('openai/dall-e-3')));
+    });
+  });
+
+  group('catalog metadata', () {
+    test('every curated model is a chat model with sane capabilities', () {
+      // A curated id that the heuristics misclassify would be listed with
+      // wrong metadata - e.g. advertising media:false for a multimodal model,
+      // which makes Genkit reject image inputs.
+      for (final id in knownChatModels) {
+        expect(getModelType(id), 'chat', reason: '$id should classify as chat');
+
+        final supports = modelInfoFor(id).supports!;
+        expect(supports['tools'], isTrue, reason: '$id should support tools');
+
+        // Every curated gpt-* model is multimodal. The o-series is mixed -
+        // o3-mini and the o1-mini/preview pair are text-only - so those are
+        // left to the dedicated heuristics tests.
+        if (id.startsWith('gpt-')) {
+          expect(
+            supports['media'],
+            isTrue,
+            reason: '$id is multimodal and should advertise media input',
+          );
+        } else {
+          expect(supports['media'], isA<bool>());
+        }
+      }
+    });
+
+    test('the catalog holds aliases, not dated snapshots', () {
+      for (final id in knownChatModels) {
+        expect(
+          RegExp(r'-\d{4}-\d{2}-\d{2}$').hasMatch(id),
+          isFalse,
+          reason: '$id is a dated snapshot; discovery surfaces those',
+        );
+        expect(id, isNot(contains('chat-latest')));
+      }
+    });
+  });
+
+  group('apiKeyProvider is handled defensively during listing', () {
+    test('a throwing provider degrades to the catalog', () async {
+      // Key resolution happens inside list()'s try/catch. If it did not, a
+      // provider blip (expired credentials, a failed token fetch) would take
+      // the whole listing down instead of degrading.
+      final plugin = OpenAIPlugin(
+        apiKeyProvider: () async =>
+            throw StateError('token endpoint unavailable'),
+        httpClient: RecordingFailClient().client,
+      );
+
+      final metadata = await plugin.list();
+
+      expect(
+        modelNames(metadata),
+        containsAll(knownChatModels.map((id) => 'openai/$id')),
+      );
+    });
+
+    test('the provider is invoked once per listing, not twice', () async {
+      // list() checks for a key and then builds a client. Resolving twice
+      // would double the cost for a provider that mints a token per call,
+      // on every Dev UI poll.
+      var calls = 0;
+      final requests = <String>[];
+      final plugin = OpenAIPlugin(
+        apiKeyProvider: () async {
+          calls++;
+          return 'minted-key';
+        },
+        httpClient: discoveryClient(requests, ids: ['gpt-4o']),
+      );
+
+      await plugin.list();
+
+      expect(calls, 1);
+    });
+
+    test('init never asks for a key at all', () async {
+      var calls = 0;
+      final plugin = OpenAIPlugin(
+        apiKeyProvider: () async {
+          calls++;
+          return 'minted-key';
+        },
+        httpClient: RecordingFailClient().client,
+        customModels: [CustomModelDefinition(name: 'my-model')],
+      );
+
+      await plugin.init();
+
+      expect(calls, 0, reason: 'startup must not need credentials');
+    });
+  });
+
+  group('custom hosts', () {
+    test('discovery is attempted against a custom baseUrl', () async {
+      final requests = <String>[];
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.groq.test/openai/v1',
+        httpClient: discoveryClient(requests, ids: ['llama-3.3-70b']),
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(
+        requests.any((r) => r.contains('api.groq.test')),
+        isTrue,
+        reason: 'compatible hosts often do serve /models',
+      );
+      expect(names, contains('groq/llama-3.3-70b'));
+    });
+
+    test(
+      'a host without /models still lists catalog and custom models',
+      () async {
+        final plugin = OpenAIPlugin(
+          name: 'local',
+          apiKey: 'test-key',
+          baseUrl: 'http://127.0.0.1:9/v1',
+          httpClient: MockClient(
+            (request) async => http.Response('no such endpoint', 404),
+          ),
+          customModels: [CustomModelDefinition(name: 'my-local-model')],
+        );
+
+        final names = modelNames(await plugin.list());
+
+        expect(names, contains('local/my-local-model'));
+        expect(names, contains('local/gpt-4o'));
+      },
+    );
+  });
+
+  group('api key resolution', () {
+    test('a missing key still fails at generate time', () async {
+      // The startup requirement is gone; the call-time requirement stays.
+      final recorder = RecordingFailClient();
+      final ai = Genkit(plugins: [openAI(httpClient: recorder.client)]);
+
+      await expectLater(
+        ai.generate(model: openAI.model('gpt-4o'), prompt: 'hi'),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.toString(),
+            'message',
+            contains('API key is required'),
+          ),
+        ),
+      );
+
+      await ai.shutdown();
+    });
+
+    test('apiKeyProvider takes precedence over apiKey', () async {
+      final seen = <String>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            apiKeyProvider: () async => 'from-provider',
+            httpClient: MockClient((request) async {
+              seen.add(request.headers['authorization'] ?? '');
+              return http.Response(
+                jsonEncode({
+                  'id': 'x',
+                  'object': 'chat.completion',
+                  'created': 0,
+                  'model': 'gpt-4o',
+                  'choices': [
+                    {
+                      'index': 0,
+                      'message': {'role': 'assistant', 'content': 'ok'},
+                      'finish_reason': 'stop',
+                    },
+                  ],
+                }),
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }),
+          ),
+        ],
+      );
+
+      await ai.generate(model: openAI.model('gpt-4o'), prompt: 'hi');
+
+      expect(seen.single, 'Bearer from-provider');
+
+      await ai.shutdown();
+    });
+  });
+}

--- a/packages/genkit_openai/test/openai_plugin_startup_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_startup_test.dart
@@ -411,21 +411,22 @@ void main() {
   group('api key resolution', () {
     test('a missing key still fails at generate time', () async {
       // The startup requirement is gone; the call-time requirement stays.
+      // Since #413, generate() reports a model error as a failed response
+      // rather than throwing, so the requirement shows up there.
       final recorder = RecordingFailClient();
       final ai = Genkit(
         plugins: [OpenAIPlugin(httpClient: recorder.client, configVar: noEnv)],
       );
 
-      await expectLater(
-        ai.generate(model: openAI.model('gpt-4o'), prompt: 'hi'),
-        throwsA(
-          isA<GenkitException>().having(
-            (e) => e.toString(),
-            'message',
-            contains('API key is required'),
-          ),
-        ),
+      final response = await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'hi',
       );
+
+      expect(response.finishReason, FinishReason.failed);
+      expect(response.error, isNotNull);
+      expect(response.error!.status, StatusCodes.INVALID_ARGUMENT.name);
+      expect(response.error!.message, contains('API key is required'));
 
       await ai.shutdown();
     });

--- a/packages/genkit_openai/test/openai_plugin_startup_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_startup_test.dart
@@ -22,6 +22,13 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
+/// An environment with no API key in it.
+///
+/// The package's own `integration_test.dart` expects `OPENAI_API_KEY`
+/// exported, so the no-key tests below must not read the real environment or
+/// they pass or fail depending on the developer's shell.
+String? noEnv(String name) => null;
+
 /// A client that records every request and refuses them all.
 ///
 /// Startup must not touch the network, so a test that passes with this client
@@ -111,7 +118,9 @@ void main() {
       // /api/__health and /api/actions return 500 and the Dev UI unable to
       // connect at all.
       final recorder = RecordingFailClient();
-      final ai = Genkit(plugins: [openAI(httpClient: recorder.client)]);
+      final ai = Genkit(
+        plugins: [OpenAIPlugin(httpClient: recorder.client, configVar: noEnv)],
+      );
 
       final actions = await ai.registry.listActions();
       final names = actions
@@ -326,8 +335,7 @@ void main() {
 
     test('the provider is invoked once per listing, not twice', () async {
       // list() checks for a key and then builds a client. Resolving twice
-      // would double the cost for a provider that mints a token per call,
-      // on every Dev UI poll.
+      // would double the cost for a provider that mints a token per call.
       var calls = 0;
       final requests = <String>[];
       final plugin = OpenAIPlugin(
@@ -404,7 +412,9 @@ void main() {
     test('a missing key still fails at generate time', () async {
       // The startup requirement is gone; the call-time requirement stays.
       final recorder = RecordingFailClient();
-      final ai = Genkit(plugins: [openAI(httpClient: recorder.client)]);
+      final ai = Genkit(
+        plugins: [OpenAIPlugin(httpClient: recorder.client, configVar: noEnv)],
+      );
 
       await expectLater(
         ai.generate(model: openAI.model('gpt-4o'), prompt: 'hi'),

--- a/packages/genkit_openai/test/openai_plugin_startup_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_startup_test.dart
@@ -380,25 +380,24 @@ void main() {
       expect(names, contains('groq/llama-3.3-70b'));
     });
 
-    test(
-      'a host without /models still lists catalog and custom models',
-      () async {
-        final plugin = OpenAIPlugin(
-          name: 'local',
-          apiKey: 'test-key',
-          baseUrl: 'http://127.0.0.1:9/v1',
-          httpClient: MockClient(
-            (request) async => http.Response('no such endpoint', 404),
-          ),
-          customModels: [CustomModelDefinition(name: 'my-local-model')],
-        );
+    test('a host without /models still lists its custom models', () async {
+      final plugin = OpenAIPlugin(
+        name: 'local',
+        apiKey: 'test-key',
+        baseUrl: 'http://127.0.0.1:9/v1',
+        httpClient: MockClient(
+          (request) async => http.Response('no such endpoint', 404),
+        ),
+        customModels: [CustomModelDefinition(name: 'my-local-model')],
+      );
 
-        final names = modelNames(await plugin.list());
+      final names = modelNames(await plugin.list());
 
-        expect(names, contains('local/my-local-model'));
-        expect(names, contains('local/gpt-4o'));
-      },
-    );
+      expect(names, {'local/my-local-model'});
+      // The curated catalog is OpenAI's. A local llama.cpp-style host has no
+      // gpt-4o, so listing 'local/gpt-4o' would only hand the Dev UI a 404.
+      expect(names, isNot(contains('local/gpt-4o')));
+    });
   });
 
   group('api key resolution', () {

--- a/packages/genkit_openai/test/openai_plugin_tool_schema_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_tool_schema_wire_test.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:genkit/genkit.dart';
 import 'package:genkit_openai/genkit_openai.dart';
@@ -132,37 +131,5 @@ void main() {
         await ai.shutdown();
       },
     );
-  });
-
-  group('live', () {
-    final apiKey = Platform.environment['OPENAI_API_KEY'];
-
-    test('schema-less tool round-trips against the real API', () async {
-      if (apiKey == null || apiKey.isEmpty) {
-        fail(
-          'OPENAI_API_KEY environment variable must be set to run integration tests',
-        );
-      }
-
-      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
-      var toolRan = false;
-      ai.defineTool(
-        name: 'getTime',
-        description: 'Returns the current time',
-        fn: (input, ctx) async {
-          toolRan = true;
-          return .response({'time': '12:00'});
-        },
-      );
-
-      final response = await ai.generate(
-        model: openAI.model('gpt-4o'),
-        prompt: 'Use the getTime tool to tell me the current time.',
-        toolNames: ['getTime'],
-      );
-
-      expect(response.message, isNotNull);
-      expect(toolRan, isTrue);
-    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
   });
 }

--- a/packages/genkit_openai/test/openai_plugin_utils_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_utils_test.dart
@@ -65,6 +65,19 @@ void main() {
       expect(supportsVision('gpt-6o-mini'), true);
       expect(supportsVision('chatgpt-4o-latest'), true);
 
+      // GPT 4.1 and the whole gpt-5.x line are multimodal. The version
+      // marker moved from an 'o' suffix into the number, so matching on a
+      // literal 'o' used to report all of these as text-only.
+      expect(supportsVision('gpt-4.1'), true);
+      expect(supportsVision('gpt-4.1-mini'), true);
+      expect(supportsVision('gpt-4.1-nano'), true);
+      expect(supportsVision('gpt-4.5'), true);
+      expect(supportsVision('gpt-5'), true);
+      expect(supportsVision('gpt-5-mini'), true);
+      expect(supportsVision('gpt-5.4'), true);
+      expect(supportsVision('gpt-5.5-pro'), true);
+      expect(supportsVision('gpt-6'), true);
+
       // Non-vision models
       expect(supportsVision('gpt-3.5-turbo'), false);
       expect(supportsVision('gpt-4'), false);


### PR DESCRIPTION
## Summary

`OpenAIPlugin.init()` called `models.list()` whenever no custom `baseUrl` was
set, and resolved the API key there too. Both requirements landed at startup:

- **`init()` failure is fatal and uncached.** The registry initializes plugins
  *outside* the try/catch that guards per-plugin `list()`, and only records
  success — so the throw recurred on every subsequent call.
- **It took the Dev UI down.** `/api/__health` and `/api/actions` both go
  through `listActions()`, and one plugin's `init()` throw returns HTTP 500 for
  the whole request. With no key, the Dev UI could not connect at all.

`genkit_openai` was the only plugin in the repo doing I/O in `init()` —
`genkit_anthropic` and `genkit_google_genai` never override it.

After this change, `Genkit(plugins: [openAI()])` starts offline with no key, and
a missing or invalid key surfaces at `generate()` time instead.

### Also included: vision metadata fix

`_supportsVisionByHeuristics` matched vision only via a literal `gpt-4o`,
`vision`, `gpt-4-turbo`, or an `o` immediately after the version digits. Once
OpenAI moved that marker into the version number, every modern multimodal
family reported `media: false`:

```
gpt-4.1    media=false
gpt-5      media=false
gpt-5.5    media=false
```

Nothing in `packages/genkit` reads `supports`, so this misreports rather than
blocks: the models still take images, but every consumer of the metadata — the
Dev UI's model picker, `listActions` output, anything selecting a model by
capability — is told the current multimodal families are text-only. Replaced
with a version comparison (4.1 and newer, all of 5+); plain `gpt-4` stays
text-only. This is a separate bug, but the curated catalog can't carry correct
metadata without it.

## Testing



```bash
cd packages/genkit_openai
OPENAI_API_KEY=sk-... dart test test/integration_test.dart -n 'OPENAI_API_KEY|enriches'
```

Fixes #360

