### PR TITLE
fix(genkit_openai)!: send json_object for schemaless JSON output

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -67,7 +67,6 @@ final response = await ai.generate(
   config: OpenAIChatOptions(
     temperature: 0.7,
     maxTokens: 100,
-    jsonMode: false,
   ),
 );
 ```
@@ -297,9 +296,49 @@ The `OpenAIChatOptions` class supports the following options:
 - `frequencyPenalty` (double?, -2.0 to 2.0) - Frequency penalty
 - `seed` (int?) - Seed for deterministic sampling
 - `user` (String?) - User identifier for abuse detection
-- `jsonMode` (bool?) - Enable JSON mode
+- `jsonMode` (bool?) - Forces `{"type": "json_object"}`. Only consulted when Genkit's own output config does not already imply JSON; see [JSON output](#json-output)
 - `visualDetailLevel` (String?, 'auto'|'low'|'high') - Visual detail level for images
 - `version` (String?) - Model version override
+
+### JSON output
+
+There are three ways to get JSON back, in order of preference:
+
+```dart
+// 1. A schema - the model is constrained to the shape and `output` is typed.
+final response = await ai.generate(
+  model: openAI.model('gpt-4o'),
+  prompt: 'Describe a book.',
+  outputSchema: Book.$schema,
+);
+print(response.output!.title);
+
+// 2. JSON with no particular shape.
+final response = await ai.generate(
+  model: openAI.model('gpt-4o'),
+  prompt: 'Return a JSON object with keys "name" and "age".',
+  outputFormat: 'json',
+);
+
+// 3. The provider flag directly, for callers not using Genkit's output config.
+final response = await ai.generate(
+  model: openAI.model('gpt-4o'),
+  prompt: 'Reply with a JSON object.',
+  config: OpenAIChatOptions(jsonMode: true),
+);
+```
+
+`outputSchema` sends `response_format: {"type": "json_schema"}`; the other two
+send `{"type": "json_object"}`. Output config wins when both are set, so
+`jsonMode` never overrides a schema.
+
+OpenAI rejects `json_object` unless the conversation also asks for JSON, so
+options 2 and 3 need the prompt to say so. Option 1 does not.
+
+Schemas are sent as authored. The plugin does not set `strict`, because
+OpenAI's strict mode requires every property to appear in `required` and
+`additionalProperties: false` on every object — which rejects ordinary schemas
+that have optional fields.
 
 ## Custom Headers
 

--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -296,7 +296,7 @@ The `OpenAIChatOptions` class supports the following options:
 - `frequencyPenalty` (double?, -2.0 to 2.0) - Frequency penalty
 - `seed` (int?) - Seed for deterministic sampling
 - `user` (String?) - User identifier for abuse detection
-- `jsonMode` (bool?) - Forces `{"type": "json_object"}`. Only consulted when Genkit's own output config does not already imply JSON; see [JSON output](#json-output)
+- `jsonMode` (bool?) - Forces `{"type": "json_object"}`. Only consulted when Genkit's own output config says nothing about the format; any explicit `outputFormat` wins, `'text'` included. See [JSON output](#json-output)
 - `visualDetailLevel` (String?, 'auto'|'low'|'high') - Visual detail level for images
 - `version` (String?) - Model version override
 

--- a/packages/genkit_openai/lib/src/chat.dart
+++ b/packages/genkit_openai/lib/src/chat.dart
@@ -51,7 +51,14 @@ abstract class $OpenAIChatOptions {
   /// User identifier for abuse detection
   String? get user;
 
-  /// JSON mode
+  /// Forces `{"type": "json_object"}` on the request.
+  ///
+  /// Only consulted when Genkit's own output config does not already imply
+  /// JSON - `outputFormat: 'json'` or an `outputSchema` takes precedence, and
+  /// a schema additionally constrains the shape.
+  ///
+  /// OpenAI rejects json_object unless the conversation also asks for JSON, so
+  /// the prompt must say so. Prefer `outputSchema` where the shape is known.
   bool? get jsonMode;
 
   /// Visual detail level for images ('auto', 'low', 'high')
@@ -73,17 +80,45 @@ bool isJsonStructuredOutput(String? format, String? contentType) {
   return format == 'json' || contentType == 'application/json';
 }
 
-/// Builds an OpenAI [ResponseFormat] from a Genkit output schema.
-/// Flattens `$ref`/`$defs` since OpenAI requires `type` at the top level.
-/// Returns null if [schema] is null.
-ResponseFormat? buildOpenAIResponseFormat(Map<String, dynamic>? schema) {
-  if (schema == null) return null;
-  final flattened = schema.flatten();
-  return ResponseFormat.jsonSchema(
-    name: 'output',
-    schema: {...flattened, 'additionalProperties': false},
-    strict: true,
-  );
+/// Maps Genkit's output config onto OpenAI's `response_format`.
+///
+/// Mirrors the JS plugin: JSON output with a schema becomes `json_schema`,
+/// JSON output without one becomes `json_object`, and an explicit text format
+/// becomes `text`. Anything else sends no `response_format` at all, which
+/// matters for OpenAI-compatible hosts that reject the field.
+///
+/// Returning `json_object` for a schemaless JSON request is not a nicety: with
+/// no schema, Genkit's json formatter also emits no prompt instructions, so
+/// without this nothing would ask the model for JSON at all.
+ResponseFormat? buildOpenAIResponseFormat({
+  String? format,
+  String? contentType,
+  Map<String, dynamic>? schema,
+  bool? jsonMode,
+}) {
+  if (isJsonStructuredOutput(format, contentType)) {
+    if (schema == null) return ResponseFormat.jsonObject();
+
+    // Flattened because OpenAI needs `type` at the top level, so `$ref`/
+    // `$defs` have to be resolved away first.
+    return ResponseFormat.jsonSchema(
+      name: 'output',
+      schema: schema.flatten(),
+      // Strict mode demands `additionalProperties: false` on every object and
+      // every property listed in `required`. Genkit schemas are not authored
+      // that way - an optional field is simply absent from `required` - so
+      // strict rejects ordinary schemas with a 400. JS omits the flag
+      // entirely; the SDK always serializes it, so false is how we say that.
+      strict: false,
+    );
+  }
+
+  if (format == 'text') return ResponseFormat.text();
+
+  // Reached only when the caller opts in without using Genkit's output config.
+  if (jsonMode == true) return ResponseFormat.jsonObject();
+
+  return null;
 }
 
 /// Returns custom options schema for standard chat models.

--- a/packages/genkit_openai/lib/src/chat.dart
+++ b/packages/genkit_openai/lib/src/chat.dart
@@ -53,9 +53,10 @@ abstract class $OpenAIChatOptions {
 
   /// Forces `{"type": "json_object"}` on the request.
   ///
-  /// Only consulted when Genkit's own output config does not already imply
-  /// JSON - `outputFormat: 'json'` or an `outputSchema` takes precedence, and
-  /// a schema additionally constrains the shape.
+  /// Only consulted when Genkit's own output config says nothing about the
+  /// format. Any explicit `outputFormat` wins, including `'text'`, which
+  /// suppresses this rather than conflicting with it; `outputSchema` wins too
+  /// and additionally constrains the shape.
   ///
   /// OpenAI rejects json_object unless the conversation also asks for JSON, so
   /// the prompt must say so. Prefer `outputSchema` where the shape is known.
@@ -108,14 +109,22 @@ ResponseFormat? buildOpenAIResponseFormat({
       // every property listed in `required`. Genkit schemas are not authored
       // that way - an optional field is simply absent from `required` - so
       // strict rejects ordinary schemas with a 400. JS omits the flag
-      // entirely; the SDK always serializes it, so false is how we say that.
+      // entirely; `ResponseFormat.jsonSchema` declares `bool strict = true`
+      // and always serializes it, so false is the closest Dart gets.
+      //
+      // The trade is deliberate and visible: `strict: true` had OpenAI
+      // guarantee the reply conformed to the schema. It no longer does, and
+      // the schema is advisory. Schemas that did satisfy strict lose that
+      // guarantee; schemas that did not stop 400ing.
       strict: false,
     );
   }
 
   if (format == 'text') return ResponseFormat.text();
 
-  // Reached only when the caller opts in without using Genkit's output config.
+  // Reached only when the caller opts in without using Genkit's output
+  // config. An explicit `outputFormat: 'text'` has already returned above, so
+  // it suppresses jsonMode rather than competing with it.
   if (jsonMode == true) return ResponseFormat.jsonObject();
 
   return null;

--- a/packages/genkit_openai/lib/src/chat.g.dart
+++ b/packages/genkit_openai/lib/src/chat.g.dart
@@ -189,12 +189,26 @@ base class OpenAIChatOptions {
     }
   }
 
-  /// JSON mode
+  /// Forces `{"type": "json_object"}` on the request.
+  ///
+  /// Only consulted when Genkit's own output config does not already imply
+  /// JSON - `outputFormat: 'json'` or an `outputSchema` takes precedence, and
+  /// a schema additionally constrains the shape.
+  ///
+  /// OpenAI rejects json_object unless the conversation also asks for JSON, so
+  /// the prompt must say so. Prefer `outputSchema` where the shape is known.
   bool? get jsonMode {
     return _json['jsonMode'] as bool?;
   }
 
-  /// JSON mode
+  /// Forces `{"type": "json_object"}` on the request.
+  ///
+  /// Only consulted when Genkit's own output config does not already imply
+  /// JSON - `outputFormat: 'json'` or an `outputSchema` takes precedence, and
+  /// a schema additionally constrains the shape.
+  ///
+  /// OpenAI rejects json_object unless the conversation also asks for JSON, so
+  /// the prompt must say so. Prefer `outputSchema` where the shape is known.
   set jsonMode(bool? value) {
     if (value == null) {
       _json.remove('jsonMode');

--- a/packages/genkit_openai/lib/src/chat.g.dart
+++ b/packages/genkit_openai/lib/src/chat.g.dart
@@ -191,9 +191,10 @@ base class OpenAIChatOptions {
 
   /// Forces `{"type": "json_object"}` on the request.
   ///
-  /// Only consulted when Genkit's own output config does not already imply
-  /// JSON - `outputFormat: 'json'` or an `outputSchema` takes precedence, and
-  /// a schema additionally constrains the shape.
+  /// Only consulted when Genkit's own output config says nothing about the
+  /// format. Any explicit `outputFormat` wins, including `'text'`, which
+  /// suppresses this rather than conflicting with it; `outputSchema` wins too
+  /// and additionally constrains the shape.
   ///
   /// OpenAI rejects json_object unless the conversation also asks for JSON, so
   /// the prompt must say so. Prefer `outputSchema` where the shape is known.
@@ -203,9 +204,10 @@ base class OpenAIChatOptions {
 
   /// Forces `{"type": "json_object"}` on the request.
   ///
-  /// Only consulted when Genkit's own output config does not already imply
-  /// JSON - `outputFormat: 'json'` or an `outputSchema` takes precedence, and
-  /// a schema additionally constrains the shape.
+  /// Only consulted when Genkit's own output config says nothing about the
+  /// format. Any explicit `outputFormat` wins, including `'text'`, which
+  /// suppresses this rather than conflicting with it; `outputSchema` wins too
+  /// and additionally constrains the shape.
   ///
   /// OpenAI rejects json_object unless the conversation also asks for JSON, so
   /// the prompt must say so. Prefer `outputSchema` where the shape is known.

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -291,13 +291,6 @@ class OpenAIPlugin extends GenkitPlugin {
               ?.map(GenkitConverter.toOpenAITool)
               .toList();
 
-          final isJsonMode = chat.isJsonStructuredOutput(
-            modelRequest.output?.format,
-            modelRequest.output?.contentType,
-          );
-          final responseFormat = chat.buildOpenAIResponseFormat(
-            modelRequest.output?.schema,
-          );
           final request = sdk.ChatCompletionCreateRequest(
             model: options.version ?? modelName,
             messages: GenkitConverter.toOpenAIMessages(
@@ -314,7 +307,12 @@ class OpenAIPlugin extends GenkitPlugin {
             frequencyPenalty: options.frequencyPenalty,
             seed: options.seed,
             user: options.user,
-            responseFormat: isJsonMode ? responseFormat : null,
+            responseFormat: chat.buildOpenAIResponseFormat(
+              format: modelRequest.output?.format,
+              contentType: modelRequest.output?.contentType,
+              schema: modelRequest.output?.schema,
+              jsonMode: options.jsonMode,
+            ),
           );
           if (ctx.streamingRequested) {
             return await _handleStreaming(client, request, ctx);

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:genkit/genkit.dart';
@@ -249,6 +250,63 @@ void main() {
             ? 'OPENAI_API_KEY not set'
             : null,
       );
+
+      test(
+        'schemaless json output returns parseable JSON',
+        () async {
+          if (apiKey == null || apiKey.isEmpty) {
+            fail(
+              'OPENAI_API_KEY environment variable must be set to run integration tests',
+            );
+          }
+
+          // Without a schema Genkit adds no prompt instructions either, so
+          // before the json_object fallback nothing asked for JSON at all.
+          final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+          final response = await ai.generate(
+            model: openAI.model('gpt-4o'),
+            prompt:
+                'Return a JSON object with keys "name" and "age" for a '
+                'person named John Doe aged 30.',
+            outputFormat: 'json',
+          );
+
+          final decoded = jsonDecode(response.text) as Map<String, dynamic>;
+          expect(decoded['name'], isNotNull);
+        },
+        skip: apiKey == null || apiKey.isEmpty
+            ? 'OPENAI_API_KEY not set'
+            : null,
+      );
+
+      test(
+        'an output schema with an optional field is accepted',
+        () async {
+          if (apiKey == null || apiKey.isEmpty) {
+            fail(
+              'OPENAI_API_KEY environment variable must be set to run integration tests',
+            );
+          }
+
+          // Regression test for the old `strict: true`, which made OpenAI
+          // reject any schema whose `required` omitted a property. Only the
+          // live API can prove this; a mock cannot.
+          final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+          final response = await ai.generate(
+            model: openAI.model('gpt-4o'),
+            prompt: 'A person named John Doe who goes by JD.',
+            outputSchema: ProfileSchema.$schema,
+          );
+
+          expect(response.output, isNotNull);
+          expect(response.output!.name, isNotEmpty);
+        },
+        skip: apiKey == null || apiKey.isEmpty
+            ? 'OPENAI_API_KEY not set'
+            : null,
+      );
     });
 
     test('multi-turn conversation', () async {
@@ -400,4 +458,15 @@ abstract class $WeatherInputSchema {
 abstract class $PersonSchema {
   String get name;
   int get age;
+}
+
+/// A schema with an optional field.
+///
+/// `nickname` is nullable, so schemantic leaves it out of `required` - which
+/// is precisely what OpenAI's strict mode rejects. The plugin used to send
+/// `strict: true`, so this shape returned a 400.
+@Schema()
+abstract class $ProfileSchema {
+  String get name;
+  String? get nickname;
 }

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -300,8 +300,14 @@ void main() {
             outputSchema: ProfileSchema.$schema,
           );
 
+          // Asserted field by field rather than through `output!.name`: if
+          // the model omits a field, the getter throws a TypeError inside
+          // expect() and the test reports a crash instead of the assertion
+          // that actually failed.
           expect(response.output, isNotNull);
-          expect(response.output!.name, isNotEmpty);
+          final profile = response.output!.toJson();
+          expect(profile['name'], isA<String>());
+          expect(profile['name'], isNotEmpty);
         },
         skip: apiKey == null || apiKey.isEmpty
             ? 'OPENAI_API_KEY not set'

--- a/packages/genkit_openai/test/integration_test.g.dart
+++ b/packages/genkit_openai/test/integration_test.g.dart
@@ -143,3 +143,77 @@ base class _PersonSchemaTypeFactory extends SchemanticType<PersonSchema> {
     dependencies: [],
   );
 }
+
+/// A schema with an optional field.
+///
+/// `nickname` is nullable, so schemantic leaves it out of `required` - which
+/// is precisely what OpenAI's strict mode rejects. The plugin used to send
+/// `strict: true`, so this shape returned a 400.
+base class ProfileSchema {
+  /// Creates a [ProfileSchema] from a JSON map.
+  factory ProfileSchema.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  ProfileSchema._(this._json);
+
+  ProfileSchema({required String name, String? nickname}) {
+    _json = {'name': name, 'nickname': ?nickname};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [ProfileSchema].
+  static const SchemanticType<ProfileSchema> $schema =
+      _ProfileSchemaTypeFactory();
+
+  String get name {
+    return _json['name'] as String;
+  }
+
+  set name(String value) {
+    _json['name'] = value;
+  }
+
+  String? get nickname {
+    return _json['nickname'] as String?;
+  }
+
+  set nickname(String? value) {
+    if (value == null) {
+      _json.remove('nickname');
+    } else {
+      _json['nickname'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [ProfileSchema] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _ProfileSchemaTypeFactory extends SchemanticType<ProfileSchema> {
+  const _ProfileSchemaTypeFactory();
+
+  @override
+  ProfileSchema parse(Object? json) {
+    return ProfileSchema._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'ProfileSchema',
+    definition: $Schema
+        .object(
+          properties: {'name': $Schema.string(), 'nickname': $Schema.string()},
+          required: ['name'],
+        )
+        .value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_openai/test/openai_plugin_chat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_chat_test.dart
@@ -71,27 +71,111 @@ void main() {
   });
 
   group('buildOpenAIResponseFormat', () {
-    test('builds ResponseFormat from schema with \$defs', () {
-      final result = buildOpenAIResponseFormat(_createPersonSchema());
-      expect(result, isNotNull);
+    test('json output with a schema builds a json_schema format', () {
+      final result = buildOpenAIResponseFormat(
+        format: 'json',
+        schema: _createPersonSchema(),
+      );
       final js = _jsonSchema(result!);
       expect(js.name, 'output');
       expect(js.schema['type'], 'object');
-      expect(js.schema['additionalProperties'], false);
       expect(js.schema['properties'], isNotNull);
     });
 
-    test('returns null only for null schema', () {
-      expect(buildOpenAIResponseFormat(null), isNull);
+    test('resolves \$defs so type sits at the top level', () {
+      final js = _jsonSchema(
+        buildOpenAIResponseFormat(
+          format: 'json',
+          schema: _createPersonSchema(),
+        )!,
+      );
+      expect(js.schema.containsKey(r'\$defs'), isFalse);
+      expect(js.schema.containsKey(r'\$ref'), isFalse);
     });
 
-    test('builds ResponseFormat from schema without \$defs', () {
-      final result = buildOpenAIResponseFormat({'type': 'object'});
-      expect(result, isNotNull);
-      final js = _jsonSchema(result!);
-      expect(js.name, 'output');
-      expect(js.schema['type'], 'object');
-      expect(js.schema['additionalProperties'], false);
+    test('does not set strict', () {
+      // Strict mode requires additionalProperties:false on every object and
+      // every property in `required`. Genkit schemas are not authored that
+      // way, so strict rejects them with a 400.
+      final js = _jsonSchema(
+        buildOpenAIResponseFormat(format: 'json', schema: {'type': 'object'})!,
+      );
+      expect(js.strict, isFalse);
+    });
+
+    test('passes the schema through without injecting fields', () {
+      // The plugin used to add additionalProperties:false at the top level,
+      // which is both insufficient for strict mode and a silent mutation of
+      // the caller's schema.
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'title': {'type': 'string'},
+          'year': {'type': 'integer'},
+          'author': {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+            'required': ['name'],
+          },
+        },
+        // `year` deliberately absent - an optional field.
+        'required': ['title'],
+      };
+
+      final js = _jsonSchema(
+        buildOpenAIResponseFormat(format: 'json', schema: schema)!,
+      );
+
+      expect(js.schema, equals(schema));
+      expect(js.schema.containsKey('additionalProperties'), isFalse);
+      final author =
+          (js.schema['properties'] as Map)['author'] as Map<String, dynamic>;
+      expect(author.containsKey('additionalProperties'), isFalse);
+    });
+
+    test('json output without a schema falls back to json_object', () {
+      // The regression this issue is about: with no schema, Genkit emits no
+      // prompt instructions either, so without this nothing asks for JSON.
+      expect(
+        buildOpenAIResponseFormat(format: 'json'),
+        isA<JsonObjectResponseFormat>(),
+      );
+      expect(
+        buildOpenAIResponseFormat(contentType: 'application/json'),
+        isA<JsonObjectResponseFormat>(),
+      );
+    });
+
+    test('an explicit text format maps to text', () {
+      expect(
+        buildOpenAIResponseFormat(format: 'text'),
+        isA<TextResponseFormat>(),
+      );
+    });
+
+    test('jsonMode alone forces json_object', () {
+      expect(
+        buildOpenAIResponseFormat(jsonMode: true),
+        isA<JsonObjectResponseFormat>(),
+      );
+      expect(buildOpenAIResponseFormat(jsonMode: false), isNull);
+    });
+
+    test('output config wins over jsonMode', () {
+      final result = buildOpenAIResponseFormat(
+        format: 'json',
+        schema: {'type': 'object'},
+        jsonMode: true,
+      );
+      expect(result, isA<JsonSchemaResponseFormat>());
+    });
+
+    test('sends nothing when no format is requested', () {
+      // Compatible hosts that reject response_format must keep working.
+      expect(buildOpenAIResponseFormat(), isNull);
+      expect(buildOpenAIResponseFormat(schema: {'type': 'object'}), isNull);
     });
   });
 

--- a/packages/genkit_openai/test/openai_plugin_chat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_chat_test.dart
@@ -89,8 +89,12 @@ void main() {
           schema: _createPersonSchema(),
         )!,
       );
-      expect(js.schema.containsKey(r'\$defs'), isFalse);
-      expect(js.schema.containsKey(r'\$ref'), isFalse);
+      // Raw strings: r'$defs' is the literal JSON Schema key. Escaping it as
+      // r'\$defs' looks for a backslash and can never match, so the assertion
+      // passed even with the flatten removed.
+      expect(js.schema.containsKey(r'$defs'), isFalse);
+      expect(js.schema.containsKey(r'$ref'), isFalse);
+      expect(js.schema['properties'], isNotNull);
     });
 
     test('does not set strict', () {

--- a/packages/genkit_openai/test/openai_plugin_response_format_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_response_format_wire_test.dart
@@ -1,0 +1,200 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:schemantic/schemantic.dart';
+import 'package:test/test.dart';
+
+/// Captures every chat-completions body so tests can assert on the actual
+/// `response_format` sent, rather than on the helper in isolation.
+MockClient wireClient(List<Map<String, dynamic>> capturedBodies) {
+  return MockClient((request) async {
+    if (request.url.path.endsWith('/models')) {
+      return http.Response(
+        jsonEncode({
+          'object': 'list',
+          'data': [
+            {
+              'id': 'gpt-4o',
+              'object': 'model',
+              'created': 0,
+              'owned_by': 'openai',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (request.url.path.endsWith('/chat/completions')) {
+      capturedBodies.add(
+        (jsonDecode(request.body) as Map).cast<String, dynamic>(),
+      );
+      return http.Response(
+        jsonEncode({
+          'id': 'chatcmpl-test',
+          'object': 'chat.completion',
+          'created': 0,
+          'model': 'gpt-4o',
+          'choices': [
+            {
+              'index': 0,
+              'message': {'role': 'assistant', 'content': '{"title":"ok"}'},
+              'finish_reason': 'stop',
+            },
+          ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('not found', 404);
+  });
+}
+
+Genkit wireGenkit(List<Map<String, dynamic>> captured) => Genkit(
+  plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+);
+
+Map<String, dynamic>? responseFormatOf(Map<String, dynamic> body) =>
+    (body['response_format'] as Map?)?.cast<String, dynamic>();
+
+void main() {
+  group('response_format on the wire', () {
+    test('schemaless json output sends json_object', () async {
+      // The regression #359 is about: this previously sent no
+      // response_format at all, and Genkit emits no prompt instructions
+      // without a schema either - so nothing asked for JSON.
+      final captured = <Map<String, dynamic>>[];
+      final ai = wireGenkit(captured);
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Give me an object with a title.',
+        outputFormat: 'json',
+      );
+
+      expect(responseFormatOf(captured.single), {'type': 'json_object'});
+
+      await ai.shutdown();
+    });
+
+    test('a schema sends json_schema with strict false', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = wireGenkit(captured);
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Describe a book.',
+        outputSchema: _bookSchema,
+      );
+
+      final format = responseFormatOf(captured.single)!;
+      expect(format['type'], 'json_schema');
+      final jsonSchema = (format['json_schema'] as Map).cast<String, dynamic>();
+      expect(jsonSchema['name'], 'output');
+      expect(
+        jsonSchema['strict'],
+        isFalse,
+        reason: 'strict rejects schemas with optional fields',
+      );
+
+      await ai.shutdown();
+    });
+
+    test('an optional field reaches the wire unmodified', () async {
+      // Under the old strict:true path OpenAI rejected this outright, because
+      // strict requires every property to appear in `required`.
+      final captured = <Map<String, dynamic>>[];
+      final ai = wireGenkit(captured);
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Describe a book.',
+        outputSchema: _bookSchema,
+      );
+
+      final schema =
+          ((responseFormatOf(captured.single)!['json_schema'] as Map)['schema']
+                  as Map)
+              .cast<String, dynamic>();
+
+      expect(schema['required'], ['title']);
+      expect((schema['properties'] as Map).containsKey('year'), isTrue);
+      expect(
+        schema.containsKey('additionalProperties'),
+        isFalse,
+        reason: 'the plugin must not mutate the caller schema',
+      );
+
+      await ai.shutdown();
+    });
+
+    test('jsonMode forces json_object without an output config', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = wireGenkit(captured);
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Reply in JSON.',
+        config: OpenAIChatOptions(jsonMode: true),
+      );
+
+      expect(responseFormatOf(captured.single), {'type': 'json_object'});
+
+      await ai.shutdown();
+    });
+
+    test('a plain request sends no response_format at all', () async {
+      // Compatible hosts that reject the field must keep working.
+      final captured = <Map<String, dynamic>>[];
+      final ai = wireGenkit(captured);
+
+      await ai.generate(model: openAI.model('gpt-4o'), prompt: 'Hello.');
+
+      expect(captured.single.containsKey('response_format'), isFalse);
+
+      await ai.shutdown();
+    });
+  });
+}
+
+/// A schema with an optional field (`year`) and a nested object.
+///
+/// `year` is deliberately absent from `required`, which is exactly what
+/// schemantic generates for a nullable field - and exactly what OpenAI's
+/// strict mode rejects.
+final _bookSchema = SchemanticType.from<Map<String, Object?>>(
+  jsonSchema: {
+    'type': 'object',
+    'properties': {
+      'title': {'type': 'string'},
+      'year': {'type': 'integer'},
+      'author': {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+        },
+        'required': ['name'],
+      },
+    },
+    'required': ['title'],
+  },
+  parse: (json) => (json as Map).cast<String, Object?>(),
+);

--- a/packages/genkit_openai/test/openai_plugin_response_format_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_response_format_wire_test.dart
@@ -72,6 +72,18 @@ Genkit wireGenkit(List<Map<String, dynamic>> captured) => Genkit(
   plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
 );
 
+/// A Genkit whose openai plugin points at a compatible host, not OpenAI.
+Genkit compatGenkit(List<Map<String, dynamic>> captured) => Genkit(
+  plugins: [
+    openAI(
+      name: 'groq',
+      apiKey: 'test-key',
+      baseUrl: 'https://api.groq.com/openai/v1',
+      httpClient: wireClient(captured),
+    ),
+  ],
+);
+
 Map<String, dynamic>? responseFormatOf(Map<String, dynamic> body) =>
     (body['response_format'] as Map?)?.cast<String, dynamic>();
 
@@ -154,6 +166,61 @@ void main() {
         model: openAI.model('gpt-4o'),
         prompt: 'Reply in JSON.',
         config: OpenAIChatOptions(jsonMode: true),
+      );
+
+      expect(responseFormatOf(captured.single), {'type': 'json_object'});
+
+      await ai.shutdown();
+    });
+
+    test('an explicit text output format sends type: text', () async {
+      // Mirrors JS (compat-oai/src/model.ts:622). Nothing in the plugin needs
+      // it, so without a test the branch is unpinned - and it is the one
+      // response_format a compat host is most likely to reject.
+      final captured = <Map<String, dynamic>>[];
+      final ai = wireGenkit(captured);
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Hello.',
+        outputFormat: 'text',
+      );
+
+      expect(responseFormatOf(captured.single), {'type': 'text'});
+
+      await ai.shutdown();
+    });
+
+    test('an explicit text format suppresses jsonMode', () async {
+      // The documented rule is that jsonMode loses to Genkit's own output
+      // config. `text` is part of that config, so it wins here too.
+      final captured = <Map<String, dynamic>>[];
+      final ai = wireGenkit(captured);
+
+      await ai.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'Hello.',
+        outputFormat: 'text',
+        config: OpenAIChatOptions(jsonMode: true),
+      );
+
+      expect(responseFormatOf(captured.single), {'type': 'text'});
+
+      await ai.shutdown();
+    });
+
+    test('a compat host gets json_object for schemaless json too', () async {
+      // Behaviour change: before this fix a schemaless json request sent no
+      // response_format anywhere, so a compat host saw nothing. It now sends
+      // json_object to every host, OpenAI-compatible ones included. Hosts
+      // vary in what they accept, so this is pinned rather than assumed.
+      final captured = <Map<String, dynamic>>[];
+      final ai = compatGenkit(captured);
+
+      await ai.generate(
+        model: openAI.model('gpt-4', namespace: 'groq'),
+        prompt: 'Reply in JSON.',
+        outputFormat: 'json',
       );
 
       expect(responseFormatOf(captured.single), {'type': 'json_object'});


### PR DESCRIPTION
## Problem

Three defects in `buildOpenAIResponseFormat` (`lib/src/chat.dart`):

1. **Schemaless JSON asked for nothing.** `outputFormat: 'json'` without a
   schema sent no `response_format`. Genkit adds no prompt instructions in that
   case either, so nothing told the model to emit JSON.
2. **`jsonMode` was dead code** — declared, documented in the README, never
   read. Its test only checked that the option parsed.
3. **`strict: true` rejected ordinary schemas.** Strict mode needs
   `additionalProperties: false` on every object and every property in
   `required`; the plugin injected it only at the top level, and schemantic
   omits optional fields from `required`. Any schema with an optional field
   returned a 400.

## Solution

One function covering the whole output config, mirroring the JS plugin:

- `format: 'json'` + schema → `json_schema`, schema verbatim, `strict: false`
- `format: 'json'`, no schema → `json_object`
- `format: 'text'` → `text`
- `jsonMode: true` alone → `json_object`
- nothing requested → no `response_format` key, so compatible hosts still work

Output config wins over `jsonMode`, and the caller's schema is no longer
mutated.

## Breaking change

`strict: true` -> `strict: false` on `json_schema`. With strict, OpenAI
guaranteed the reply conformed to the schema; it no longer does, and the schema
becomes advisory. Schemas that already satisfied strict lose that guarantee —
schemas that did not stop returning 400.

JS omits the flag entirely, which is what we want, but
`ResponseFormat.jsonSchema` declares `bool strict = true` and always
serializes it, so `false` is the closest Dart gets.

The title carries `!` so `tools/version.dart` bumps the major rather than
shipping this as a patch — a caller relying on guaranteed conformance needs to
see it in the changelog.

Second behaviour change, non-breaking but worth stating: a schemaless
`outputFormat: 'json'` request now sends `json_object` to **every** host,
compat backends included, where before it sent no `response_format` at all.
Hosts vary in what they accept, so there is a wire test pinning it.

## Testing

175 pass, `dart analyze --fatal-infos` clean, and the full workspace
(`melos exec --dir-exists=test -- dart test`) is green. There were zero wire
tests asserting `response_format` before this — which is how three defects
coexisted. The new wire suite fails against the pre-fix code, so it isn't
decoration.

**Live tests run against the real API: 14/14 pass.** That includes
`an output schema with an optional field is accepted`, which is the only thing
that can verify defect 3 — a mock cannot prove OpenAI stopped rejecting the
schema. Defect 1's `schemaless json output returns parseable JSON` passed too.

```bash
OPENAI_API_KEY=sk-... dart test test/integration_test.dart
# 00:25 +14: All tests passed!
```

## Notes

- `jsonMode` is a divergence from JS, which has no such option. Wiring it up beat
  deleting it: a documented option that silently does nothing is worse.
- Dropping `strict` means output is best-effort JSON matching the schema, as in
  JS — no exact-conformance guarantee.

Fixes #359


