### PR TITLE
feat(genkit_openai): add gpt-6-astra support

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -213,6 +213,12 @@ final response = await ai.generate(
 );
 ```
 
+`gpt-6-astra` is registered without tool support: the Chat Completions
+endpoint rejects function tools for it at every accepted `reasoningEffort`.
+It accepts `reasoningEffort` values `low`, `medium`, `high` and `xhigh`,
+rejects `none`, and rejects `temperature` other than 1 and `topP`, so leave
+those unset.
+
 ## Options
 
 The `OpenAIChatOptions` class supports the following options:
@@ -227,6 +233,7 @@ The `OpenAIChatOptions` class supports the following options:
 - `user` (String?) - User identifier for abuse detection
 - `jsonMode` (bool?) - Enable JSON mode
 - `visualDetailLevel` (String?, 'auto'|'low'|'high') - Visual detail level for images
+- `reasoningEffort` (String?, 'none'|'minimal'|'low'|'medium'|'high'|'xhigh') - Reasoning effort for reasoning models
 - `version` (String?) - Model version override
 
 ## Custom Headers

--- a/packages/genkit_openai/lib/src/chat.dart
+++ b/packages/genkit_openai/lib/src/chat.dart
@@ -57,6 +57,13 @@ abstract class $OpenAIChatOptions {
   /// Visual detail level for images ('auto', 'low', 'high')
   @StringField(enumValues: ['auto', 'low', 'high'])
   String? get visualDetailLevel;
+
+  /// Reasoning effort for reasoning models ('none', 'minimal', 'low',
+  /// 'medium', 'high', 'xhigh'); each model accepts a subset
+  @StringField(
+    enumValues: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+  )
+  String? get reasoningEffort;
 }
 
 /// Alias for [OpenAIChatOptions].

--- a/packages/genkit_openai/lib/src/chat.g.dart
+++ b/packages/genkit_openai/lib/src/chat.g.dart
@@ -41,6 +41,7 @@ base class OpenAIChatOptions {
     String? user,
     bool? jsonMode,
     String? visualDetailLevel,
+    String? reasoningEffort,
   }) {
     _json = {
       'version': ?version,
@@ -54,6 +55,7 @@ base class OpenAIChatOptions {
       'user': ?user,
       'jsonMode': ?jsonMode,
       'visualDetailLevel': ?visualDetailLevel,
+      'reasoningEffort': ?reasoningEffort,
     };
   }
 
@@ -217,6 +219,22 @@ base class OpenAIChatOptions {
     }
   }
 
+  /// Reasoning effort for reasoning models ('none', 'minimal', 'low',
+  /// 'medium', 'high', 'xhigh'); each model accepts a subset
+  String? get reasoningEffort {
+    return _json['reasoningEffort'] as String?;
+  }
+
+  /// Reasoning effort for reasoning models ('none', 'minimal', 'low',
+  /// 'medium', 'high', 'xhigh'); each model accepts a subset
+  set reasoningEffort(String? value) {
+    if (value == null) {
+      _json.remove('reasoningEffort');
+    } else {
+      _json['reasoningEffort'] = value;
+    }
+  }
+
   @override
   String toString() {
     return _json.toString();
@@ -255,6 +273,9 @@ base class _OpenAIChatOptionsTypeFactory
             'jsonMode': $Schema.boolean(),
             'visualDetailLevel': $Schema.string(
               enumValues: ['auto', 'low', 'high'],
+            ),
+            'reasoningEffort': $Schema.string(
+              enumValues: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'],
             ),
           },
         )

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -253,6 +253,9 @@ class OpenAIPlugin extends GenkitPlugin {
             seed: options.seed,
             user: options.user,
             responseFormat: isJsonMode ? responseFormat : null,
+            reasoningEffort: options.reasoningEffort == null
+                ? null
+                : _reasoningEffort(options.reasoningEffort!),
           );
           if (ctx.streamingRequested) {
             return await _handleStreaming(client, request, ctx);
@@ -373,3 +376,16 @@ final class _ResolvedClientConfig {
     required this.headers,
   });
 }
+
+sdk.ReasoningEffort _reasoningEffort(String effort) => switch (effort) {
+  'none' => sdk.ReasoningEffort.none,
+  'minimal' => sdk.ReasoningEffort.minimal,
+  'low' => sdk.ReasoningEffort.low,
+  'medium' => sdk.ReasoningEffort.medium,
+  'high' => sdk.ReasoningEffort.high,
+  'xhigh' => sdk.ReasoningEffort.xhigh,
+  _ => throw GenkitException(
+    'Unsupported OpenAI reasoningEffort "$effort".',
+    status: StatusCodes.INVALID_ARGUMENT,
+  ),
+};

--- a/packages/genkit_openai/lib/src/utils.dart
+++ b/packages/genkit_openai/lib/src/utils.dart
@@ -17,6 +17,7 @@ import 'package:genkit/genkit.dart';
 final RegExp _oSeriesPattern = RegExp(r'^o\d+(?:-|$)');
 final RegExp _gptPattern = RegExp(r'^gpt-\d+(\.\d+)?o?(?:-|$)');
 final RegExp _gptOPattern = RegExp(r'gpt-\d+(?:\.\d+)?o');
+final RegExp _gpt6AstraPattern = RegExp(r'^gpt-6-astra(?:-|$)');
 
 const List<String> _nonToolKeywords = [
   'embedding',
@@ -55,8 +56,12 @@ abstract class _ModelCapabilities {
   }
 
   static _ModelCapabilities forModel(String modelId) {
-    if (_oSeriesPattern.hasMatch(modelId.toLowerCase())) {
+    final id = modelId.toLowerCase();
+    if (_oSeriesPattern.hasMatch(id)) {
       return _OSeriesModelCapabilities(modelId);
+    }
+    if (_gpt6AstraPattern.hasMatch(id)) {
+      return _Gpt6AstraModelCapabilities(modelId);
     }
 
     return _DefaultModelCapabilities(modelId);
@@ -88,6 +93,17 @@ class _OSeriesModelCapabilities extends _DefaultModelCapabilities {
       !id.startsWith('o3-mini') &&
       !id.startsWith('o1-mini') &&
       !id.startsWith('o1-preview');
+}
+
+/// GPT-6 Astra: Chat Completions rejects tools at every reasoning effort.
+class _Gpt6AstraModelCapabilities extends _DefaultModelCapabilities {
+  const _Gpt6AstraModelCapabilities(super.modelId);
+
+  @override
+  bool get supportsTools => false;
+
+  @override
+  bool get supportsMedia => true;
 }
 
 bool _supportsToolsByHeuristics(String id) {

--- a/packages/genkit_openai/test/openai_plugin_chat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_chat_test.dart
@@ -63,6 +63,37 @@ void main() {
       expect(options.stop, ['stop1', 'stop2']);
     });
 
+    test('parses reasoningEffort', () {
+      for (final value in [
+        'none',
+        'minimal',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+      ]) {
+        final options = OpenAIChatOptions.$schema.parse({
+          'reasoningEffort': value,
+        });
+        expect(options.reasoningEffort, value);
+      }
+    });
+
+    test('schema advertises the reasoningEffort enum', () {
+      final schema = OpenAIChatOptions.$schema.jsonSchema();
+      final properties = (schema['properties'] as Map).cast<String, dynamic>();
+      final field = (properties['reasoningEffort'] as Map)
+          .cast<String, dynamic>();
+      expect(field['enum'], [
+        'none',
+        'minimal',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+      ]);
+    });
+
     test('creates default options', () {
       final options = OpenAIChatOptions();
       expect(options.temperature, isNull);

--- a/packages/genkit_openai/test/openai_plugin_utils_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_utils_test.dart
@@ -45,6 +45,30 @@ void main() {
       expect(oSeriesInfo.supports?['media'], false);
     });
 
+    test('gpt-6-astra advertises media but not tools', () {
+      for (final id in [
+        'gpt-6-astra',
+        'gpt-6-astra-2026-09-01',
+        'gpt-6-astra-mini',
+      ]) {
+        final info = modelInfoFor(id);
+        expect(info.supports, {
+          'multiturn': true,
+          'tools': false,
+          'systemRole': true,
+          'media': true,
+        });
+      }
+      expect(supportsTools('gpt-6-astra'), false);
+      expect(supportsVision('gpt-6-astra'), true);
+      expect(getModelType('gpt-6-astra'), 'chat');
+      // Other gpt-6 ids and fine-tunes keep the default GPT profile.
+      for (final id in ['gpt-6', 'gpt-6-astral', 'ft:gpt-6-astra:org::id']) {
+        expect(supportsTools(id), true);
+        expect(supportsVision(id), false);
+      }
+    });
+
     test('supportsVision identifies vision models', () {
       // Vision models
       expect(supportsVision('gpt-4o'), true);

--- a/packages/genkit_openai/test/openai_plugin_wire_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_wire_test.dart
@@ -152,6 +152,82 @@ void main() {
       await ai.shutdown();
     });
 
+    test('reasoningEffort reaches the wire as reasoning_effort', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+
+      await ai.generate(
+        model: openAI.model('gpt-6-astra'),
+        prompt: 'Say hello.',
+        config: OpenAIChatOptions(reasoningEffort: 'xhigh'),
+      );
+
+      expect(captured.first['reasoning_effort'], 'xhigh');
+
+      await ai.shutdown();
+    });
+
+    test('an unknown reasoningEffort is rejected before any request', () async {
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [openAI(apiKey: 'test-key', httpClient: wireClient(captured))],
+      );
+
+      await expectLater(
+        ai.generate(
+          model: openAI.model('gpt-6-astra'),
+          prompt: 'Say hello.',
+          config: OpenAIChatOptions(reasoningEffort: 'max'),
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+      expect(captured, isEmpty);
+
+      await ai.shutdown();
+    });
+
+    test(
+      'a default request sends no temperature, top_p or reasoning_effort',
+      () async {
+        // gpt-6-astra rejects temperature != 1 and top_p, so the defaults must
+        // stay unset; tools stay advisory and still reach the wire.
+        final captured = <Map<String, dynamic>>[];
+        final ai = Genkit(
+          plugins: [
+            openAI(apiKey: 'test-key', httpClient: wireClient(captured)),
+          ],
+        );
+        ai.defineTool(
+          name: 'getWeather',
+          description: 'Get the weather for a location',
+          fn: (input, ctx) async => .response({'temperature': 72}),
+        );
+
+        await ai.generate(
+          model: openAI.model('gpt-6-astra'),
+          prompt: 'What is the weather in Boston?',
+          toolNames: ['getWeather'],
+        );
+
+        final body = captured.first;
+        expect(body['model'], 'gpt-6-astra');
+        expect(body.containsKey('temperature'), isFalse);
+        expect(body.containsKey('top_p'), isFalse);
+        expect(body.containsKey('reasoning_effort'), isFalse);
+        expect(body.containsKey('tools'), isTrue);
+
+        await ai.shutdown();
+      },
+    );
+
     test('tools reach the wire for standard GPT models', () async {
       final captured = <Map<String, dynamic>>[];
       final ai = Genkit(


### PR DESCRIPTION
`gpt-6-astra` fell through the default GPT heuristics in the Dart OpenAI plugin, which advertised `tools: true` and `media: false`. Live runs against `/v1/chat/completions` (genkit-ai/genkit#6303) show the reverse: function tools are rejected with 400 at every accepted `reasoning_effort`, and `none` is itself rejected, so no value lets tools through. Image input, system role, multiturn, streaming and `json_schema` output work.

This adds a `_Gpt6AstraModelCapabilities` profile (tools false, media true) matched by `^gpt-6-astra(?:-|$)` so dated snapshots and suffixed variants get the same metadata, mirroring the JS (genkit-ai/genkit#6303), Go (genkit-ai/genkit#6304) and Python (genkit-ai/genkit#6306) entries. Tools are still forwarded unconditionally; `supports.tools` stays advisory for the Dev UI and refs.

It also adds a `reasoningEffort` option (`none|minimal|low|medium|high|xhigh`) to `OpenAIChatOptions`, forwarded as `reasoning_effort` through an explicit switch; a value outside the enum fails with `INVALID_ARGUMENT` rather than reaching the API as the SDK's `unknown` sentinel. Astra accepts `low`..`xhigh`, rejects `none`/`max`, `temperature != 1` and `top_p`; the plugin only sends those when set.

Tests pin the supports map (bare id, dated snapshot, suffixed variant, fine-tune default), the schema enum, the wire body, and the unknown-effort rejection. `dart analyze`, `dart format` and `dart test` (81 passed) are clean. Live smoke run from Dart: strict `json_schema` with `additionalProperties: false` is accepted and parses; text, streaming, image input, system role, multiturn and `max_completion_tokens` work; tools return the provider 400 as `INVALID_ARGUMENT`; `reasoningEffort: 'max'` fails locally. `dart test` with a key: 91 passed including the 9 integration tests.

