### PR TITLE
feat(genkit_openai): ship embedders with a curated per-model catalog

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -285,6 +285,45 @@ OpenAI's own hosting. The catalog is also not added to that host's listing:
 what a compatible provider lists is whatever its `/models` reports plus the
 models you register.
 
+## Embeddings
+
+Embedders resolve the same way models do, and `OpenAIEmbedders` exposes a typed
+reference for each curated one:
+
+```dart
+final vectors = await ai.embed(
+  embedder: OpenAIEmbedders.textEmbedding3Small,
+  document: DocumentData(content: [TextPart(text: 'The cat sat on the mat.')]),
+);
+
+print(vectors.single.embedding.length); // 1536
+```
+
+`embedMany` takes a list of documents and returns one vector per document, in
+order. A corpus larger than the 2048 inputs OpenAI accepts per request is split
+across requests rather than rejected.
+
+Each document's text parts are joined with newlines; media parts are dropped,
+since OpenAI has no multimodal embedder. A document carrying no text at all is
+rejected before the request goes out.
+
+`KnownOpenAIEmbedder` carries the catalog, including the vector length each
+model returns. The `text-embedding-3-*` models will also return a shorter
+vector on request:
+
+```dart
+final vectors = await ai.embed(
+  embedder: OpenAIEmbedders.textEmbedding3Small,
+  document: DocumentData(content: [TextPart(text: 'hello')]),
+  options: OpenAIEmbedderOptions(dimensions: 256),
+);
+```
+
+As with models, the catalog is not the set of usable embedders: any name works
+by passing it to `openAI.embedder()`, it is just described without a vector
+length, and behind a custom `baseUrl` only what that host's `/models` reports
+is listed.
+
 ## Options
 
 The `OpenAIChatOptions` class supports the following options:
@@ -300,6 +339,12 @@ The `OpenAIChatOptions` class supports the following options:
 - `jsonMode` (bool?) - Enable JSON mode
 - `visualDetailLevel` (String?, 'auto'|'low'|'high') - Visual detail level for images
 - `version` (String?) - Model version override
+
+The `OpenAIEmbedderOptions` class supports:
+
+- `dimensions` (int?) - Length of the returned vector, for the models that
+  accept a shorter one
+- `user` (String?) - User identifier for abuse detection
 
 ## Custom Headers
 

--- a/packages/genkit_openai/example/example.dart
+++ b/packages/genkit_openai/example/example.dart
@@ -164,6 +164,29 @@ Flow<String, String, void, void> defineModelListFlow(Genkit ai) {
   );
 }
 
+/// Defines a flow that embeds a batch of documents and reports the vectors it
+/// got back.
+Flow<List<String>, String, void, void> defineEmbeddingFlow(Genkit ai) {
+  return ai.defineFlow(
+    name: 'embedding',
+    inputSchema: .list(.string()),
+    outputSchema: .string(),
+    fn: (texts, _) async {
+      final vectors = await ai.embedMany(
+        embedder: OpenAIEmbedders.textEmbedding3Small,
+        documents: [
+          for (final text in texts)
+            DocumentData(content: [TextPart(text: text)]),
+        ],
+        // Optional: the -3- models return a shorter vector on request.
+        options: OpenAIEmbedderOptions(dimensions: 256),
+      );
+
+      return vectors.map((v) => '${v.embedding.length} dimensions').join('\n');
+    },
+  );
+}
+
 /// Defines a flow that demonstrates OpenAI tool/function calling.
 Flow<WeatherFlowInput, String, void, void> defineToolCallingFlow(
   Genkit ai,
@@ -309,6 +332,7 @@ void main() {
   defineStreamedSimpleGenerationFlow(ai);
   defineModelResolutionFlow(ai);
   defineModelListFlow(ai);
+  defineEmbeddingFlow(ai);
   defineToolCallingFlow(ai, getWeather);
   defineStreamedToolCallingFlow(ai, getWeather);
   defineStructuredOutputFlow(ai);

--- a/packages/genkit_openai/lib/genkit_openai.dart
+++ b/packages/genkit_openai/lib/genkit_openai.dart
@@ -18,11 +18,25 @@ import 'package:genkit/plugin.dart';
 import 'package:http/http.dart' as http;
 
 import 'src/chat.dart' as chat;
+import 'src/embed.dart' as embed;
+import 'src/known_embedders.dart';
 import 'src/known_models.dart';
 import 'src/openai_plugin.dart';
 
 export 'src/chat.dart' show OpenAIChatOptions, OpenAIOptions;
 export 'src/converters.dart' show GenkitConverter;
+export 'src/embed.dart' show OpenAIEmbedderOptions;
+// The embedder catalog is public for the same reason the model catalog is.
+// `embedderInfoFor` and its compat variant are not: until core grows an
+// `EmbedderInfo` (#327) they hand back a raw map whose shape is expected to
+// change, and freezing that as API now would make the migration a breaking
+// one.
+export 'src/known_embedders.dart'
+    show
+        KnownOpenAIEmbedder,
+        knownEmbedderModels,
+        knownOpenAIEmbedderFor,
+        knownOpenAIEmbedders;
 // The catalog and the capability vocabulary are public: describing a model
 // the plugin does not know is a supported thing to do, and a caller doing it
 // should reach for the same presets the curated entries use.
@@ -157,6 +171,28 @@ class OpenAICompatPluginHandle {
     return modelRef(
       '$namespace/$name',
       customOptions: chat.chatModelOptionsSchema(),
+    );
+  }
+
+  /// Reference to an embedding model.
+  ///
+  /// Takes [namespace] for the same reason [model] does: it is the prefix the
+  /// embedder is looked up under (e.g. `openai/text-embedding-3-small`), and a
+  /// plugin registered with a custom name needs it passed.
+  ///
+  /// ```dart
+  /// final vectors = await ai.embed(
+  ///   embedder: openAI.embedder('text-embedding-3-small'),
+  ///   document: DocumentData(content: [TextPart(text: 'hello')]),
+  /// );
+  /// ```
+  EmbedderRef<embed.OpenAIEmbedderOptions> embedder(
+    String name, {
+    String namespace = defaultOpenAINamespace,
+  }) {
+    return embedderRef(
+      '$namespace/$name',
+      customOptions: embed.embedderOptionsSchema(),
     );
   }
 }
@@ -334,5 +370,36 @@ abstract final class OpenAIModels {
     gpt4Turbo,
     gpt4,
     gpt35Turbo,
+  ];
+}
+
+/// Typed [EmbedderRef]s for the OpenAI embedders curated by the `openai`
+/// plugin.
+///
+/// Each entry is equivalent to `openAI.embedder('<name>')`, which remains the
+/// escape hatch for embedders not listed here and for plugin instances
+/// registered under a custom namespace.
+abstract final class OpenAIEmbedders {
+  /// OpenAI text-embedding-3-small, 1536 dimensions.
+  static final EmbedderRef<embed.OpenAIEmbedderOptions> textEmbedding3Small =
+      openAI.embedder(KnownOpenAIEmbedder.textEmbedding3Small.id);
+
+  /// OpenAI text-embedding-3-large, 3072 dimensions.
+  static final EmbedderRef<embed.OpenAIEmbedderOptions> textEmbedding3Large =
+      openAI.embedder(KnownOpenAIEmbedder.textEmbedding3Large.id);
+
+  /// OpenAI text-embedding-ada-002, 1536 dimensions and no `dimensions`
+  /// option.
+  static final EmbedderRef<embed.OpenAIEmbedderOptions> textEmbeddingAda002 =
+      openAI.embedder(KnownOpenAIEmbedder.textEmbeddingAda002.id);
+
+  /// Every ref above, in catalog order.
+  ///
+  /// Exists so the statics cannot silently fall behind [KnownOpenAIEmbedder],
+  /// the same way `OpenAIModels.all` guards the model refs.
+  static final List<EmbedderRef<embed.OpenAIEmbedderOptions>> all = [
+    textEmbedding3Small,
+    textEmbedding3Large,
+    textEmbeddingAda002,
   ];
 }

--- a/packages/genkit_openai/lib/src/embed.dart
+++ b/packages/genkit_openai/lib/src/embed.dart
@@ -109,6 +109,10 @@ String _documentText(DocumentData document, {required int index}) {
 /// and what it would have returned. Only curated models are checked — an
 /// uncurated name has no claim to check against, so its request goes through
 /// and OpenAI has the last word either way.
+///
+/// The caller decides when the catalog is authoritative enough to reject on:
+/// it describes OpenAI's models, and a compatible host serving one of those
+/// names may not have the same limits.
 void validateEmbedderDimensions(String embedderName, int? dimensions) {
   if (dimensions == null) return;
   final curated = knownOpenAIEmbedderFor(embedderName);

--- a/packages/genkit_openai/lib/src/embed.dart
+++ b/packages/genkit_openai/lib/src/embed.dart
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+import 'package:openai_dart/openai_dart.dart' as sdk;
+import 'package:schemantic/schemantic.dart';
+
+import 'known_embedders.dart';
+
+part 'embed.g.dart';
+
+/// Options for OpenAI embedding models.
+///
+/// `encoding_format` is deliberately absent: the only alternative to the
+/// default is `base64`, which returns the vector as a string the SDK's
+/// response model cannot parse, so offering it would only let a caller break
+/// the call.
+@Schema()
+abstract class $OpenAIEmbedderOptions {
+  /// Length of the returned vector.
+  ///
+  /// Only the `text-embedding-3-*` models accept this, and only to shorten:
+  /// they are trained so that a prefix of the vector is still a usable
+  /// embedding. Defaults to the model's full size.
+  int? get dimensions;
+
+  /// User identifier for abuse detection.
+  String? get user;
+}
+
+/// Returns the custom options schema for embedders.
+SchemanticType<OpenAIEmbedderOptions> embedderOptionsSchema() =>
+    OpenAIEmbedderOptions.$schema;
+
+/// Parses embedder options from action config.
+OpenAIEmbedderOptions parseEmbedderOptions(Map<String, dynamic>? config) {
+  return config != null
+      ? OpenAIEmbedderOptions.$schema.parse(config)
+      : OpenAIEmbedderOptions();
+}
+
+/// Maximum inputs OpenAI accepts in one `POST /v1/embeddings` call.
+///
+/// A larger `embedMany` is split across requests rather than rejected, since a
+/// corpus of more than 2048 documents is an ordinary thing to embed.
+///
+/// The array limit is the only one enforced here. A request is also capped at
+/// 300,000 tokens across all of its inputs, which cannot be checked without
+/// tokenising; a batch that trips it surfaces as OpenAI's own error.
+const maxEmbeddingInputs = 2048;
+
+/// Splits [inputs] into batches OpenAI will accept in a single request.
+Iterable<List<String>> embeddingBatches(List<String> inputs) sync* {
+  for (var start = 0; start < inputs.length; start += maxEmbeddingInputs) {
+    yield inputs.sublist(
+      start,
+      (start + maxEmbeddingInputs).clamp(0, inputs.length),
+    );
+  }
+}
+
+/// Flattens [documents] into the strings sent as `input`.
+///
+/// A document's text parts are joined with newlines, the way the googleai and
+/// vertexai embedders do it. Media parts are dropped: OpenAI has no
+/// multimodal embedder, so there is nowhere to send them.
+///
+/// A document that carries no text is rejected rather than sent as `""`.
+/// OpenAI answers an empty string with a 400 naming only the input index, and
+/// an all-media document reaching a text embedder is a caller mistake worth
+/// naming.
+List<String> embeddingInputs(List<DocumentData> documents) {
+  return [
+    for (var i = 0; i < documents.length; i++)
+      _documentText(documents[i], index: i),
+  ];
+}
+
+String _documentText(DocumentData document, {required int index}) {
+  final text = document.content
+      .where((part) => part.isText)
+      .map((part) => part.text)
+      .join('\n');
+  if (text.trim().isEmpty) {
+    throw GenkitException(
+      'Document at index $index has no text content to embed. OpenAI '
+      'embedders accept text only.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+  return text;
+}
+
+/// Validates a requested [dimensions] against the curated catalog.
+///
+/// Both failures are 400s from OpenAI if sent, but the API reports them
+/// against the raw parameter; the catalog knows which model the caller named
+/// and what it would have returned. Only curated models are checked — an
+/// uncurated name has no claim to check against, so its request goes through
+/// and OpenAI has the last word either way.
+void validateEmbedderDimensions(String embedderName, int? dimensions) {
+  if (dimensions == null) return;
+  final curated = knownOpenAIEmbedderFor(embedderName);
+  if (curated == null) return;
+
+  if (!curated.dimensionsReducible) {
+    throw GenkitException(
+      '${curated.id} does not support the dimensions option; it always '
+      'returns ${curated.dimensions} dimensions.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+  if (dimensions < 1 || dimensions > curated.dimensions) {
+    throw GenkitException(
+      '${curated.id} returns between 1 and ${curated.dimensions} dimensions; '
+      'got $dimensions.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+}
+
+/// Converts an OpenAI embeddings response into Genkit [Embedding]s.
+///
+/// Ordered by the `index` OpenAI stamps on each vector rather than by
+/// position, because the caller's list order is the only thing tying a vector
+/// back to its document and the response is not documented to preserve it.
+List<Embedding> toGenkitEmbeddings(
+  sdk.EmbeddingResponse response, {
+  required int expectedCount,
+}) {
+  if (response.data.length != expectedCount) {
+    throw GenkitException(
+      'OpenAI returned ${response.data.length} embeddings for $expectedCount '
+      'input documents.',
+      status: StatusCodes.INTERNAL,
+    );
+  }
+
+  final ordered = [...response.data]
+    ..sort((a, b) => a.index.compareTo(b.index));
+  return [
+    for (final embedding in ordered) Embedding(embedding: embedding.embedding),
+  ];
+}

--- a/packages/genkit_openai/lib/src/embed.g.dart
+++ b/packages/genkit_openai/lib/src/embed.g.dart
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+part of 'embed.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+/// Options for OpenAI embedding models.
+///
+/// `encoding_format` is deliberately absent: the only alternative to the
+/// default is `base64`, which returns the vector as a string the SDK's
+/// response model cannot parse, so offering it would only let a caller break
+/// the call.
+base class OpenAIEmbedderOptions {
+  /// Creates a [OpenAIEmbedderOptions] from a JSON map.
+  factory OpenAIEmbedderOptions.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  OpenAIEmbedderOptions._(this._json);
+
+  OpenAIEmbedderOptions({int? dimensions, String? user}) {
+    _json = {'dimensions': ?dimensions, 'user': ?user};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [OpenAIEmbedderOptions].
+  static const SchemanticType<OpenAIEmbedderOptions> $schema =
+      _OpenAIEmbedderOptionsTypeFactory();
+
+  /// Length of the returned vector.
+  ///
+  /// Only the `text-embedding-3-*` models accept this, and only to shorten:
+  /// they are trained so that a prefix of the vector is still a usable
+  /// embedding. Defaults to the model's full size.
+  int? get dimensions {
+    return _json['dimensions'] as int?;
+  }
+
+  /// Length of the returned vector.
+  ///
+  /// Only the `text-embedding-3-*` models accept this, and only to shorten:
+  /// they are trained so that a prefix of the vector is still a usable
+  /// embedding. Defaults to the model's full size.
+  set dimensions(int? value) {
+    if (value == null) {
+      _json.remove('dimensions');
+    } else {
+      _json['dimensions'] = value;
+    }
+  }
+
+  /// User identifier for abuse detection.
+  String? get user {
+    return _json['user'] as String?;
+  }
+
+  /// User identifier for abuse detection.
+  set user(String? value) {
+    if (value == null) {
+      _json.remove('user');
+    } else {
+      _json['user'] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [OpenAIEmbedderOptions] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _OpenAIEmbedderOptionsTypeFactory
+    extends SchemanticType<OpenAIEmbedderOptions> {
+  const _OpenAIEmbedderOptionsTypeFactory();
+
+  @override
+  OpenAIEmbedderOptions parse(Object? json) {
+    return OpenAIEmbedderOptions._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'OpenAIEmbedderOptions',
+    definition: $Schema
+        .object(
+          properties: {
+            'dimensions': $Schema.integer(),
+            'user': $Schema.string(),
+          },
+        )
+        .value,
+    dependencies: [],
+  );
+}

--- a/packages/genkit_openai/lib/src/known_embedders.dart
+++ b/packages/genkit_openai/lib/src/known_embedders.dart
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'known_models.dart' show OpenAIModelStage;
+
+/// Input modalities every OpenAI embedding model accepts.
+///
+/// `POST /v1/embeddings` takes text (or pre-tokenised text) and nothing else —
+/// OpenAI has no multimodal embedder — so this is a constant rather than a
+/// per-entry field. It is the `supports.input` vocabulary JS `EmbedderInfo`
+/// and Go `ai.EmbedderOptions` use.
+const _textInput = <String, dynamic>{
+  'input': ['text'],
+};
+
+/// OpenAI embedding models the plugin curates metadata for.
+///
+/// Each value pairs a bare model [id] (no plugin prefix) with a display
+/// [label] and the size of the vector it returns. This is not the set of
+/// usable embedders: any name still resolves, and one with no entry here is
+/// simply described without [dimensions].
+///
+/// Per-model behaviour belongs on this enum rather than in a name-matching
+/// branch at the call site, the same way `KnownOpenAIModel` carries chat
+/// capabilities.
+///
+/// Catalog: https://developers.openai.com/api/docs/guides/embeddings
+enum KnownOpenAIEmbedder {
+  /// The default: the same 8191-token context as the large model at a
+  /// fraction of the cost.
+  textEmbedding3Small(
+    'text-embedding-3-small',
+    'OpenAI text-embedding-3-small',
+    dimensions: 1536,
+  ),
+
+  /// The highest-scoring OpenAI embedder, at 3072 dimensions.
+  textEmbedding3Large(
+    'text-embedding-3-large',
+    'OpenAI text-embedding-3-large',
+    dimensions: 3072,
+  ),
+
+  /// The second-generation embedder, superseded by the `-3-` pair.
+  ///
+  /// Predates Matryoshka training, so its vector length is fixed: it rejects
+  /// the `dimensions` parameter rather than truncating.
+  textEmbeddingAda002(
+    'text-embedding-ada-002',
+    'OpenAI text-embedding-ada-002',
+    dimensions: 1536,
+    dimensionsReducible: false,
+    stage: OpenAIModelStage.legacy,
+  );
+
+  const KnownOpenAIEmbedder(
+    this.id,
+    this.label, {
+    required this.dimensions,
+    this.dimensionsReducible = true,
+    this.stage = OpenAIModelStage.stable,
+  });
+
+  /// Bare model name (no plugin prefix).
+  final String id;
+
+  /// Human-readable label surfaced in listings.
+  final String label;
+
+  /// Length of the vector this model returns when asked for no particular
+  /// size.
+  final int dimensions;
+
+  /// Whether the model honours a smaller `dimensions` than [dimensions].
+  ///
+  /// The `-3-` models are trained with Matryoshka Representation Learning, so
+  /// a prefix of the vector is still a usable embedding and the API will
+  /// truncate on request. Earlier models 400 instead.
+  final bool dimensionsReducible;
+
+  /// Lifecycle stage, in the same vocabulary `KnownOpenAIModel` uses.
+  final OpenAIModelStage stage;
+
+  /// Metadata registered for this embedder.
+  ///
+  /// One instance per entry, shared by every resolution of the embedder, so
+  /// the maps it carries are unmodifiable: mutating action metadata in place
+  /// must fail loudly rather than corrupt the catalog.
+  Map<String, dynamic> get info => _curatedInfo[this]!;
+}
+
+/// The shape core will grow a type for in #327.
+///
+/// Until `Embedder` / `embedderMetadata()` carry an `EmbedderInfo` of their
+/// own, this rides in the `model` metadata map that both already merge —
+/// alongside the `label` they write there — so the Dev UI has something to
+/// read and the values do not have to be invented twice later. The keys are
+/// JS `EmbedderInfo`'s: `label`, `dimensions`, `supports.input`.
+Map<String, dynamic> _info({String? label, int? dimensions, String? stage}) =>
+    Map.unmodifiable(<String, dynamic>{
+      'label': ?label,
+      'dimensions': ?dimensions,
+      'stage': ?stage,
+      'supports': Map<String, dynamic>.unmodifiable(_textInput),
+    });
+
+final _curatedInfo = <KnownOpenAIEmbedder, Map<String, dynamic>>{
+  for (final embedder in KnownOpenAIEmbedder.values)
+    embedder: _info(
+      label: embedder.label,
+      dimensions: embedder.dimensions,
+      stage: embedder.stage.wireName,
+    ),
+};
+
+/// Curated metadata for known OpenAI embedders, keyed by bare model name (no
+/// plugin prefix).
+///
+/// Derived from [KnownOpenAIEmbedder]; other names still resolve, they just
+/// take [dynamicEmbedderInfo] instead of a curated entry.
+final Map<String, Map<String, dynamic>> knownOpenAIEmbedders = Map.unmodifiable(
+  {
+    for (final embedder in KnownOpenAIEmbedder.values)
+      embedder.id: embedder.info,
+  },
+);
+
+/// Embedders the plugin lists without network access.
+///
+/// Listed alongside whatever `GET /models` reports, for the same reason
+/// `knownChatModels` is: discovery needs both connectivity and a valid key,
+/// and neither is guaranteed. [OpenAIModelStage.deprecated] entries are
+/// excluded — OpenAI no longer serves them.
+final List<String> knownEmbedderModels = List.unmodifiable([
+  for (final embedder in KnownOpenAIEmbedder.values)
+    if (embedder.stage != OpenAIModelStage.deprecated) embedder.id,
+]);
+
+final _knownOpenAIEmbeddersByName = <String, KnownOpenAIEmbedder>{
+  for (final embedder in KnownOpenAIEmbedder.values)
+    embedder.id.toLowerCase(): embedder,
+};
+
+/// Returns the curated entry for [embedderName], or `null` when the name is
+/// not curated.
+///
+/// Matching is case-insensitive; the OpenAI catalog is lower-case. Unlike the
+/// chat models, OpenAI has never shipped a dated snapshot of an embedder, so
+/// there is no suffix to strip.
+KnownOpenAIEmbedder? knownOpenAIEmbedderFor(String embedderName) =>
+    _knownOpenAIEmbeddersByName[embedderName.toLowerCase()];
+
+/// Metadata for an embedder with no curated entry.
+///
+/// Every OpenAI embedding endpoint takes text, so that much is safe to claim.
+/// The vector length is not: it is a property of the specific model, it is
+/// what a caller sizes a vector store on, and guessing 1536 because two of the
+/// three curated models return it would be a number this plugin made up.
+/// Omitting it says "ask the model", which is what a caller can actually do.
+final Map<String, dynamic> dynamicEmbedderInfo = _info();
+
+/// Metadata for any OpenAI embedder name: the curated entry when there is one,
+/// [dynamicEmbedderInfo] otherwise.
+Map<String, dynamic> embedderInfoFor(String embedderName) =>
+    knownOpenAIEmbedderFor(embedderName)?.info ?? dynamicEmbedderInfo;
+
+final _compatInfo = <KnownOpenAIEmbedder, Map<String, dynamic>>{
+  for (final embedder in KnownOpenAIEmbedder.values)
+    embedder: _info(dimensions: embedder.dimensions),
+};
+
+/// Metadata for [embedderName] on an OpenAI-compatible backend that is not
+/// OpenAI itself.
+///
+/// Splits the same way `compatModelInfo` does: the vector length is a property
+/// of the model, so a gateway routing `text-embedding-3-small` to OpenAI still
+/// returns 1536 dimensions, but OpenAI's label and retirement schedule
+/// describe OpenAI's deployment and not the backend's.
+Map<String, dynamic> compatEmbedderInfo(String embedderName) {
+  final curated = knownOpenAIEmbedderFor(embedderName);
+  return curated != null ? _compatInfo[curated]! : dynamicEmbedderInfo;
+}

--- a/packages/genkit_openai/lib/src/known_models.dart
+++ b/packages/genkit_openai/lib/src/known_models.dart
@@ -121,9 +121,10 @@ const multimodalNoToolsSupports = <String, dynamic>{
 
 /// Capabilities advertised for a discovered model that is not a chat model.
 ///
-/// Chat generation is the only modality this plugin serves, so an embedding,
-/// audio, image, moderation, or legacy completion model claims none of it.
-/// Embedders arrive with their own metadata; see issue #361.
+/// Chat generation is the only modality this plugin serves *here*, so an
+/// embedding, audio, image, moderation, or legacy completion model claims none
+/// of it. An embedding model named as a model still lands on this - what the
+/// plugin serves it as is an embedder, described by `known_embedders.dart`.
 const nonChatSupports = <String, dynamic>{
   'multiturn': false,
   'systemRole': false,
@@ -168,8 +169,9 @@ enum OpenAIModelStage {
 ///
 /// Per-model behaviour beyond capabilities belongs on this enum as another
 /// field rather than in a name-matching branch at the call site — that is what
-/// keeps `reasoning_effort` (#239) and the embedder catalog (#361) from each
-/// growing their own copy of the model list.
+/// keeps something like `reasoning_effort` (#239) from growing its own copy of
+/// the model list. A different modality gets its own catalog instead; see
+/// `KnownOpenAIEmbedder`.
 ///
 /// Catalog: https://developers.openai.com/api/docs/models
 /// Retirements: https://developers.openai.com/api/docs/deprecations

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -20,7 +20,11 @@ import 'package:openai_dart/openai_dart.dart' as sdk;
 
 import '../genkit_openai.dart';
 import 'chat.dart' as chat;
-// compatModelInfo is intentionally not part of the public surface.
+import 'embed.dart' as embed;
+// The compat variants and the embedder metadata are intentionally not part of
+// the public surface.
+import 'known_embedders.dart'
+    show compatEmbedderInfo, embedderInfoFor, knownEmbedderModels;
 import 'known_models.dart' show compatModelInfo;
 
 final _logger = Logger('genkit_openai');
@@ -28,8 +32,9 @@ final _logger = Logger('genkit_openai');
 /// Core Genkit plugin implementation for OpenAI-compatible APIs.
 ///
 /// Registers nothing up front beyond [customModels]: [resolve] builds a model
-/// on demand for any id. Discovery runs in [list], against whichever host
-/// [baseUrl] names, and returns metadata rather than registered actions.
+/// or an embedder on demand for any id. Discovery runs in [list], against
+/// whichever host [baseUrl] names, and returns metadata rather than registered
+/// actions.
 class OpenAIPlugin extends GenkitPlugin {
   final String _pluginName;
 
@@ -184,8 +189,8 @@ class OpenAIPlugin extends GenkitPlugin {
     );
   }
 
-  /// Lists the plugin's models, enriching the curated catalog with whatever
-  /// `GET /models` reports.
+  /// Lists the plugin's models and embedders, enriching the curated catalogs
+  /// with whatever `GET /models` reports.
   ///
   /// Discovery is best-effort. Any failure - offline, bad key, a compatible
   /// host that does not serve `/models` - degrades to the curated catalog with
@@ -195,6 +200,7 @@ class OpenAIPlugin extends GenkitPlugin {
   Future<List<ActionMetadata<dynamic, dynamic, dynamic, dynamic>>>
   list() async {
     final discovered = <String>{};
+    final discoveredEmbedders = <String>{};
 
     // Key resolution is inside the try on purpose: an apiKeyProvider that
     // throws must degrade like any other discovery failure, not take the
@@ -205,6 +211,10 @@ class OpenAIPlugin extends GenkitPlugin {
       if (config != null) {
         for (final modelId in await _fetchAvailableModels(config)) {
           final modelType = getModelType(modelId);
+          if (modelType == 'embedding') {
+            discoveredEmbedders.add(modelId);
+            continue;
+          }
           if (modelType != 'chat' && modelType != 'unknown') {
             continue;
           }
@@ -235,6 +245,13 @@ class OpenAIPlugin extends GenkitPlugin {
       ...customModels.map((m) => m.name),
     };
 
+    // Embedders follow the same rule for the same reason: discovery when
+    // there is any, plus the curated catalog when the host is OpenAI itself.
+    final embedderIds = <String>{
+      ...discoveredEmbedders,
+      if (baseUrl == null) ...knownEmbedderModels,
+    };
+
     final infoOverrides = {
       for (final model in customModels)
         if (model.info != null) model.name: model.info!,
@@ -247,7 +264,37 @@ class OpenAIPlugin extends GenkitPlugin {
           modelInfo: infoOverrides[id] ?? _infoFor(id),
           customOptions: chat.chatModelOptionsSchema(),
         ),
+      for (final id in embedderIds) _embedderMetadata(id),
     ];
+  }
+
+  /// Listing metadata for the embedder [embedderName].
+  ///
+  /// Built from `embedderMetadata` rather than replacing it, so the label,
+  /// description and options schema stay whatever core writes, and the
+  /// curated entry only adds to them. The input and output schemas are named
+  /// explicitly the way `genkit_vertexai` does; core's helper omits them.
+  ActionMetadata<dynamic, dynamic, dynamic, dynamic> _embedderMetadata(
+    String embedderName,
+  ) {
+    final base = embedderMetadata(
+      '$_pluginName/$embedderName',
+      customOptions: embed.embedderOptionsSchema(),
+    );
+    final metadata = {...base.metadata};
+    metadata['model'] = <String, dynamic>{
+      ...(metadata['model'] as Map).cast<String, dynamic>(),
+      ..._embedderInfoFor(embedderName),
+    };
+
+    return ActionMetadata(
+      name: base.name,
+      description: base.description,
+      actionType: base.actionType,
+      inputSchema: EmbedRequest.$schema,
+      outputSchema: EmbedResponse.$schema,
+      metadata: metadata,
+    );
   }
 
   /// Capability metadata for [modelName] on this plugin instance.
@@ -259,12 +306,82 @@ class OpenAIPlugin extends GenkitPlugin {
   ModelInfo _infoFor(String modelName) =>
       baseUrl == null ? modelInfoFor(modelName) : compatModelInfo(modelName);
 
+  /// Embedder metadata for [embedderName] on this plugin instance, split the
+  /// same way [_infoFor] splits a model's.
+  Map<String, dynamic> _embedderInfoFor(String embedderName) => baseUrl == null
+      ? embedderInfoFor(embedderName)
+      : compatEmbedderInfo(embedderName);
+
   @override
   Action? resolve(ActionType actionType, String name) {
     if (actionType == .model) {
       return _createModel(name, null);
     }
+    if (actionType == .embedder) {
+      return _createEmbedder(name);
+    }
     return null;
+  }
+
+  /// Builds the embedder [embedderName] against `POST /v1/embeddings`.
+  ///
+  /// Like [_createModel], this resolves any name: an embedder released after
+  /// this version of the plugin, or one a compatible host serves under a name
+  /// OpenAI never used, works as soon as it is named.
+  Embedder _createEmbedder(String embedderName) {
+    return Embedder(
+      name: '$_pluginName/$embedderName',
+      customOptions: embed.embedderOptionsSchema(),
+      metadata: {
+        'model': {..._embedderInfoFor(embedderName)},
+      },
+      fn: (req, ctx) async {
+        if (req == null || req.input.isEmpty) {
+          // Nothing to embed, and an empty `input` is a 400. Answering
+          // directly keeps `embedMany([])` from costing a request.
+          return EmbedResponse(embeddings: []);
+        }
+
+        final options = embed.parseEmbedderOptions(req.options);
+        embed.validateEmbedderDimensions(embedderName, options.dimensions);
+        final inputs = embed.embeddingInputs(req.input);
+
+        final resolvedConfig = await _resolveClientConfig();
+        final client = sdk.OpenAIClient.withApiKey(
+          resolvedConfig.apiKey,
+          baseUrl: resolvedConfig.baseUrl,
+          defaultHeaders: resolvedConfig.headers,
+          httpClient: httpClient,
+        );
+
+        try {
+          // Batches go out one at a time rather than in parallel: a corpus
+          // large enough to need splitting is also large enough for a fan-out
+          // to trip the account's rate limit.
+          final embeddings = <Embedding>[];
+          for (final batch in embed.embeddingBatches(inputs)) {
+            final response = await client.embeddings.create(
+              sdk.EmbeddingRequest(
+                model: embedderName,
+                input: sdk.EmbeddingInput.textList(batch),
+                dimensions: options.dimensions,
+                user: options.user,
+              ),
+            );
+            embeddings.addAll(
+              embed.toGenkitEmbeddings(response, expectedCount: batch.length),
+            );
+          }
+          return EmbedResponse(embeddings: embeddings);
+        } catch (e, stackTrace) {
+          throw _toGenkitException(e, stackTrace);
+        } finally {
+          if (httpClient == null) {
+            client.close();
+          }
+        }
+      },
+    );
   }
 
   Model _createModel(String modelName, ModelInfo? info) {
@@ -322,31 +439,38 @@ class OpenAIPlugin extends GenkitPlugin {
             return await _handleNonStreaming(client, request);
           }
         } catch (e, stackTrace) {
-          if (e is GenkitException) {
-            rethrow;
-          }
-
-          StatusCodes? status;
-          String? details;
-
-          if (e is sdk.ApiException) {
-            status = StatusCodes.fromHttpStatus(e.statusCode);
-            details = e.body?.toString();
-          }
-
-          throw GenkitException(
-            'OpenAI API error: $e',
-            status: status,
-            details: details ?? e.toString(),
-            underlyingException: e,
-            stackTrace: stackTrace,
-          );
+          throw _toGenkitException(e, stackTrace);
         } finally {
           if (httpClient == null) {
             client.close();
           }
         }
       },
+    );
+  }
+
+  /// Maps a failure from the OpenAI SDK onto a [GenkitException], preserving
+  /// the HTTP status when there was one.
+  ///
+  /// Returned rather than thrown so the call sites keep their `throw`, which
+  /// is what tells the analyzer control flow ends there.
+  GenkitException _toGenkitException(Object e, StackTrace stackTrace) {
+    if (e is GenkitException) return e;
+
+    StatusCodes? status;
+    String? details;
+
+    if (e is sdk.ApiException) {
+      status = StatusCodes.fromHttpStatus(e.statusCode);
+      details = e.body?.toString();
+    }
+
+    return GenkitException(
+      'OpenAI API error: $e',
+      status: status,
+      details: details ?? e.toString(),
+      underlyingException: e,
+      stackTrace: stackTrace,
     );
   }
 

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -343,7 +343,14 @@ class OpenAIPlugin extends GenkitPlugin {
         }
 
         final options = embed.parseEmbedderOptions(req.options);
-        embed.validateEmbedderDimensions(embedderName, options.dimensions);
+        if (baseUrl == null) {
+          // Only OpenAI's own host is held to the catalog. Advertising a
+          // vector length that turns out wrong costs a bad number in the Dev
+          // UI; refusing a request the backend would have served costs the
+          // caller the feature outright, so the claim is worth less confidence
+          // when it is load-bearing than when it is advisory.
+          embed.validateEmbedderDimensions(embedderName, options.dimensions);
+        }
         final inputs = embed.embeddingInputs(req.input);
 
         final resolvedConfig = await _resolveClientConfig();
@@ -374,7 +381,10 @@ class OpenAIPlugin extends GenkitPlugin {
           }
           return EmbedResponse(embeddings: embeddings);
         } catch (e, stackTrace) {
-          throw _toGenkitException(e, stackTrace);
+          Error.throwWithStackTrace(
+            _toGenkitException(e, stackTrace),
+            stackTrace,
+          );
         } finally {
           if (httpClient == null) {
             client.close();
@@ -439,7 +449,10 @@ class OpenAIPlugin extends GenkitPlugin {
             return await _handleNonStreaming(client, request);
           }
         } catch (e, stackTrace) {
-          throw _toGenkitException(e, stackTrace);
+          Error.throwWithStackTrace(
+            _toGenkitException(e, stackTrace),
+            stackTrace,
+          );
         } finally {
           if (httpClient == null) {
             client.close();
@@ -452,8 +465,10 @@ class OpenAIPlugin extends GenkitPlugin {
   /// Maps a failure from the OpenAI SDK onto a [GenkitException], preserving
   /// the HTTP status when there was one.
   ///
-  /// Returned rather than thrown so the call sites keep their `throw`, which
-  /// is what tells the analyzer control flow ends there.
+  /// Returned rather than thrown, and rethrown by the call sites through
+  /// `Error.throwWithStackTrace`: a plain `throw` restamps the trace at the
+  /// throw site, which for an exception that was already a [GenkitException]
+  /// would lose the origin `rethrow` used to keep.
   GenkitException _toGenkitException(Object e, StackTrace stackTrace) {
     if (e is GenkitException) return e;
 

--- a/packages/genkit_openai/lib/src/utils.dart
+++ b/packages/genkit_openai/lib/src/utils.dart
@@ -23,7 +23,7 @@ final RegExp _gptPattern = RegExp(r'^gpt-\d+(\.\d+)?o?(?:-|$)');
 ///
 /// Returns one of the following model types:
 /// - 'chat': Chat completion models (gpt-4, gpt-4o, o1, etc.)
-/// - 'embedding': Text embedding models
+/// - 'embedding': Text embedding models (any id containing 'embed')
 /// - 'audio': Audio processing models (TTS, transcription, realtime)
 /// - 'image': Image generation models (DALL-E, gpt-image)
 /// - 'video': Video generation models (Sora)
@@ -47,7 +47,14 @@ String getModelType(String modelId) {
   }
 
   // Embedding models.
-  if (id.contains('embedding')) {
+  //
+  // Matched on `embed` rather than `embedding` for the compatible hosts:
+  // OpenAI's own embedders all spell it out, but `nomic-embed-text` and
+  // `mxbai-embed-large` do not, and a compat host's `/models` is the only
+  // place its embedders can come from - the curated catalog is withheld once
+  // a baseUrl is set. Names carrying neither (`bge-m3`, `all-minilm`) are
+  // still missed; nothing short of declaring them will catch those.
+  if (id.contains('embed')) {
     return 'embedding';
   }
 

--- a/packages/genkit_openai/test/discovery_client.dart
+++ b/packages/genkit_openai/test/discovery_client.dart
@@ -44,6 +44,19 @@ MockClient discoveryClient(List<String> requests, {List<String>? ids}) {
   });
 }
 
-/// The action names in a listing.
+/// The model names in a listing.
+///
+/// Filtered by action type: a listing also carries embedders, and a test
+/// asserting on an exact set of models should not have to spell them out.
 Set<String> modelNames(List<ActionMetadata> metadata) =>
-    metadata.map((m) => m.name).toSet();
+    _namesOf(metadata, ActionType.model);
+
+/// The embedder names in a listing.
+Set<String> embedderNames(List<ActionMetadata> metadata) =>
+    _namesOf(metadata, ActionType.embedder);
+
+Set<String> _namesOf(List<ActionMetadata> metadata, ActionType actionType) =>
+    metadata
+        .where((m) => m.actionType == actionType)
+        .map((m) => m.name)
+        .toSet();

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -387,6 +387,45 @@ void main() {
 
       await ai.shutdown();
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('embeds documents and honours the dimensions option', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+      final documents = [
+        DocumentData(content: [TextPart(text: 'The cat sat on the mat.')]),
+        DocumentData(
+          content: [TextPart(text: 'Paris is the capital of France.')],
+        ),
+      ];
+
+      final full = await ai.embedMany(
+        embedder: OpenAIEmbedders.textEmbedding3Small,
+        documents: documents,
+      );
+
+      // The vector length the catalog claims, checked against the API rather
+      // than against the catalog itself.
+      expect(full, hasLength(2));
+      expect(
+        full.first.embedding,
+        hasLength(KnownOpenAIEmbedder.textEmbedding3Small.dimensions),
+      );
+
+      final shortened = await ai.embed(
+        embedder: OpenAIEmbedders.textEmbedding3Small,
+        document: documents.first,
+        options: OpenAIEmbedderOptions(dimensions: 256),
+      );
+
+      expect(shortened.single.embedding, hasLength(256));
+
+      await ai.shutdown();
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
   });
 }
 

--- a/packages/genkit_openai/test/known_embedders_test.dart
+++ b/packages/genkit_openai/test/known_embedders_test.dart
@@ -1,0 +1,227 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:genkit/plugin.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:genkit_openai/src/known_embedders.dart'
+    show compatEmbedderInfo, embedderInfoFor;
+import 'package:genkit_openai/src/openai_plugin.dart';
+import 'package:test/test.dart';
+
+import 'discovery_client.dart';
+
+/// A plugin whose `GET /models` answers with [modelIds] and nothing else.
+OpenAIPlugin pluginListing(List<String> modelIds, {String? baseUrl}) =>
+    OpenAIPlugin(
+      apiKey: 'test-key',
+      baseUrl: baseUrl,
+      httpClient: discoveryClient([], ids: modelIds),
+    );
+
+void main() {
+  group('catalog invariants', () {
+    test('the exported collections cannot be mutated', () {
+      expect(() => knownEmbedderModels.add('x'), throwsUnsupportedError);
+      expect(
+        () => knownOpenAIEmbedders['x'] = <String, dynamic>{},
+        throwsUnsupportedError,
+      );
+    });
+
+    test('curated metadata is not mutable through the returned map', () {
+      expect(
+        () => embedderInfoFor('text-embedding-3-small')['dimensions'] = 1,
+        throwsUnsupportedError,
+      );
+    });
+
+    test('no two entries claim the same name', () {
+      final seen = <String>{};
+      for (final embedder in KnownOpenAIEmbedder.values) {
+        expect(seen, isNot(contains(embedder.id)), reason: embedder.id);
+        seen.add(embedder.id);
+      }
+    });
+
+    test('every entry claims a positive vector length', () {
+      for (final embedder in KnownOpenAIEmbedder.values) {
+        expect(embedder.dimensions, greaterThan(0), reason: embedder.id);
+      }
+    });
+
+    test('every listed embedder is one OpenAI still serves', () {
+      for (final embedder in KnownOpenAIEmbedder.values) {
+        expect(
+          knownEmbedderModels.contains(embedder.id),
+          embedder.stage != OpenAIModelStage.deprecated,
+          reason: embedder.id,
+        );
+      }
+    });
+  });
+
+  group('embedderInfoFor', () {
+    test('a curated embedder carries its label, size and stage', () {
+      final info = embedderInfoFor('text-embedding-3-small');
+
+      expect(info['label'], 'OpenAI text-embedding-3-small');
+      expect(info['dimensions'], 1536);
+      expect(info['stage'], 'stable');
+      expect(info['supports'], {
+        'input': ['text'],
+      });
+    });
+
+    test('lookup is case-insensitive', () {
+      expect(embedderInfoFor('TEXT-EMBEDDING-3-LARGE')['dimensions'], 3072);
+    });
+
+    test('an uncurated embedder claims text input and no size', () {
+      final info = embedderInfoFor('bge-large-en-embedding-v1.5');
+
+      expect(info.containsKey('dimensions'), isFalse);
+      expect(info.containsKey('label'), isFalse);
+      expect(info['supports'], {
+        'input': ['text'],
+      });
+    });
+
+    test('ada-002 is superseded but still served', () {
+      expect(
+        KnownOpenAIEmbedder.textEmbeddingAda002.stage,
+        OpenAIModelStage.legacy,
+      );
+      expect(knownEmbedderModels, contains('text-embedding-ada-002'));
+    });
+
+    test('only the -3- models take a shorter vector', () {
+      expect(KnownOpenAIEmbedder.textEmbedding3Small.dimensionsReducible, true);
+      expect(KnownOpenAIEmbedder.textEmbedding3Large.dimensionsReducible, true);
+      expect(
+        KnownOpenAIEmbedder.textEmbeddingAda002.dimensionsReducible,
+        false,
+      );
+    });
+  });
+
+  group('compatEmbedderInfo', () {
+    test('keeps the vector length and drops the deployment details', () {
+      final info = compatEmbedderInfo('text-embedding-3-small');
+
+      // A gateway routing this name to OpenAI returns 1536 dimensions, but
+      // OpenAI's label and retirement schedule are not the backend's.
+      expect(info['dimensions'], 1536);
+      expect(info.containsKey('label'), isFalse);
+      expect(info.containsKey('stage'), isFalse);
+    });
+
+    test('an uncurated name takes the dynamic defaults', () {
+      expect(compatEmbedderInfo('nomic-embedding-text'), {
+        'supports': {
+          'input': ['text'],
+        },
+      });
+    });
+  });
+
+  group('typed refs', () {
+    test('name the curated embedders under the default namespace', () {
+      expect(
+        OpenAIEmbedders.textEmbedding3Small.name,
+        'openai/text-embedding-3-small',
+      );
+      expect(
+        OpenAIEmbedders.textEmbeddingAda002.name,
+        'openai/text-embedding-ada-002',
+      );
+    });
+
+    test('cover every embedder OpenAI still serves', () {
+      // Nothing else fails when a catalog entry is added without a ref.
+      expect(
+        OpenAIEmbedders.all.map((r) => r.name).toSet(),
+        knownEmbedderModels.map((id) => 'openai/$id').toSet(),
+      );
+    });
+
+    test('match openAI.embedder() for the same id', () {
+      expect(
+        OpenAIEmbedders.textEmbedding3Large.name,
+        openAI.embedder(KnownOpenAIEmbedder.textEmbedding3Large.id).name,
+      );
+    });
+
+    test('carry the options schema', () {
+      expect(OpenAIEmbedders.textEmbedding3Small.customOptions, isNotNull);
+    });
+  });
+
+  group('list', () {
+    test('lists the curated embedders without discovery', () async {
+      final listing = await pluginListing(const []).list();
+
+      expect(
+        embedderNames(listing),
+        knownEmbedderModels.map((id) => 'openai/$id').toSet(),
+      );
+    });
+
+    test('a discovered embedder is listed as an embedder', () async {
+      final listing = await pluginListing(['text-embedding-4-turbo']).list();
+
+      expect(embedderNames(listing), contains('openai/text-embedding-4-turbo'));
+      expect(
+        listing
+            .where((m) => m.actionType == ActionType.model)
+            .map((m) => m.name),
+        isNot(contains('openai/text-embedding-4-turbo')),
+      );
+    });
+
+    test('a listed embedder carries its curated metadata', () async {
+      final listing = await pluginListing(const []).list();
+      final metadata = listing.firstWhere(
+        (m) => m.name == 'openai/text-embedding-3-large',
+      );
+      final info = (metadata.metadata['model'] as Map).cast<String, dynamic>();
+
+      expect(metadata.actionType, ActionType.embedder);
+      expect(info['label'], 'OpenAI text-embedding-3-large');
+      expect(info['dimensions'], 3072);
+      // Core's own keys survive alongside the curated ones.
+      expect(info['customOptions'], isNotNull);
+      expect(metadata.inputSchema, isNotNull);
+      expect(metadata.outputSchema, isNotNull);
+    });
+
+    test('a compat backend is left with what it reports', () async {
+      final listing = await pluginListing([
+        'text-embedding-3-small',
+      ], baseUrl: 'https://api.deepinfra.com/v1/openai').list();
+      final info =
+          (listing
+                      .firstWhere(
+                        (m) => m.name == 'openai/text-embedding-3-small',
+                      )
+                      .metadata['model']
+                  as Map)
+              .cast<String, dynamic>();
+
+      // The curated catalog is withheld, so only the discovered id is there.
+      expect(embedderNames(listing), {'openai/text-embedding-3-small'});
+      expect(info['dimensions'], 1536);
+      expect(info.containsKey('stage'), isFalse);
+    });
+  });
+}

--- a/packages/genkit_openai/test/known_models_test.dart
+++ b/packages/genkit_openai/test/known_models_test.dart
@@ -266,11 +266,17 @@ void main() {
         'whisper-1',
         'dall-e-3',
       ]).list();
-      final names = metadata.map((m) => m.name).toSet();
+      final models = modelNames(metadata);
 
-      expect(names, isNot(contains('openai/text-embedding-3-small')));
-      expect(names, isNot(contains('openai/whisper-1')));
-      expect(names, isNot(contains('openai/dall-e-3')));
+      // The embedder is listed, but as an embedder; the rest are modalities
+      // this plugin does not serve at all.
+      expect(models, isNot(contains('openai/text-embedding-3-small')));
+      expect(
+        embedderNames(metadata),
+        contains('openai/text-embedding-3-small'),
+      );
+      expect(models, isNot(contains('openai/whisper-1')));
+      expect(models, isNot(contains('openai/dall-e-3')));
     });
   });
 
@@ -294,8 +300,8 @@ void main() {
       expect(info['supports'], reasoningPreviewSupports);
     });
 
-    test('non-model action types do not resolve', () {
-      expect(pluginListing(const []).resolve(.embedder, 'gpt-4o'), isNull);
+    test('action types this plugin does not serve do not resolve', () {
+      expect(pluginListing(const []).resolve(.evaluator, 'gpt-4o'), isNull);
     });
   });
 }

--- a/packages/genkit_openai/test/openai_plugin_compat_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_compat_test.dart
@@ -32,8 +32,10 @@ import 'package:test/test.dart';
 
 import 'fake_openai_server.dart';
 
-Set<String> modelNames(List<ActionMetadata> metadata) =>
-    metadata.map((m) => m.name).toSet();
+Set<String> modelNames(List<ActionMetadata> metadata) => metadata
+    .where((m) => m.actionType == ActionType.model)
+    .map((m) => m.name)
+    .toSet();
 
 /// A Groq-shaped model definition, matching the README's example.
 /// Matches the failed response `generate()` returns for a model error.

--- a/packages/genkit_openai/test/openai_plugin_embed_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_embed_test.dart
@@ -228,6 +228,20 @@ void main() {
       );
     });
 
+    test('a failure keeps the stack trace of its origin', () async {
+      // The count-mismatch check throws from embed.dart; a plain `throw` at
+      // the plugin's catch site would restamp the trace there.
+      try {
+        await embedWith(
+          embeddingClient([], returnCount: 1),
+          documents: [doc('first'), doc('second')],
+        );
+        fail('expected a GenkitException');
+      } on GenkitException catch (_, stackTrace) {
+        expect(stackTrace.toString(), contains('embed.dart'));
+      }
+    });
+
     test('an API error keeps its HTTP status', () async {
       await expectLater(
         embedWith(
@@ -304,6 +318,31 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('a compat host judges its own limits', () async {
+      // The catalog describes OpenAI's models. A host serving one of those
+      // names need not share its limits, so the request goes through and the
+      // backend answers for itself.
+      final captured = <Map<String, dynamic>>[];
+      final ai = Genkit(
+        plugins: [
+          openAI(
+            apiKey: 'test-key',
+            baseUrl: 'https://api.deepinfra.com/v1/openai',
+            httpClient: embeddingClient(captured),
+          ),
+        ],
+      );
+      addTearDown(ai.shutdown);
+
+      await ai.embed(
+        embedder: openAI.embedder('text-embedding-ada-002'),
+        document: doc('hello'),
+        options: OpenAIEmbedderOptions(dimensions: 256),
+      );
+
+      expect(captured.single['dimensions'], 256);
     });
 
     test('an uncurated embedder is left to OpenAI to judge', () async {

--- a/packages/genkit_openai/test/openai_plugin_embed_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_embed_test.dart
@@ -1,0 +1,368 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:genkit_openai/src/openai_plugin.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Captures every embeddings request the plugin puts on the wire and answers
+/// with a vector per input, so tests can assert on the JSON actually sent.
+MockClient embeddingClient(
+  List<Map<String, dynamic>> capturedBodies, {
+  int dimensions = 4,
+  bool reverseOrder = false,
+  int? returnCount,
+  int statusCode = 200,
+  Object? errorBody,
+}) {
+  return MockClient((request) async {
+    if (!request.url.path.endsWith('/embeddings')) {
+      return http.Response('not found', 404);
+    }
+    final body = (jsonDecode(request.body) as Map).cast<String, dynamic>();
+    capturedBodies.add(body);
+
+    if (statusCode != 200) {
+      return http.Response(
+        jsonEncode(errorBody ?? {'error': 'nope'}),
+        statusCode,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+
+    final inputs = (body['input'] as List).length;
+    final count = returnCount ?? inputs;
+    final data = [
+      for (var i = 0; i < count; i++)
+        {
+          'object': 'embedding',
+          'index': i,
+          'embedding': [
+            for (var d = 0; d < (body['dimensions'] as int? ?? dimensions); d++)
+              i + d / 10,
+          ],
+        },
+    ];
+
+    return http.Response(
+      jsonEncode({
+        'object': 'list',
+        'model': body['model'],
+        'data': reverseOrder ? data.reversed.toList() : data,
+        'usage': {'prompt_tokens': 1, 'total_tokens': 1},
+      }),
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  });
+}
+
+DocumentData doc(String text) => DocumentData(content: [TextPart(text: text)]);
+
+Future<List<Embedding>> embedWith(
+  http.Client client, {
+  String embedderName = 'text-embedding-3-small',
+  required List<DocumentData> documents,
+  OpenAIEmbedderOptions? options,
+}) async {
+  final ai = Genkit(
+    plugins: [openAI(apiKey: 'test-key', httpClient: client)],
+  );
+  addTearDown(ai.shutdown);
+  return ai.embedMany(
+    embedder: openAI.embedder(embedderName),
+    documents: documents,
+    options: options,
+  );
+}
+
+void main() {
+  group('wire-level request assembly', () {
+    test('sends every document as one input array', () async {
+      final captured = <Map<String, dynamic>>[];
+      final embeddings = await embedWith(
+        embeddingClient(captured),
+        documents: [doc('first'), doc('second')],
+      );
+
+      expect(captured, hasLength(1));
+      expect(captured.single['model'], 'text-embedding-3-small');
+      expect(captured.single['input'], ['first', 'second']);
+      expect(embeddings, hasLength(2));
+      expect(embeddings.first.embedding, hasLength(4));
+    });
+
+    test('joins a document\'s text parts with newlines', () async {
+      final captured = <Map<String, dynamic>>[];
+      await embedWith(
+        embeddingClient(captured),
+        documents: [
+          DocumentData(
+            content: [
+              TextPart(text: 'one'),
+              TextPart(text: 'two'),
+            ],
+          ),
+        ],
+      );
+
+      expect(captured.single['input'], ['one\ntwo']);
+    });
+
+    test('drops media parts, which OpenAI cannot embed', () async {
+      final captured = <Map<String, dynamic>>[];
+      await embedWith(
+        embeddingClient(captured),
+        documents: [
+          DocumentData(
+            content: [
+              TextPart(text: 'a caption'),
+              MediaPart(media: Media(url: 'data:image/png;base64,AAA')),
+            ],
+          ),
+        ],
+      );
+
+      expect(captured.single['input'], ['a caption']);
+    });
+
+    test('sends dimensions and user when asked', () async {
+      final captured = <Map<String, dynamic>>[];
+      await embedWith(
+        embeddingClient(captured),
+        documents: [doc('hello')],
+        options: OpenAIEmbedderOptions(dimensions: 256, user: 'user-1'),
+      );
+
+      expect(captured.single['dimensions'], 256);
+      expect(captured.single['user'], 'user-1');
+    });
+
+    test('omits both when they are not set', () async {
+      final captured = <Map<String, dynamic>>[];
+      await embedWith(embeddingClient(captured), documents: [doc('hello')]);
+
+      expect(captured.single, isNot(contains('dimensions')));
+      expect(captured.single, isNot(contains('user')));
+    });
+
+    test('an empty document list costs no request', () async {
+      final captured = <Map<String, dynamic>>[];
+      final embeddings = await embedWith(
+        embeddingClient(captured),
+        documents: const [],
+      );
+
+      expect(captured, isEmpty);
+      expect(embeddings, isEmpty);
+    });
+  });
+
+  group('batching', () {
+    test('splits a corpus larger than one request allows', () async {
+      final captured = <Map<String, dynamic>>[];
+      final documents = [for (var i = 0; i < 2500; i++) doc('doc $i')];
+
+      final embeddings = await embedWith(
+        embeddingClient(captured),
+        documents: documents,
+      );
+
+      expect(captured, hasLength(2));
+      expect(captured[0]['input'] as List, hasLength(2048));
+      expect(captured[1]['input'] as List, hasLength(452));
+      expect((captured[1]['input'] as List).first, 'doc 2048');
+      expect(embeddings, hasLength(2500));
+    });
+
+    test('one batch below the limit stays one request', () async {
+      final captured = <Map<String, dynamic>>[];
+      await embedWith(
+        embeddingClient(captured),
+        documents: [for (var i = 0; i < 2048; i++) doc('doc $i')],
+      );
+
+      expect(captured, hasLength(1));
+    });
+  });
+
+  group('response handling', () {
+    test('orders vectors by the index OpenAI stamps on them', () async {
+      final embeddings = await embedWith(
+        embeddingClient([], reverseOrder: true),
+        documents: [doc('first'), doc('second'), doc('third')],
+      );
+
+      // The fake builds vector i as [i, i + 0.1, ...], so a mis-ordered
+      // response would put 2.0 first.
+      expect(embeddings.map((e) => e.embedding.first), [0.0, 1.0, 2.0]);
+    });
+
+    test('a short response is an error, not a silent misalignment', () async {
+      await expectLater(
+        embedWith(
+          embeddingClient([], returnCount: 1),
+          documents: [doc('first'), doc('second')],
+        ),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INTERNAL)
+              .having((e) => e.message, 'message', contains('2 input')),
+        ),
+      );
+    });
+
+    test('an API error keeps its HTTP status', () async {
+      await expectLater(
+        embedWith(
+          embeddingClient([], statusCode: 401),
+          documents: [doc('hello')],
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.UNAUTHENTICATED,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('input validation', () {
+    test('a document with no text names its index', () async {
+      final captured = <Map<String, dynamic>>[];
+
+      await expectLater(
+        embedWith(
+          embeddingClient(captured),
+          documents: [
+            doc('fine'),
+            DocumentData(
+              content: [
+                MediaPart(media: Media(url: 'data:image/png;base64,A')),
+              ],
+            ),
+          ],
+        ),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having((e) => e.message, 'message', contains('index 1')),
+        ),
+      );
+      expect(captured, isEmpty, reason: 'rejected before any request');
+    });
+
+    test('dimensions on a model that cannot shorten is rejected', () async {
+      final captured = <Map<String, dynamic>>[];
+
+      await expectLater(
+        embedWith(
+          embeddingClient(captured),
+          embedderName: 'text-embedding-ada-002',
+          documents: [doc('hello')],
+          options: OpenAIEmbedderOptions(dimensions: 256),
+        ),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having((e) => e.message, 'message', contains('1536')),
+        ),
+      );
+      expect(captured, isEmpty);
+    });
+
+    test('dimensions larger than the model returns is rejected', () async {
+      await expectLater(
+        embedWith(
+          embeddingClient([]),
+          documents: [doc('hello')],
+          options: OpenAIEmbedderOptions(dimensions: 4096),
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
+    test('an uncurated embedder is left to OpenAI to judge', () async {
+      final captured = <Map<String, dynamic>>[];
+      await embedWith(
+        embeddingClient(captured),
+        embedderName: 'text-embedding-4-turbo',
+        documents: [doc('hello')],
+        options: OpenAIEmbedderOptions(dimensions: 99999),
+      );
+
+      expect(captured.single['dimensions'], 99999);
+    });
+  });
+
+  group('resolve', () {
+    test('a curated embedder resolves with its catalog metadata', () {
+      final plugin = OpenAIPlugin(apiKey: 'test-key');
+      final action = plugin.resolve(.embedder, 'text-embedding-3-large');
+
+      expect(action, isA<Embedder>());
+      final info = (action!.metadata['model'] as Map).cast<String, dynamic>();
+      expect(info['label'], 'OpenAI text-embedding-3-large');
+      expect(info['dimensions'], 3072);
+    });
+
+    test('an uncurated embedder resolves without a size claim', () {
+      final plugin = OpenAIPlugin(apiKey: 'test-key');
+      final action = plugin.resolve(.embedder, 'text-embedding-4-turbo')!;
+
+      final info = (action.metadata['model'] as Map).cast<String, dynamic>();
+      expect(info.containsKey('dimensions'), isFalse);
+      // Embedder falls back to the action name for the label.
+      expect(info['label'], 'openai/text-embedding-4-turbo');
+    });
+
+    test('catalog metadata is not mutable through the action', () {
+      final plugin = OpenAIPlugin(apiKey: 'test-key');
+      final action = plugin.resolve(.embedder, 'text-embedding-3-small')!;
+      final info = (action.metadata['model'] as Map).cast<String, dynamic>();
+
+      // The action's own map is a copy - core writes the label and options
+      // schema into it - but the catalog entry it was built from is shared
+      // with every other resolution, so it must not be reachable for writing.
+      expect(
+        () => (info['supports'] as Map)['input'] = ['image'],
+        throwsUnsupportedError,
+      );
+    });
+
+    test('a custom namespace is honoured by the ref and the action', () {
+      final plugin = OpenAIPlugin(name: 'deepinfra', apiKey: 'test-key');
+      final action = plugin.resolve(.embedder, 'text-embedding-3-small')!;
+
+      expect(action.name, 'deepinfra/text-embedding-3-small');
+      expect(
+        openAI.embedder('text-embedding-3-small', namespace: 'deepinfra').name,
+        action.name,
+      );
+    });
+  });
+}

--- a/packages/genkit_openai/test/openai_plugin_startup_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_startup_test.dart
@@ -245,11 +245,14 @@ void main() {
         ),
       );
 
-      final names = modelNames(await plugin.list());
+      final listing = await plugin.list();
+      final models = modelNames(listing);
 
-      expect(names, contains('openai/gpt-4o'));
-      expect(names, isNot(contains('openai/text-embedding-3-small')));
-      expect(names, isNot(contains('openai/dall-e-3')));
+      expect(models, contains('openai/gpt-4o'));
+      // The embedder is listed under its own action type, not as a model.
+      expect(models, isNot(contains('openai/text-embedding-3-small')));
+      expect(embedderNames(listing), contains('openai/text-embedding-3-small'));
+      expect(models, isNot(contains('openai/dall-e-3')));
     });
   });
 

--- a/packages/genkit_openai/test/openai_plugin_utils_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_utils_test.dart
@@ -194,8 +194,16 @@ void main() {
       expect(getModelType('whisper-1'), 'audio');
     });
 
+    test('classifies embedders a compat host spells without -ing', () {
+      expect(getModelType('text-embedding-3-small'), 'embedding');
+      expect(getModelType('nomic-embed-text'), 'embedding');
+      expect(getModelType('mxbai-embed-large'), 'embedding');
+    });
+
     test('returns unknown for unrecognized models', () {
       expect(getModelType('my-custom-model'), 'unknown');
+      // Matching on `embed` misses a name that carries neither spelling.
+      expect(getModelType('bge-m3'), 'unknown');
     });
   });
 }


### PR DESCRIPTION
Embedding models were discovered and then thrown away. This ships them: `resolve()` builds an embedder for any name, `list()` routes embedding ids to embedder metadata instead of dropping them, and `openAI.embedder()` / `OpenAIEmbedders` give you refs.

The catalog is a `KnownOpenAIEmbedder` enum shaped like `KnownOpenAIModel` — id, label, vector length, and whether the model will return a shorter one. Three entries; checked `/v1/models` with a live key and that is still the whole lineup.

Dimensions metadata is the half #327 blocks. Until core has an `EmbedderInfo`, the values ride in the `model` metadata map that `embedderMetadata()` and `Embedder` already merge, under JS `EmbedderInfo`'s keys. That shape will change when #327 lands, which is why `embedderInfoFor` stayed in `src/` rather than becoming API.

Decisions worth naming: documents flatten to text and media parts are dropped (a document with no text at all is an error naming its index); more than 2048 documents split across requests sequentially rather than 400ing; a `dimensions` a curated model can't honour is rejected before the request goes out, but only against OpenAI's own host — a compat backend serving that name may not share the limit, so it answers for itself.

`getModelType` now matches `embed` rather than `embedding`, which is what makes `nomic-embed-text` and `mxbai-embed-large` land as embedders. A name carrying neither (`bge-m3`, `all-minilm`) is still missed, and nothing short of declaring it will catch that — a `CustomEmbedderDefinition` to match `CustomModelDefinition` is the follow-up. `resolve()` serves any of them by name meanwhile, so nothing is unreachable.

Tested live: vector lengths and `dimensions: 256` both hold against the API.

Closes #361.
