### PR TITLE
chore: upgrade openai_dart to v8.0.0

### DIFF
--- a/packages/genkit_openai/pubspec.yaml
+++ b/packages/genkit_openai/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.17.0
 
-  openai_dart: ^5.0.0
+  openai_dart: ^8.0.0
   schemantic: ^0.2.2
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Upgrade `packages/genkit_openai` from `openai_dart: ^5.0.0` to `openai_dart: ^8.0.0`.
- Keep existing chat-completions integration unchanged; openai_dart v8 breaking changes do not affect APIs used by this package.

## Test plan
- [x] `dart pub get` resolves `openai_dart 8.1.0`
- [x] `dart analyze packages/genkit_openai`
- [x] `cd packages/genkit_openai && dart test`
- [x] `melos run analyze`
- [x] `melos exec --dir-exists=test -- "dart test"`
- [x] `dart run tools/check_dartdoc.dart`
