### PR TITLE
test(genkit_openai): cover the OpenAI-compatible path with a fake host

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -1,15 +1,14 @@
 [![Pub](https://img.shields.io/pub/v/genkit_openai.svg)](https://pub.dev/packages/genkit_openai)
 
-OpenAI-compatible API plugin for Genkit Dart. Supports OpenAI models (GPT-4o, GPT-4, GPT-3.5-turbo, etc.) and any OpenAI-compatible API (xAI/Grok, DeepSeek, Together AI, Groq, etc.).
+OpenAI plugin for Genkit Dart. Talks the OpenAI Chat Completions API, so it
+drives OpenAI's own models and any host that implements the same API — Groq,
+xAI/Grok, DeepSeek, Together AI, OpenRouter and friends — by pointing it at a
+different [`baseUrl`](#openai-compatible-apis).
 
 ## Installation
 
-Add `genkit_openai` to your `pubspec.yaml`:
-
-```yaml
-dependencies:
-  genkit: ^0.13.0
-  genkit_openai: ^0.3.0
+```bash
+dart pub add genkit genkit_openai
 ```
 
 ## Usage
@@ -159,9 +158,28 @@ final response = await ai.generate(
 
 ## OpenAI-Compatible APIs
 
-The plugin supports any OpenAI-compatible API by specifying a custom `baseUrl`.
-Use the `name` parameter to give each backend a unique identity — this is
-required when registering multiple backends in the same `Genkit` instance.
+Point the plugin at any OpenAI-compatible host with `baseUrl`. Use `name` to
+give each backend a unique identity — this is required when registering
+multiple backends in the same `Genkit` instance, and it becomes the namespace
+prefix for that backend's models.
+
+Two things to know before pointing this at a non-OpenAI host:
+
+- **Model discovery is optional.** `GET /models` is only called when listing
+  actions, and a host that does not serve it degrades to a warning. Name any
+  model explicitly and it resolves whether or not the host advertises it — but
+  what the Dev UI *lists* for a custom `baseUrl` is only what discovery
+  returned plus your `models:`. The curated OpenAI catalog is deliberately
+  withheld, so a Groq backend does not offer you `groq/gpt-4o`. Declare the
+  models you care about in `models:` to see them listed.
+- **Streaming always sends `stream_options.include_usage`.** Hosts that reject
+  unknown stream options will refuse streaming calls.
+
+Compatibility is verified against a local fake host
+(`test/openai_plugin_compat_test.dart`) covering `baseUrl` routing, auth,
+custom headers, custom models, streaming and error mapping — not against each
+provider's live API, so treat the providers named above as examples of the
+shape rather than a certified list.
 
 ### Groq
 

--- a/packages/genkit_openai/test/fake_openai_server.dart
+++ b/packages/genkit_openai/test/fake_openai_server.dart
@@ -1,0 +1,323 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A stand-in for an OpenAI-compatible host, ported from the JS plugin's
+/// `tests/fake_openai_server.ts`.
+///
+/// This binds a real socket rather than injecting a `MockClient` because the
+/// compat path is precisely the part a mock cannot vouch for: every other test
+/// in this package hands the plugin an `httpClient`, so the client the plugin
+/// builds for itself - the one real users get, and the only thing that turns
+/// `baseUrl` into an actual connection - is never exercised. Pointing the
+/// plugin at `server.baseUrl` with no `httpClient` proves the URL is dialed,
+/// the auth and custom headers survive the SDK's interceptor chain, and SSE is
+/// parsed off a genuinely chunked socket.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// One request as the fake host saw it.
+class RecordedRequest {
+  /// HTTP method, e.g. `POST`.
+  final String method;
+
+  /// Request path, e.g. `/v1/chat/completions`.
+  final String path;
+
+  /// Request headers, lower-cased by `dart:io`.
+  final Map<String, String> headers;
+
+  /// The raw request body.
+  final String rawBody;
+
+  RecordedRequest({
+    required this.method,
+    required this.path,
+    required this.headers,
+    required this.rawBody,
+  });
+
+  /// The body decoded as JSON, or an empty map when there was no body.
+  Map<String, dynamic> get body => rawBody.isEmpty
+      ? const {}
+      : (jsonDecode(rawBody) as Map).cast<String, dynamic>();
+
+  @override
+  String toString() => '$method $path';
+}
+
+/// A canned reply for the fake host to serve.
+class FakeResponse {
+  /// HTTP status to write.
+  final int statusCode;
+
+  /// JSON-encodable body, for non-streaming replies.
+  final Object? body;
+
+  /// Extra response headers.
+  final Map<String, String> headers;
+
+  /// Whether to serve this reply as an SSE stream.
+  final bool stream;
+
+  /// SSE payloads, each written as one `data:` frame, followed by `[DONE]`.
+  final List<Object>? chunks;
+
+  /// Verbatim SSE frames, for wire shapes [chunks] cannot express. No `[DONE]`
+  /// frame is appended.
+  final List<String>? rawSse;
+
+  const FakeResponse({
+    this.statusCode = 200,
+    this.body,
+    this.headers = const {},
+    this.stream = false,
+    this.chunks,
+    this.rawSse,
+  });
+
+  /// A JSON reply with the given [body] and [statusCode].
+  const FakeResponse.json(Object body, {int statusCode = 200})
+    : this(body: body, statusCode: statusCode);
+
+  /// An OpenAI-style error reply, as a compatible host returns on failure.
+  factory FakeResponse.error(int statusCode, String message) {
+    return FakeResponse(
+      statusCode: statusCode,
+      body: {
+        'error': {'message': message, 'type': 'invalid_request_error'},
+      },
+    );
+  }
+
+  /// An SSE reply built from [chunks].
+  const FakeResponse.sse(List<Object> chunks)
+    : this(stream: true, chunks: chunks);
+}
+
+/// An OpenAI-compatible host backed by a real [HttpServer] on an ephemeral
+/// port.
+///
+/// Queued replies are served in order; once the queue drains, a path-aware
+/// default keeps tests that do not care about the response body short. When
+/// `expectedApiKey` is set, any request without a matching bearer token gets
+/// the same 401 shape OpenAI returns.
+class FakeOpenAIServer {
+  FakeOpenAIServer._(this._server, this._expectedApiKey) {
+    unawaited(_serve());
+  }
+
+  final HttpServer _server;
+  final String? _expectedApiKey;
+  final List<FakeResponse> _queued = [];
+
+  /// Every request the host received, in order.
+  final List<RecordedRequest> requests = [];
+
+  /// Anything thrown while serving a request.
+  ///
+  /// A handler that dies leaves the client staring at a closed socket, which
+  /// surfaces in the test as an opaque transport error a long way from the
+  /// cause. These are printed as they happen so the real reason is on screen.
+  final List<Object> handlerErrors = [];
+
+  /// Binds a fake host on an ephemeral loopback port.
+  ///
+  /// Pass [expectedApiKey] to have the host reject any other bearer token with
+  /// a 401, the way a real provider would.
+  static Future<FakeOpenAIServer> start({String? expectedApiKey}) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return FakeOpenAIServer._(server, expectedApiKey);
+  }
+
+  /// The base URL to hand the plugin, including the `/v1` prefix that
+  /// OpenAI-compatible hosts conventionally serve under.
+  String get baseUrl => 'http://127.0.0.1:${_server.port}/v1';
+
+  /// Queues [response] to be served to the next request.
+  void enqueue(FakeResponse response) => _queued.add(response);
+
+  /// Stops the host, dropping any in-flight connections.
+  Future<void> stop() => _server.close(force: true);
+
+  /// The bodies of every chat-completions request received.
+  List<Map<String, dynamic>> get chatRequestBodies => [
+    for (final r in requests)
+      if (r.path.endsWith('/chat/completions')) r.body,
+  ];
+
+  Future<void> _serve() async {
+    await for (final request in _server) {
+      try {
+        await _handle(request);
+      } catch (e, stackTrace) {
+        // Usually the client hung up or the test ended, which is harmless. A
+        // bug in this harness lands here too, so make it visible rather than
+        // letting the test fail with an unexplained transport error.
+        handlerErrors.add(e);
+        stderr.writeln(
+          'FakeOpenAIServer failed to serve a request: $e\n$stackTrace',
+        );
+      }
+    }
+  }
+
+  Future<void> _handle(HttpRequest request) async {
+    final rawBody = await utf8.decoder.bind(request).join();
+    final headers = <String, String>{};
+    request.headers.forEach((name, values) => headers[name] = values.join(','));
+
+    requests.add(
+      RecordedRequest(
+        method: request.method,
+        path: request.uri.path,
+        headers: headers,
+        rawBody: rawBody,
+      ),
+    );
+
+    final expected = _expectedApiKey;
+    if (expected != null &&
+        request.headers.value('authorization') != 'Bearer $expected') {
+      await _writeJson(request.response, 401, {
+        'error': {
+          'message': 'Incorrect API key provided',
+          'type': 'invalid_request_error',
+          'param': null,
+          'code': 'invalid_api_key',
+        },
+      });
+      return;
+    }
+
+    final response = _queued.isNotEmpty
+        ? _queued.removeAt(0)
+        : _defaultFor(request.uri.path);
+
+    if (response.stream) {
+      await _writeSse(request.response, response);
+    } else {
+      await _writeJson(
+        request.response,
+        response.statusCode,
+        response.body,
+        extraHeaders: response.headers,
+      );
+    }
+  }
+
+  Future<void> _writeJson(
+    HttpResponse response,
+    int statusCode,
+    Object? body, {
+    Map<String, String> extraHeaders = const {},
+  }) async {
+    response.statusCode = statusCode;
+    response.headers.contentType = ContentType.json;
+    extraHeaders.forEach(response.headers.set);
+    response.write(jsonEncode(body));
+    await response.close();
+  }
+
+  Future<void> _writeSse(HttpResponse response, FakeResponse spec) async {
+    response.statusCode = spec.statusCode;
+    response.headers.set('content-type', 'text/event-stream');
+    response.headers.set('cache-control', 'no-cache');
+    spec.headers.forEach(response.headers.set);
+
+    final rawSse = spec.rawSse;
+    if (rawSse != null) {
+      for (final frame in rawSse) {
+        response.write(frame);
+        await response.flush();
+      }
+      await response.close();
+      return;
+    }
+
+    for (final chunk in spec.chunks ?? const []) {
+      response.write('data: ${jsonEncode(chunk)}\n\n');
+      await response.flush();
+    }
+    response.write('data: [DONE]\n\n');
+    await response.close();
+  }
+
+  FakeResponse _defaultFor(String path) {
+    if (path.endsWith('/models')) return FakeResponse.json(modelList(const []));
+    return FakeResponse.json(chatCompletion(content: 'default response'));
+  }
+}
+
+/// Builds a `chat.completion` body, the shape a compatible host must return.
+Map<String, dynamic> chatCompletion({
+  String content = 'ok',
+  String model = 'test-model',
+  String finishReason = 'stop',
+  List<Map<String, dynamic>>? toolCalls,
+  Map<String, dynamic>? usage,
+}) {
+  return {
+    'id': 'chatcmpl-fake',
+    'object': 'chat.completion',
+    'created': 0,
+    'model': model,
+    'choices': [
+      {
+        'index': 0,
+        'message': {
+          'role': 'assistant',
+          'content': content,
+          'tool_calls': ?toolCalls,
+        },
+        'finish_reason': finishReason,
+      },
+    ],
+    'usage': ?usage,
+  };
+}
+
+/// Builds one `chat.completion.chunk` frame for [FakeResponse.sse].
+Map<String, dynamic> chatChunk({
+  String? content,
+  String model = 'test-model',
+  String? finishReason,
+}) {
+  return {
+    'id': 'chatcmpl-fake',
+    'object': 'chat.completion.chunk',
+    'created': 0,
+    'model': model,
+    'choices': [
+      {
+        'index': 0,
+        'delta': {'content': ?content},
+        'finish_reason': finishReason,
+      },
+    ],
+  };
+}
+
+/// Builds a `GET /models` listing over [ids].
+Map<String, dynamic> modelList(List<String> ids) {
+  return {
+    'object': 'list',
+    'data': [
+      for (final id in ids)
+        {'id': id, 'object': 'model', 'created': 0, 'owned_by': 'fake'},
+    ],
+  };
+}

--- a/packages/genkit_openai/test/fake_openai_server.dart
+++ b/packages/genkit_openai/test/fake_openai_server.dart
@@ -18,11 +18,11 @@
 /// This binds a real socket rather than injecting a `MockClient` because the
 /// compat path is precisely the part a mock cannot vouch for: every other test
 /// in this package hands the plugin an `httpClient`, so the client the plugin
-/// builds for itself - the one real users get, and the only thing that turns
-/// `baseUrl` into an actual connection - is never exercised. Pointing the
-/// plugin at `server.baseUrl` with no `httpClient` proves the URL is dialed,
-/// the auth and custom headers survive the SDK's interceptor chain, and SSE is
-/// parsed off a genuinely chunked socket.
+/// builds for itself - the one real users get - is never exercised, and nor is
+/// closing it. The `MockClient` tests do cover `baseUrl` reaching the client
+/// and streaming; what a real socket adds is the self-built client and its
+/// `close()`, header serialisation as the wire sees it, and SSE parsed off
+/// genuinely chunked frames.
 library;
 
 import 'dart:async';
@@ -54,9 +54,6 @@ class RecordedRequest {
   Map<String, dynamic> get body => rawBody.isEmpty
       ? const {}
       : (jsonDecode(rawBody) as Map).cast<String, dynamic>();
-
-  @override
-  String toString() => '$method $path';
 }
 
 /// A canned reply for the fake host to serve.
@@ -66,9 +63,6 @@ class FakeResponse {
 
   /// JSON-encodable body, for non-streaming replies.
   final Object? body;
-
-  /// Extra response headers.
-  final Map<String, String> headers;
 
   /// Whether to serve this reply as an SSE stream.
   final bool stream;
@@ -83,7 +77,6 @@ class FakeResponse {
   const FakeResponse({
     this.statusCode = 200,
     this.body,
-    this.headers = const {},
     this.stream = false,
     this.chunks,
     this.rawSse,
@@ -131,7 +124,9 @@ class FakeOpenAIServer {
   ///
   /// A handler that dies leaves the client staring at a closed socket, which
   /// surfaces in the test as an opaque transport error a long way from the
-  /// cause. These are printed as they happen so the real reason is on screen.
+  /// cause. These are printed as they happen so the real reason is on screen,
+  /// and [stop] fails the test rather than letting one pass over a host that
+  /// was quietly broken.
   final List<Object> handlerErrors = [];
 
   /// Binds a fake host on an ephemeral loopback port.
@@ -151,7 +146,15 @@ class FakeOpenAIServer {
   void enqueue(FakeResponse response) => _queued.add(response);
 
   /// Stops the host, dropping any in-flight connections.
-  Future<void> stop() => _server.close(force: true);
+  Future<void> stop() async {
+    await _server.close(force: true);
+    if (handlerErrors.isNotEmpty) {
+      throw StateError(
+        'the fake host threw while serving a request: '
+        '${handlerErrors.join('; ')}',
+      );
+    }
+  }
 
   /// The bodies of every chat-completions request received.
   List<Map<String, dynamic>> get chatRequestBodies => [
@@ -210,24 +213,17 @@ class FakeOpenAIServer {
     if (response.stream) {
       await _writeSse(request.response, response);
     } else {
-      await _writeJson(
-        request.response,
-        response.statusCode,
-        response.body,
-        extraHeaders: response.headers,
-      );
+      await _writeJson(request.response, response.statusCode, response.body);
     }
   }
 
   Future<void> _writeJson(
     HttpResponse response,
     int statusCode,
-    Object? body, {
-    Map<String, String> extraHeaders = const {},
-  }) async {
+    Object? body,
+  ) async {
     response.statusCode = statusCode;
     response.headers.contentType = ContentType.json;
-    extraHeaders.forEach(response.headers.set);
     response.write(jsonEncode(body));
     await response.close();
   }
@@ -236,7 +232,6 @@ class FakeOpenAIServer {
     response.statusCode = spec.statusCode;
     response.headers.set('content-type', 'text/event-stream');
     response.headers.set('cache-control', 'no-cache');
-    spec.headers.forEach(response.headers.set);
 
     final rawSse = spec.rawSse;
     if (rawSse != null) {
@@ -265,7 +260,6 @@ class FakeOpenAIServer {
 /// Builds a `chat.completion` body, the shape a compatible host must return.
 Map<String, dynamic> chatCompletion({
   String content = 'ok',
-  String model = 'test-model',
   String finishReason = 'stop',
   List<Map<String, dynamic>>? toolCalls,
   Map<String, dynamic>? usage,
@@ -274,7 +268,7 @@ Map<String, dynamic> chatCompletion({
     'id': 'chatcmpl-fake',
     'object': 'chat.completion',
     'created': 0,
-    'model': model,
+    'model': 'test-model',
     'choices': [
       {
         'index': 0,
@@ -291,16 +285,12 @@ Map<String, dynamic> chatCompletion({
 }
 
 /// Builds one `chat.completion.chunk` frame for [FakeResponse.sse].
-Map<String, dynamic> chatChunk({
-  String? content,
-  String model = 'test-model',
-  String? finishReason,
-}) {
+Map<String, dynamic> chatChunk({String? content, String? finishReason}) {
   return {
     'id': 'chatcmpl-fake',
     'object': 'chat.completion.chunk',
     'created': 0,
-    'model': model,
+    'model': 'test-model',
     'choices': [
       {
         'index': 0,

--- a/packages/genkit_openai/test/openai_plugin_compat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_compat_test.dart
@@ -46,8 +46,6 @@ CustomModelDefinition llama() => CustomModelDefinition(
 );
 
 void main() {
-  late FakeOpenAIServer server;
-
   Future<FakeOpenAIServer> startServer({String? expectedApiKey}) async {
     final started = await FakeOpenAIServer.start(
       expectedApiKey: expectedApiKey,
@@ -57,6 +55,8 @@ void main() {
   }
 
   group('baseUrl routing', () {
+    late FakeOpenAIServer server;
+
     setUp(() async {
       server = await startServer();
     });
@@ -227,12 +227,21 @@ void main() {
           .cast<Map<String, dynamic>>();
       final function = tools.single['function'] as Map<String, dynamic>;
       expect(function['name'], 'getWeather');
-      // The second turn must carry the tool result the host asked for.
-      final followUpRoles = (bodies[1]['messages'] as List)
-          .cast<Map<String, dynamic>>()
-          .map((m) => m['role'])
-          .toList();
-      expect(followUpRoles, contains('tool'));
+      // The second turn must carry the tool result back under the id the host
+      // asked for. A plugin that sends the right role with the wrong
+      // tool_call_id is the real failure mode on Groq and DeepSeek, and a
+      // role-only assertion would not see it.
+      final followUp = (bodies[1]['messages'] as List)
+          .cast<Map<String, dynamic>>();
+
+      final assistant = followUp.firstWhere((m) => m['role'] == 'assistant');
+      final reSentCalls = (assistant['tool_calls'] as List)
+          .cast<Map<String, dynamic>>();
+      expect(reSentCalls.single['id'], 'call_1');
+
+      final toolMessage = followUp.firstWhere((m) => m['role'] == 'tool');
+      expect(toolMessage['tool_call_id'], 'call_1');
+      expect(toolMessage['content'], contains('72'));
     });
 
     test('a stream with no [DONE] sentinel still completes', () async {
@@ -268,7 +277,7 @@ void main() {
 
   group('authentication against a compat host', () {
     test('the configured key is sent as a bearer token', () async {
-      server = await startServer(expectedApiKey: 'groq-key');
+      final server = await startServer(expectedApiKey: 'groq-key');
       final ai = Genkit(
         plugins: [
           openAI(name: 'groq', apiKey: 'groq-key', baseUrl: server.baseUrl),
@@ -288,7 +297,7 @@ void main() {
     });
 
     test('apiKeyProvider is honored on the compat path', () async {
-      server = await startServer(expectedApiKey: 'minted-token');
+      final server = await startServer(expectedApiKey: 'minted-token');
       var calls = 0;
       final ai = Genkit(
         plugins: [
@@ -317,7 +326,7 @@ void main() {
     });
 
     test('a rejected key surfaces as UNAUTHENTICATED', () async {
-      server = await startServer(expectedApiKey: 'right-key');
+      final server = await startServer(expectedApiKey: 'right-key');
       final ai = Genkit(
         plugins: [
           openAI(name: 'groq', apiKey: 'wrong-key', baseUrl: server.baseUrl),
@@ -344,6 +353,8 @@ void main() {
   });
 
   group('custom headers', () {
+    late FakeOpenAIServer server;
+
     setUp(() async {
       server = await startServer();
     });
@@ -392,6 +403,8 @@ void main() {
   });
 
   group('CustomModelDefinition', () {
+    late FakeOpenAIServer server;
+
     setUp(() async {
       server = await startServer();
     });
@@ -530,20 +543,6 @@ void main() {
       expect(deepseek.chatRequestBodies.single['model'], 'deepseek-chat');
     });
 
-    test('a compat backend never claims the openai namespace', () async {
-      final compat = await startServer();
-      final plugin = OpenAIPlugin(
-        name: 'groq',
-        apiKey: 'groq-key',
-        baseUrl: compat.baseUrl,
-        customModels: [llama()],
-      );
-
-      final names = modelNames(await plugin.list());
-
-      expect(names.every((n) => n.startsWith('groq/')), isTrue);
-    });
-
     test('a compat backend does not list the curated OpenAI catalog', () async {
       // Regression: list() merged the curated catalog in unconditionally, so
       // a Groq backend advertised 'groq/gpt-5.5', 'groq/o3' and fifteen more
@@ -595,12 +594,15 @@ void main() {
       403: StatusCodes.PERMISSION_DENIED,
       404: StatusCodes.NOT_FOUND,
       500: StatusCodes.INTERNAL,
+      503: StatusCodes.UNAVAILABLE,
     };
 
     cases.forEach((statusCode, expected) {
       test('$statusCode becomes ${expected.name}', () async {
         // 429 is deliberately absent: the SDK retries it with exponential
-        // backoff, which would add ~7s to this suite for one assertion.
+        // backoff, which would add ~7s to this suite for one assertion. 503
+        // is not retried here - the SDK only retries 5xx on idempotent
+        // methods, and chat completions is a POST.
         final host = await startServer();
         host.enqueue(FakeResponse.error(statusCode, 'compat host said no'));
         final ai = Genkit(
@@ -627,25 +629,41 @@ void main() {
       final baseUrl = dead.baseUrl;
       await dead.stop();
 
-      final ai = Genkit(
-        plugins: [openAI(name: 'groq', apiKey: 'groq-key', baseUrl: baseUrl)],
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: baseUrl,
+        customModels: [llama()],
       );
+      final ai = Genkit(plugins: [plugin]);
       addTearDown(ai.shutdown);
 
-      // Startup and listing survive a host that is not there at all. This
-      // takes ~7s: discovery is a GET, so the SDK retries the refused
+      // Listing survives a host that is not there at all, and still returns
+      // the plugin's own models. Asserting on listActions() alone would not
+      // pin this: a compat backend is withheld the curated catalog, so that
+      // call passes on the core actions even if the plugin contributes none.
+      //
+      // Costs ~7s: discovery is a GET, so the SDK retries the refused
       // connection three times with exponential backoff before list() gives
-      // up and falls back to the catalog. That is the whole test - do not
-      // "speed it up" by dropping the listActions() call.
-      final actions = await ai.registry.listActions();
-      expect(actions, isNotEmpty);
+      // up. Accepted deliberately - do not "speed it up" by dropping it.
+      expect(modelNames(await plugin.list()), {'groq/llama-3.3-70b-versatile'});
 
       await expectLater(
         ai.generate(
           model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
           prompt: 'Hello!',
         ),
-        throwsA(isA<GenkitException>()),
+        throwsA(
+          // INTERNAL, not UNAVAILABLE: a refused socket never becomes an
+          // ApiException, so there is no HTTP status to map and the generic
+          // default applies. Pinned as-is - arguably it should be
+          // UNAVAILABLE, but that is a behaviour change, not a test fix.
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INTERNAL,
+          ),
+        ),
       );
     });
   });

--- a/packages/genkit_openai/test/openai_plugin_compat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_compat_test.dart
@@ -656,8 +656,8 @@ void main() {
         throwsA(
           // INTERNAL, not UNAVAILABLE: a refused socket never becomes an
           // ApiException, so there is no HTTP status to map and the generic
-          // default applies. Pinned as-is - arguably it should be
-          // UNAVAILABLE, but that is a behaviour change, not a test fix.
+          // default applies. Pinned as current behaviour; #424 tracks the
+          // fix, which is a behaviour change rather than a test one.
           isA<GenkitException>().having(
             (e) => e.status,
             'status',

--- a/packages/genkit_openai/test/openai_plugin_compat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_compat_test.dart
@@ -37,6 +37,21 @@ Set<String> modelNames(List<ActionMetadata> metadata) =>
     metadata.map((m) => m.name).toSet();
 
 /// A Groq-shaped model definition, matching the README's example.
+/// Matches the failed response `generate()` returns for a model error.
+///
+/// Since #413 a model error is reported as a response with
+/// [FinishReason.failed] and a structured `error`, not a thrown exception.
+/// `error.status` is the status *name*, not the enum.
+Matcher failsWith(StatusCodes status, {String? message}) =>
+    isA<GenerateResponse>()
+        .having((r) => r.finishReason, 'finishReason', FinishReason.failed)
+        .having((r) => r.error?.status, 'error.status', status.name)
+        .having(
+          (r) => r.error?.message ?? '',
+          'error.message',
+          message == null ? anything : contains(message),
+        );
+
 CustomModelDefinition llama() => CustomModelDefinition(
   name: 'llama-3.3-70b-versatile',
   info: ModelInfo(
@@ -334,19 +349,14 @@ void main() {
       );
       addTearDown(ai.shutdown);
 
-      await expectLater(
-        ai.generate(
+      expect(
+        await ai.generate(
           model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
           prompt: 'Hello!',
         ),
-        throwsA(
-          isA<GenkitException>()
-              .having((e) => e.status, 'status', StatusCodes.UNAUTHENTICATED)
-              .having(
-                (e) => e.toString(),
-                'message',
-                contains('Incorrect API key provided'),
-              ),
+        failsWith(
+          StatusCodes.UNAUTHENTICATED,
+          message: 'Incorrect API key provided',
         ),
       );
     });
@@ -612,14 +622,12 @@ void main() {
         );
         addTearDown(ai.shutdown);
 
-        await expectLater(
-          ai.generate(
+        expect(
+          await ai.generate(
             model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
             prompt: 'Hello!',
           ),
-          throwsA(
-            isA<GenkitException>().having((e) => e.status, 'status', expected),
-          ),
+          failsWith(expected),
         );
       });
     });
@@ -648,22 +656,16 @@ void main() {
       // up. Accepted deliberately - do not "speed it up" by dropping it.
       expect(modelNames(await plugin.list()), {'groq/llama-3.3-70b-versatile'});
 
-      await expectLater(
-        ai.generate(
+      // INTERNAL, not UNAVAILABLE: a refused socket never becomes an
+      // ApiException, so there is no HTTP status to map and the generic
+      // default applies. Pinned as current behaviour; #424 tracks the fix,
+      // which is a behaviour change rather than a test one.
+      expect(
+        await ai.generate(
           model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
           prompt: 'Hello!',
         ),
-        throwsA(
-          // INTERNAL, not UNAVAILABLE: a refused socket never becomes an
-          // ApiException, so there is no HTTP status to map and the generic
-          // default applies. Pinned as current behaviour; #424 tracks the
-          // fix, which is a behaviour change rather than a test one.
-          isA<GenkitException>().having(
-            (e) => e.status,
-            'status',
-            StatusCodes.INTERNAL,
-          ),
-        ),
+        failsWith(StatusCodes.INTERNAL),
       );
     });
   });

--- a/packages/genkit_openai/test/openai_plugin_compat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_compat_test.dart
@@ -1,0 +1,652 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Coverage for the OpenAI-compatible path: `baseUrl`, `headers`, and
+/// `CustomModelDefinition`.
+///
+/// The README advertises Groq, xAI, DeepSeek and Together AI, but nothing
+/// tested that a `baseUrl` was ever dialed. These tests run the plugin against
+/// a real loopback host with no injected `httpClient`, so they exercise the
+/// client the plugin builds for itself - the same one a compat user gets.
+library;
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:genkit_openai/src/known_models.dart' show knownChatModels;
+import 'package:genkit_openai/src/openai_plugin.dart' show OpenAIPlugin;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import 'fake_openai_server.dart';
+
+Set<String> modelNames(List<ActionMetadata> metadata) =>
+    metadata.map((m) => m.name).toSet();
+
+/// A Groq-shaped model definition, matching the README's example.
+CustomModelDefinition llama() => CustomModelDefinition(
+  name: 'llama-3.3-70b-versatile',
+  info: ModelInfo(
+    label: 'Llama 3.3 70B',
+    supports: {'multiturn': true, 'tools': true, 'systemRole': true},
+  ),
+);
+
+void main() {
+  late FakeOpenAIServer server;
+
+  Future<FakeOpenAIServer> startServer({String? expectedApiKey}) async {
+    final started = await FakeOpenAIServer.start(
+      expectedApiKey: expectedApiKey,
+    );
+    addTearDown(started.stop);
+    return started;
+  }
+
+  group('baseUrl routing', () {
+    setUp(() async {
+      server = await startServer();
+    });
+
+    test('generate reaches the compat host, not api.openai.com', () async {
+      server.enqueue(FakeResponse.json(chatCompletion(content: 'from groq')));
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'groq',
+            apiKey: 'groq-key',
+            baseUrl: server.baseUrl,
+            models: [llama()],
+          ),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      final response = await ai.generate(
+        model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+        prompt: 'Hello!',
+      );
+
+      expect(response.text, 'from groq');
+      expect(server.requests, hasLength(1));
+      expect(server.requests.single.method, 'POST');
+      expect(server.requests.single.path, '/v1/chat/completions');
+    });
+
+    test('the custom model id is what goes on the wire', () async {
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'groq',
+            apiKey: 'groq-key',
+            baseUrl: server.baseUrl,
+            models: [llama()],
+          ),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      await ai.generate(
+        model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+        prompt: 'Hello!',
+      );
+
+      expect(
+        server.chatRequestBodies.single['model'],
+        'llama-3.3-70b-versatile',
+      );
+    });
+
+    test('a model the host never advertised still resolves', () async {
+      // Compat hosts often serve no /models at all, and their catalogs move
+      // faster than this plugin releases. resolve() must not gate on discovery.
+      final ai = Genkit(
+        plugins: [
+          openAI(name: 'deepseek', apiKey: 'ds-key', baseUrl: server.baseUrl),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      await ai.generate(
+        model: openAI.model('deepseek-reasoner', namespace: 'deepseek'),
+        prompt: 'Hello!',
+      );
+
+      expect(server.chatRequestBodies.single['model'], 'deepseek-reasoner');
+    });
+
+    test('streaming works against a compat host', () async {
+      server.enqueue(
+        FakeResponse.sse([
+          chatChunk(content: 'Hel'),
+          chatChunk(content: 'lo'),
+          chatChunk(finishReason: 'stop'),
+        ]),
+      );
+      final ai = Genkit(
+        plugins: [
+          openAI(name: 'xai', apiKey: 'xai-key', baseUrl: server.baseUrl),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      final streamed = StringBuffer();
+      final stream = ai.generateStream(
+        model: openAI.model('grok-4', namespace: 'xai'),
+        prompt: 'Say hello',
+      );
+      await for (final chunk in stream) {
+        for (final part in chunk.content) {
+          if (part.isText) streamed.write(part.text);
+        }
+      }
+
+      expect(streamed.toString(), 'Hello');
+      expect((await stream.onResult).text, 'Hello');
+      expect(server.chatRequestBodies.single['stream'], true);
+    });
+
+    test('a tool call round-trips through a compat host', () async {
+      // Tool calling is where compatible hosts diverge most, and the README's
+      // Groq example advertises `'tools': true`. Two exchanges: the host asks
+      // for the tool, then sees the result come back as a `tool` message.
+      server.enqueue(
+        FakeResponse.json(
+          chatCompletion(
+            content: '',
+            finishReason: 'tool_calls',
+            toolCalls: [
+              {
+                'id': 'call_1',
+                'type': 'function',
+                'function': {
+                  'name': 'getWeather',
+                  'arguments': '{"location":"Boston"}',
+                },
+              },
+            ],
+          ),
+        ),
+      );
+      server.enqueue(
+        FakeResponse.json(
+          chatCompletion(
+            content: 'It is 72F in Boston.',
+            usage: {
+              'prompt_tokens': 11,
+              'completion_tokens': 7,
+              'total_tokens': 18,
+            },
+          ),
+        ),
+      );
+
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'groq',
+            apiKey: 'groq-key',
+            baseUrl: server.baseUrl,
+            models: [llama()],
+          ),
+        ],
+      );
+      addTearDown(ai.shutdown);
+      ai.defineTool(
+        name: 'getWeather',
+        description: 'Get the weather for a location',
+        fn: (input, ctx) async => .response({'temperature': 72}),
+      );
+
+      final response = await ai.generate(
+        model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+        prompt: 'What is the weather in Boston?',
+        toolNames: ['getWeather'],
+      );
+
+      expect(response.text, 'It is 72F in Boston.');
+      expect(response.usage?.inputTokens, 11);
+      expect(response.usage?.outputTokens, 7);
+
+      final bodies = server.chatRequestBodies;
+      expect(bodies, hasLength(2), reason: 'one call out, one result back');
+      final tools = (bodies.first['tools'] as List)
+          .cast<Map<String, dynamic>>();
+      final function = tools.single['function'] as Map<String, dynamic>;
+      expect(function['name'], 'getWeather');
+      // The second turn must carry the tool result the host asked for.
+      final followUpRoles = (bodies[1]['messages'] as List)
+          .cast<Map<String, dynamic>>()
+          .map((m) => m['role'])
+          .toList();
+      expect(followUpRoles, contains('tool'));
+    });
+
+    test('a stream with no [DONE] sentinel still completes', () async {
+      // Not every compatible host terminates the stream the way OpenAI does;
+      // some just close the socket. Written with rawSse so the frames are
+      // verbatim - the chunks helper always appends [DONE].
+      server.enqueue(
+        FakeResponse(
+          stream: true,
+          rawSse: [
+            'data: ${jsonEncode(chatChunk(content: 'par'))}\n\n',
+            'data: ${jsonEncode(chatChunk(content: 'tial'))}\n\n',
+            'data: ${jsonEncode(chatChunk(finishReason: 'stop'))}\n\n',
+          ],
+        ),
+      );
+      final ai = Genkit(
+        plugins: [
+          openAI(name: 'xai', apiKey: 'xai-key', baseUrl: server.baseUrl),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      final stream = ai.generateStream(
+        model: openAI.model('grok-4', namespace: 'xai'),
+        prompt: 'Say hello',
+      );
+      await stream.drain<void>();
+
+      expect((await stream.onResult).text, 'partial');
+    });
+  });
+
+  group('authentication against a compat host', () {
+    test('the configured key is sent as a bearer token', () async {
+      server = await startServer(expectedApiKey: 'groq-key');
+      final ai = Genkit(
+        plugins: [
+          openAI(name: 'groq', apiKey: 'groq-key', baseUrl: server.baseUrl),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      await ai.generate(
+        model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+        prompt: 'Hello!',
+      );
+
+      expect(
+        server.requests.single.headers['authorization'],
+        'Bearer groq-key',
+      );
+    });
+
+    test('apiKeyProvider is honored on the compat path', () async {
+      server = await startServer(expectedApiKey: 'minted-token');
+      var calls = 0;
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'groq',
+            apiKeyProvider: () async {
+              calls++;
+              return 'minted-token';
+            },
+            baseUrl: server.baseUrl,
+          ),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      await ai.generate(
+        model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+        prompt: 'Hello!',
+      );
+
+      expect(calls, 1);
+      expect(
+        server.requests.single.headers['authorization'],
+        'Bearer minted-token',
+      );
+    });
+
+    test('a rejected key surfaces as UNAUTHENTICATED', () async {
+      server = await startServer(expectedApiKey: 'right-key');
+      final ai = Genkit(
+        plugins: [
+          openAI(name: 'groq', apiKey: 'wrong-key', baseUrl: server.baseUrl),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      await expectLater(
+        ai.generate(
+          model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+          prompt: 'Hello!',
+        ),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.UNAUTHENTICATED)
+              .having(
+                (e) => e.toString(),
+                'message',
+                contains('Incorrect API key provided'),
+              ),
+        ),
+      );
+    });
+  });
+
+  group('custom headers', () {
+    setUp(() async {
+      server = await startServer();
+    });
+
+    test('reach the compat host on generate', () async {
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'openrouter',
+            apiKey: 'or-key',
+            baseUrl: server.baseUrl,
+            headers: {
+              'HTTP-Referer': 'https://example.com',
+              'X-Title': 'Genkit Dart',
+            },
+          ),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      await ai.generate(
+        model: openAI.model('gpt-4o', namespace: 'openrouter'),
+        prompt: 'Hello!',
+      );
+
+      final headers = server.requests.single.headers;
+      expect(headers['http-referer'], 'https://example.com');
+      expect(headers['x-title'], 'Genkit Dart');
+      // The SDK's own auth header must survive alongside them.
+      expect(headers['authorization'], 'Bearer or-key');
+    });
+
+    test('reach the compat host on model discovery', () async {
+      final plugin = OpenAIPlugin(
+        name: 'openrouter',
+        apiKey: 'or-key',
+        baseUrl: server.baseUrl,
+        headers: {'X-Title': 'Genkit Dart'},
+      );
+
+      await plugin.list();
+
+      expect(server.requests.single.path, '/v1/models');
+      expect(server.requests.single.headers['x-title'], 'Genkit Dart');
+    });
+  });
+
+  group('CustomModelDefinition', () {
+    setUp(() async {
+      server = await startServer();
+    });
+
+    test('is registered by init(), before any discovery', () async {
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: server.baseUrl,
+        customModels: [llama()],
+      );
+
+      final actions = await plugin.init();
+
+      expect(actions.map((a) => a.name), ['groq/llama-3.3-70b-versatile']);
+      expect(
+        server.requests,
+        isEmpty,
+        reason: 'init() must not touch the compat host either',
+      );
+    });
+
+    test('its ModelInfo overrides the id-based heuristics', () async {
+      // 'llama-3.3-70b-versatile' matches no OpenAI naming rule, so without
+      // the override the listing would describe it by guesswork.
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: server.baseUrl,
+        customModels: [llama()],
+      );
+
+      final metadata = await plugin.list();
+      final llamaMeta = metadata.singleWhere(
+        (m) => m.name == 'groq/llama-3.3-70b-versatile',
+      );
+
+      final info = llamaMeta.metadata['model'] as Map<String, dynamic>;
+      expect(info['label'], 'Llama 3.3 70B');
+      expect((info['supports'] as Map)['tools'], true);
+    });
+
+    test('is listed even when the host serves no /models', () async {
+      server.enqueue(FakeResponse.error(404, 'Not Found'));
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: server.baseUrl,
+        customModels: [llama()],
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(names, contains('groq/llama-3.3-70b-versatile'));
+    });
+
+    test('is listed alongside models the host does advertise', () async {
+      server.enqueue(
+        FakeResponse.json(modelList(['llama-3.1-8b-instant', 'gemma2-9b-it'])),
+      );
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: server.baseUrl,
+        customModels: [llama()],
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(
+        names,
+        containsAll([
+          'groq/llama-3.3-70b-versatile',
+          'groq/llama-3.1-8b-instant',
+          'groq/gemma2-9b-it',
+        ]),
+      );
+    });
+
+    test('listing is namespaced by the plugin name', () async {
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: server.baseUrl,
+        customModels: [llama()],
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(names.every((n) => n.startsWith('groq/')), isTrue);
+      expect(names, isNot(contains('openai/gpt-4o')));
+    });
+  });
+
+  group('multiple backends side by side', () {
+    test('each plugin dials its own host with its own key', () async {
+      final groq = await startServer(expectedApiKey: 'groq-key');
+      final deepseek = await startServer(expectedApiKey: 'ds-key');
+      groq.enqueue(FakeResponse.json(chatCompletion(content: 'from groq')));
+      deepseek.enqueue(
+        FakeResponse.json(chatCompletion(content: 'from deepseek')),
+      );
+
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            name: 'groq',
+            apiKey: 'groq-key',
+            baseUrl: groq.baseUrl,
+            models: [llama()],
+          ),
+          openAI(
+            name: 'deepseek',
+            apiKey: 'ds-key',
+            baseUrl: deepseek.baseUrl,
+            models: [CustomModelDefinition(name: 'deepseek-chat')],
+          ),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      final a = await ai.generate(
+        model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+        prompt: 'Hello!',
+      );
+      final b = await ai.generate(
+        model: openAI.model('deepseek-chat', namespace: 'deepseek'),
+        prompt: 'Hello!',
+      );
+
+      expect(a.text, 'from groq');
+      expect(b.text, 'from deepseek');
+      expect(groq.requests, hasLength(1));
+      expect(deepseek.requests, hasLength(1));
+      expect(groq.chatRequestBodies.single['model'], 'llama-3.3-70b-versatile');
+      expect(deepseek.chatRequestBodies.single['model'], 'deepseek-chat');
+    });
+
+    test('a compat backend never claims the openai namespace', () async {
+      final compat = await startServer();
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: compat.baseUrl,
+        customModels: [llama()],
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(names.every((n) => n.startsWith('groq/')), isTrue);
+    });
+
+    test('a compat backend does not list the curated OpenAI catalog', () async {
+      // Regression: list() merged the curated catalog in unconditionally, so
+      // a Groq backend advertised 'groq/gpt-5.5', 'groq/o3' and fifteen more
+      // models Groq has never served - all of them a 404 from the Dev UI.
+      final compat = await startServer();
+      compat.enqueue(FakeResponse.json(modelList(['llama-3.1-8b-instant'])));
+      final plugin = OpenAIPlugin(
+        name: 'groq',
+        apiKey: 'groq-key',
+        baseUrl: compat.baseUrl,
+        customModels: [llama()],
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(names, {
+        'groq/llama-3.1-8b-instant',
+        'groq/llama-3.3-70b-versatile',
+      });
+      for (final curated in knownChatModels) {
+        expect(names, isNot(contains('groq/$curated')));
+      }
+    });
+
+    test('the default OpenAI backend still gets the curated catalog', () async {
+      // The counterpart to the test above: withholding the catalog from compat
+      // backends must not withhold it from the backend it was written for.
+      //
+      // This is the one test here that injects a client - with no baseUrl to
+      // redirect it, the real api.openai.com is the alternative, and a test
+      // suite must not dial the internet.
+      final plugin = OpenAIPlugin(
+        apiKey: 'test-key',
+        httpClient: MockClient(
+          (_) async => http.Response('{"error":{"message":"nope"}}', 401),
+        ),
+      );
+
+      final names = modelNames(await plugin.list());
+
+      expect(names, containsAll(knownChatModels.map((id) => 'openai/$id')));
+    });
+  });
+
+  group('compat host errors map to Genkit statuses', () {
+    const cases = <int, StatusCodes>{
+      400: StatusCodes.INVALID_ARGUMENT,
+      401: StatusCodes.UNAUTHENTICATED,
+      403: StatusCodes.PERMISSION_DENIED,
+      404: StatusCodes.NOT_FOUND,
+      500: StatusCodes.INTERNAL,
+    };
+
+    cases.forEach((statusCode, expected) {
+      test('$statusCode becomes ${expected.name}', () async {
+        // 429 is deliberately absent: the SDK retries it with exponential
+        // backoff, which would add ~7s to this suite for one assertion.
+        final host = await startServer();
+        host.enqueue(FakeResponse.error(statusCode, 'compat host said no'));
+        final ai = Genkit(
+          plugins: [
+            openAI(name: 'groq', apiKey: 'groq-key', baseUrl: host.baseUrl),
+          ],
+        );
+        addTearDown(ai.shutdown);
+
+        await expectLater(
+          ai.generate(
+            model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+            prompt: 'Hello!',
+          ),
+          throwsA(
+            isA<GenkitException>().having((e) => e.status, 'status', expected),
+          ),
+        );
+      });
+    });
+
+    test('an unreachable host fails at generate, not at startup', () async {
+      final dead = await FakeOpenAIServer.start();
+      final baseUrl = dead.baseUrl;
+      await dead.stop();
+
+      final ai = Genkit(
+        plugins: [openAI(name: 'groq', apiKey: 'groq-key', baseUrl: baseUrl)],
+      );
+      addTearDown(ai.shutdown);
+
+      // Startup and listing survive a host that is not there at all. This
+      // takes ~7s: discovery is a GET, so the SDK retries the refused
+      // connection three times with exponential backoff before list() gives
+      // up and falls back to the catalog. That is the whole test - do not
+      // "speed it up" by dropping the listActions() call.
+      final actions = await ai.registry.listActions();
+      expect(actions, isNotEmpty);
+
+      await expectLater(
+        ai.generate(
+          model: openAI.model('llama-3.3-70b-versatile', namespace: 'groq'),
+          prompt: 'Hello!',
+        ),
+        throwsA(isA<GenkitException>()),
+      );
+    });
+  });
+}

--- a/testapps/openai_sample/lib/compatible_providers.dart
+++ b/testapps/openai_sample/lib/compatible_providers.dart
@@ -182,8 +182,9 @@ void main() {
           apiKey: backend.apiKey,
           baseUrl: backend.baseUrl,
           models: backend.models,
-          // Several compatible hosts read headers for attribution or routing;
-          // this is the knob OpenRouter's rankings use, for instance.
+          // Several compatible hosts read headers for attribution or
+          // routing. None of the three below require one; this is here to
+          // show where a provider-specific header goes.
           headers: {'X-Title': 'Genkit Dart sample'},
         ),
     ],

--- a/testapps/openai_sample/lib/compatible_providers.dart
+++ b/testapps/openai_sample/lib/compatible_providers.dart
@@ -1,0 +1,194 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Drives the plugin against OpenAI-compatible providers, which the other
+/// samples here never exercise - they all use plain `openAI(apiKey:)`.
+///
+/// Set whichever provider keys you have and run:
+///
+/// ```sh
+/// GROQ_API_KEY=... genkit start -- dart run lib/compatible_providers.dart
+/// ```
+///
+/// Backends with no key are skipped rather than registered, so this starts up
+/// with none set - `listBackends` then just reports that nothing is
+/// configured.
+library;
+
+import 'dart:io';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+
+/// One OpenAI-compatible backend: where it lives and what it serves.
+class CompatBackend {
+  /// Namespace for the plugin instance, e.g. `groq`.
+  final String name;
+
+  /// Environment variable holding this provider's key.
+  final String apiKeyEnvVar;
+
+  /// The provider's OpenAI-compatible endpoint.
+  ///
+  /// Overridable per backend with `<NAME>_BASE_URL` (e.g. `GROQ_BASE_URL`), so
+  /// the same flows can be pointed at a proxy or a local server such as
+  /// llama.cpp, Ollama or LM Studio.
+  final String defaultBaseUrl;
+
+  /// Models to register.
+  ///
+  /// Required, not decorative: a compat backend is not given the curated
+  /// OpenAI catalog, and most providers' `GET /models` is either absent or
+  /// enormous, so this is what the Dev UI has to list. Models omitted here
+  /// still work when named explicitly.
+  final List<CustomModelDefinition> models;
+
+  const CompatBackend({
+    required this.name,
+    required this.apiKeyEnvVar,
+    required this.defaultBaseUrl,
+    required this.models,
+  });
+
+  /// This provider's key, or null when it is not configured.
+  String? get apiKey => _env(apiKeyEnvVar);
+
+  /// The endpoint to use, honouring the `<NAME>_BASE_URL` override.
+  String get baseUrl =>
+      _env('${name.toUpperCase()}_BASE_URL') ?? defaultBaseUrl;
+
+  static String? _env(String name) {
+    final value = Platform.environment[name];
+    return (value == null || value.isEmpty) ? null : value;
+  }
+}
+
+ModelInfo _chatModel(String label) => ModelInfo(
+  label: label,
+  supports: {
+    'multiturn': true,
+    'tools': true,
+    'systemRole': true,
+    'media': false,
+  },
+);
+
+/// The providers the README advertises.
+final List<CompatBackend> compatBackends = [
+  CompatBackend(
+    name: 'groq',
+    apiKeyEnvVar: 'GROQ_API_KEY',
+    defaultBaseUrl: 'https://api.groq.com/openai/v1',
+    models: [
+      CustomModelDefinition(
+        name: 'llama-3.3-70b-versatile',
+        info: _chatModel('Llama 3.3 70B'),
+      ),
+    ],
+  ),
+  CompatBackend(
+    name: 'deepseek',
+    apiKeyEnvVar: 'DEEPSEEK_API_KEY',
+    defaultBaseUrl: 'https://api.deepseek.com/v1',
+    models: [
+      CustomModelDefinition(
+        name: 'deepseek-chat',
+        info: _chatModel('DeepSeek Chat'),
+      ),
+    ],
+  ),
+  CompatBackend(
+    name: 'xai',
+    apiKeyEnvVar: 'XAI_API_KEY',
+    defaultBaseUrl: 'https://api.x.ai/v1',
+    models: [CustomModelDefinition(name: 'grok-4', info: _chatModel('Grok 4'))],
+  ),
+];
+
+/// The backends that actually have a key set.
+List<CompatBackend> get configuredBackends =>
+    compatBackends.where((b) => b.apiKey != null).toList();
+
+/// Reports which backends are configured and what each one lists.
+Flow<String, String, void, void> defineListBackendsFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'listBackends',
+    inputSchema: .string(),
+    outputSchema: .string(),
+    fn: (_, _) async {
+      final configured = configuredBackends.map((b) => b.name).toSet();
+      if (configured.isEmpty) {
+        final vars = compatBackends.map((b) => b.apiKeyEnvVar).join(', ');
+        return 'No compatible backends configured. Set one of: $vars';
+      }
+
+      final actions = await ai.registry.listActions();
+      final lines = <String>[];
+      for (final name in configured) {
+        final models = actions
+            .where((a) => a.actionType == .model && a.name.startsWith('$name/'))
+            .map((a) => a.name);
+        lines.add('$name:\n  ${models.join('\n  ')}');
+      }
+      return lines.join('\n');
+    },
+  );
+}
+
+/// Generates against one backend, chosen by name (`groq`, `deepseek`, `xai`).
+Flow<String, String, void, void> defineCompatGenerateFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'compatGenerate',
+    inputSchema: .string(defaultValue: 'groq'),
+    outputSchema: .string(),
+    fn: (backendName, _) async {
+      final backend = compatBackends
+          .where((b) => b.name == backendName)
+          .firstOrNull;
+      if (backend == null) {
+        final known = compatBackends.map((b) => b.name).join(', ');
+        return 'Unknown backend "$backendName". Try one of: $known';
+      }
+      if (backend.apiKey == null) {
+        return '${backend.name} is not configured; set ${backend.apiKeyEnvVar}.';
+      }
+
+      final response = await ai.generate(
+        model: openAI.model(backend.models.first.name, namespace: backend.name),
+        prompt: 'In one sentence, what are you and who made you?',
+      );
+      return response.text;
+    },
+  );
+}
+
+void main() {
+  final ai = Genkit(
+    plugins: [
+      for (final backend in configuredBackends)
+        openAI(
+          name: backend.name,
+          apiKey: backend.apiKey,
+          baseUrl: backend.baseUrl,
+          models: backend.models,
+          // Several compatible hosts read headers for attribution or routing;
+          // this is the knob OpenRouter's rankings use, for instance.
+          headers: {'X-Title': 'Genkit Dart sample'},
+        ),
+    ],
+  );
+
+  defineListBackendsFlow(ai);
+  defineCompatGenerateFlow(ai);
+}


### PR DESCRIPTION
Fixes #362. Stacked on #414.

Ports the JS plugin's `fake_openai_server` (`js/plugins/compat-oai/tests/`) to Dart. It binds a real loopback `HttpServer` rather than a `MockClient`: every other test in this package injects `httpClient`, so the client the plugin builds for itself — the only thing that acts on `baseUrl` — was never covered.

26 tests in `test/openai_plugin_compat_test.dart` covering baseUrl routing, auth and `apiKeyProvider`, custom headers, `CustomModelDefinition`, multiple named backends, streaming, tool calls, and error-status mapping.

Found one bug on the way, fixed in its own commit: `list()` merged the curated OpenAI catalog in regardless of `baseUrl`, so a Groq backend advertised 17 models Groq doesn't serve, each a 404 from the Dev UI. The catalog is now skipped when `baseUrl` is set. `resolve()` still serves any id named explicitly, so nothing becomes unreachable. Worth knowing when reviewing #414, since the bug is in the `list()` that PR introduces.

README: the install block pinned `genkit: ^0.13.0` against an actual `^0.16.1`. The compat section now says what's verified — a local fake host, not each provider's live API.

One thing this surfaced but doesn't fix: listing against an *unreachable* compat host takes ~7s, because discovery is a GET and the SDK retries the refused connection three times. The Dev UI blocks that long per poll. Probably its own issue.

Also adds `testapps/openai_sample/lib/compatible_providers.dart`, since the ticket notes the sample app only ever used plain `openAI(apiKey:)`. Flows for Groq, DeepSeek and xAI; backends without a key are skipped, so it starts up with none set. Each has a `<NAME>_BASE_URL` override for proxies and local servers (llama.cpp, Ollama, LM Studio).

```sh
GROQ_API_KEY=... genkit start -- dart run lib/compatible_providers.dart
```