### PR TITLE
fix(google_genai): map Gemini finish reasons to Genkit vocabulary

### DIFF
--- a/packages/genkit_google_genai/lib/src/common_plugin.dart
+++ b/packages/genkit_google_genai/lib/src/common_plugin.dart
@@ -258,14 +258,53 @@ abstract class CommonGoogleGenPlugin extends GenkitPlugin {
 }
 
 (Message, FinishReason) fromGeminiCandidate(gcl.Candidate candidate) {
-  final finishReason = FinishReason(
-    candidate.finishReason?.toLowerCase() ?? 'unspecified',
-  );
   final message = Message(
-    role: Role(candidate.content!.role!),
+    role: Role(candidate.content?.role ?? 'model'),
     content: candidate.content?.parts?.map(fromGeminiPart).toList() ?? [],
   );
-  return (message, finishReason);
+  return (message, _toFinishReason(candidate.finishReason));
+}
+
+/// Maps a Gemini finish reason onto Genkit's vocabulary. An absent or
+/// `FINISH_REASON_UNSPECIFIED` reason becomes [FinishReason.unknown] (a
+/// result-carrying reason), never the non-canonical `unspecified`: a truncated
+/// turn that names no reason still carries whatever text it produced.
+/// Unrecognized future reasons also fall to `unknown` rather than leaking the
+/// raw enum string.
+FinishReason _toFinishReason(String? raw) {
+  switch (raw) {
+    case null:
+    case '':
+    case 'FINISH_REASON_UNSPECIFIED':
+      return FinishReason.unknown;
+    case 'STOP':
+      return FinishReason.stop;
+    case 'MAX_TOKENS':
+      return FinishReason.length;
+    case 'SAFETY':
+    case 'RECITATION':
+    case 'LANGUAGE':
+    case 'BLOCKLIST':
+    case 'PROHIBITED_CONTENT':
+    case 'SPII':
+    case 'IMAGE_SAFETY':
+    case 'IMAGE_PROHIBITED_CONTENT':
+    case 'IMAGE_RECITATION':
+      return FinishReason.blocked;
+    case 'MALFORMED_FUNCTION_CALL':
+    case 'UNEXPECTED_TOOL_CALL':
+    case 'TOO_MANY_TOOL_CALLS':
+    case 'NO_IMAGE':
+    case 'IMAGE_OTHER':
+    case 'MALFORMED_RESPONSE':
+    // Gemini 3 returns this when thought signatures are missing from the
+    // request; treat it as a non-fatal "other" like the Go plugin.
+    case 'MISSING_THOUGHT_SIGNATURE':
+    case 'OTHER':
+      return FinishReason.other;
+    default:
+      return FinishReason.unknown;
+  }
 }
 
 @visibleForTesting

--- a/packages/genkit_google_genai/test/finish_reason_test.dart
+++ b/packages/genkit_google_genai/test/finish_reason_test.dart
@@ -21,7 +21,10 @@ import 'package:test/test.dart';
 gcl.Candidate _candidate(String? finishReason) => gcl.Candidate(
   index: 0,
   finishReason: finishReason,
-  content: gcl.Content(role: 'model', parts: [gcl.Part(text: 'hi')]),
+  content: gcl.Content(
+    role: 'model',
+    parts: [gcl.Part(text: 'hi')],
+  ),
 );
 
 void main() {
@@ -55,13 +58,16 @@ void main() {
       expect(reason.value, isNot('unspecified'));
     });
 
-    test('content-less candidate does not throw and defaults role to model', () {
-      final (message, reason) = fromGeminiCandidate(
-        gcl.Candidate(index: 0, finishReason: 'STOP'),
-      );
-      expect(message.role, Role.model);
-      expect(message.content, isEmpty);
-      expect(reason.value, FinishReason.stop.value);
-    });
+    test(
+      'content-less candidate does not throw and defaults role to model',
+      () {
+        final (message, reason) = fromGeminiCandidate(
+          gcl.Candidate(index: 0, finishReason: 'STOP'),
+        );
+        expect(message.role, Role.model);
+        expect(message.content, isEmpty);
+        expect(reason.value, FinishReason.stop.value);
+      },
+    );
   });
 }

--- a/packages/genkit_google_genai/test/finish_reason_test.dart
+++ b/packages/genkit_google_genai/test/finish_reason_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+import 'package:genkit_google_genai/src/common_plugin.dart';
+import 'package:genkit_google_genai/src/generated/generativelanguage.dart'
+    as gcl;
+import 'package:test/test.dart';
+
+gcl.Candidate _candidate(String? finishReason) => gcl.Candidate(
+  index: 0,
+  finishReason: finishReason,
+  content: gcl.Content(role: 'model', parts: [gcl.Part(text: 'hi')]),
+);
+
+void main() {
+  group('fromGeminiCandidate finish reason mapping', () {
+    // Mirrors the Go plugin's translateCandidate switch.
+    final cases = <String, FinishReason>{
+      'STOP': FinishReason.stop,
+      'MAX_TOKENS': FinishReason.length,
+      'SAFETY': FinishReason.blocked,
+      'RECITATION': FinishReason.blocked,
+      'PROHIBITED_CONTENT': FinishReason.blocked,
+      'IMAGE_SAFETY': FinishReason.blocked,
+      'OTHER': FinishReason.other,
+      'MALFORMED_FUNCTION_CALL': FinishReason.other,
+      'UNEXPECTED_TOOL_CALL': FinishReason.other,
+      'MISSING_THOUGHT_SIGNATURE': FinishReason.other,
+      'FINISH_REASON_UNSPECIFIED': FinishReason.unknown,
+      'SOME_FUTURE_REASON': FinishReason.unknown,
+    };
+
+    cases.forEach((raw, expected) {
+      test('$raw -> ${expected.value}', () {
+        final (_, reason) = fromGeminiCandidate(_candidate(raw));
+        expect(reason.value, expected.value);
+      });
+    });
+
+    test('absent finish reason maps to unknown (never "unspecified")', () {
+      final (_, reason) = fromGeminiCandidate(_candidate(null));
+      expect(reason.value, FinishReason.unknown.value);
+      expect(reason.value, isNot('unspecified'));
+    });
+
+    test('content-less candidate does not throw and defaults role to model', () {
+      final (message, reason) = fromGeminiCandidate(
+        gcl.Candidate(index: 0, finishReason: 'STOP'),
+      );
+      expect(message.role, Role.model);
+      expect(message.content, isEmpty);
+      expect(reason.value, FinishReason.stop.value);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`fromGeminiCandidate` used to build the finish reason by lowercasing the raw Gemini enum string (`FinishReason(candidate.finishReason?.toLowerCase() ?? 'unspecified')`). That leaked non-canonical values into Genkit's vocabulary: `max_tokens`, `recitation`, `unspecified`, and any future enum value all flowed straight through instead of mapping onto the reasons Genkit actually understands (`stop`, `length`, `blocked`, `other`, `unknown`, ...).

This PR replaces that with an explicit `_toFinishReason` switch that mirrors the Go plugin's `translateCandidate` and the JS plugin's `fromGeminiFinishReason`:

- `STOP` -> `stop`
- `MAX_TOKENS` -> `length`
- `SAFETY` / `RECITATION` / `LANGUAGE` / `BLOCKLIST` / `PROHIBITED_CONTENT` / `SPII` / `IMAGE_SAFETY` / `IMAGE_PROHIBITED_CONTENT` / `IMAGE_RECITATION` -> `blocked`
- `MALFORMED_FUNCTION_CALL` / `UNEXPECTED_TOOL_CALL` / `TOO_MANY_TOOL_CALLS` / `NO_IMAGE` / `IMAGE_OTHER` / `MALFORMED_RESPONSE` / `MISSING_THOUGHT_SIGNATURE` / `OTHER` -> `other`
- absent / empty / `FINISH_REASON_UNSPECIFIED` / any unrecognized value -> `unknown`

Mapping absent and unspecified reasons to `unknown` (a result-carrying reason) rather than leaking `unspecified` means a truncated turn that names no reason still surfaces whatever text it produced. `MISSING_THOUGHT_SIGNATURE` (returned by Gemini 3 when thought signatures are missing from the request) is treated as a non-fatal `other`, matching the Go plugin.

## Also

- Handle content-less candidates: safety blocks and other early terminations arrive without `content`, so default the role to `model` instead of dereferencing a null `content` (previously `candidate.content!.role!` would throw).

## Tests

Adds `finish_reason_test.dart` covering the full mapping table, the absent-reason case, and the content-less candidate path.
