### PR TITLE
feat(genkit_openai): support reasoning effort, verbosity and reasoning output

### DIFF
--- a/packages/genkit_openai/README.md
+++ b/packages/genkit_openai/README.md
@@ -285,6 +285,49 @@ OpenAI's own hosting. The catalog is also not added to that host's listing:
 what a compatible provider lists is whatever its `/models` reports plus the
 models you register.
 
+## Reasoning
+
+The o-series and the GPT-5 family take a `reasoningEffort`, which trades latency
+and tokens against answer quality:
+
+```dart
+final response = await ai.generate(
+  model: OpenAIModels.o4Mini,
+  prompt: 'Prove it.',
+  config: OpenAIChatOptions(reasoningEffort: 'high'),
+);
+```
+
+Which of these levels a model accepts moves with the generation — `minimal`
+arrived with GPT-5, `none` replaced it in GPT-5.1, `xhigh` came later — so
+every level is offered to every reasoning model and OpenAI decides whether the
+pair makes sense. The set of levels itself is fixed by `openai_dart`, which
+models the parameter as an enum: a level OpenAI ships after this release needs
+an SDK bump to reach. What the plugin does check is the model:
+sending an effort to one that does not reason is rejected before the request
+goes out, naming the model rather than the parameter. Behind a custom `baseUrl`
+that check is skipped, since the catalog describes OpenAI's models and not that
+host's.
+
+`verbosity` is a separate GPT-5-family knob, controlling how much the model says
+rather than how hard it thinks.
+
+When a model returns its chain of thought, it arrives as a `ReasoningPart`
+ahead of the answer, and streams as it is produced:
+
+```dart
+await for (final chunk in ai.generateStream(model: ..., prompt: ...)) {
+  for (final part in chunk.content) {
+    if (part.isReasoning) stdout.write(part.reasoning);
+  }
+}
+```
+
+OpenAI's own models never return reasoning on the chat API — they bill it as
+reasoning tokens and keep it — so in practice this is a compatible-backend
+path: DeepSeek R1 and vLLM send `reasoning_content`, OpenRouter sends
+`reasoning`, and both are read.
+
 ## Options
 
 The `OpenAIChatOptions` class supports the following options:
@@ -300,6 +343,9 @@ The `OpenAIChatOptions` class supports the following options:
 - `jsonMode` (bool?) - Enable JSON mode
 - `visualDetailLevel` (String?, 'auto'|'low'|'high') - Visual detail level for images
 - `version` (String?) - Model version override
+- `reasoningEffort` (String?, 'none'|'minimal'|'low'|'medium'|'high'|'xhigh'|'max') -
+  How hard a reasoning model thinks before answering
+- `verbosity` (String?, 'low'|'medium'|'high') - How much the model says in its answer
 
 ## Custom Headers
 

--- a/packages/genkit_openai/lib/src/chat.dart
+++ b/packages/genkit_openai/lib/src/chat.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:genkit/plugin.dart';
 import 'package:openai_dart/openai_dart.dart';
 import 'package:schemantic/schemantic.dart';
 
@@ -57,6 +58,31 @@ abstract class $OpenAIChatOptions {
   /// Visual detail level for images ('auto', 'low', 'high')
   @StringField(enumValues: ['auto', 'low', 'high'])
   String? get visualDetailLevel;
+
+  /// How hard a reasoning model should think before answering.
+  ///
+  /// Accepted by the o-series and the GPT-5 family; a model that does not
+  /// reason rejects the parameter outright. Which of these levels a given
+  /// model takes moves with the generation — `minimal` arrived with GPT-5,
+  /// `none` replaced it in GPT-5.1, `xhigh` came later still — so every level
+  /// is offered to every reasoning model and OpenAI decides whether the pair
+  /// makes sense.
+  ///
+  /// The set itself is closed, and not by choice: `openai_dart` models
+  /// `reasoning_effort` as an enum, so a level newer than the SDK cannot be
+  /// put on the wire as anything but `unknown`. A level OpenAI ships after
+  /// this release needs an `openai_dart` bump to reach it.
+  @StringField(
+    enumValues: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+  )
+  String? get reasoningEffort;
+
+  /// How much the model should say in its answer.
+  ///
+  /// A GPT-5-family parameter, and unrelated to [reasoningEffort]: this
+  /// shortens or lengthens the reply, not the thinking behind it.
+  @StringField(enumValues: ['low', 'medium', 'high'])
+  String? get verbosity;
 }
 
 /// Alias for [OpenAIChatOptions].
@@ -89,6 +115,40 @@ ResponseFormat? buildOpenAIResponseFormat(Map<String, dynamic>? schema) {
 /// Returns custom options schema for standard chat models.
 SchemanticType<ChatModelOptions> chatModelOptionsSchema() =>
     OpenAIChatOptions.$schema;
+
+/// Maps a [ChatModelOptions.reasoningEffort] string onto the SDK enum.
+///
+/// `ReasoningEffort.fromJson` answers `unknown` for a value it does not
+/// recognise, which would go on the wire as `reasoning_effort: "unknown"` and
+/// come back as a confusing 400. Better to name the value that was actually
+/// wrong — whether it is a typo or a level newer than the SDK, which is the
+/// one case where the caller is right and the plugin is behind.
+ReasoningEffort? toReasoningEffort(String? value) {
+  if (value == null) return null;
+  final effort = ReasoningEffort.fromJson(value);
+  if (effort == ReasoningEffort.unknown) {
+    throw GenkitException(
+      'Unknown reasoningEffort "$value". Known levels: '
+      '${ReasoningEffort.values.where((e) => e != ReasoningEffort.unknown).map((e) => e.toJson()).join(', ')}.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+  return effort;
+}
+
+/// Maps a [ChatModelOptions.verbosity] string onto the SDK enum, rejecting an
+/// unrecognised level for the same reason [toReasoningEffort] does.
+Verbosity? toVerbosity(String? value) {
+  if (value == null) return null;
+  final verbosity = Verbosity.fromJson(value);
+  if (verbosity == Verbosity.unknown) {
+    throw GenkitException(
+      'Unknown verbosity "$value".',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+  return verbosity;
+}
 
 /// Parses chat-model options from action config.
 ChatModelOptions parseChatModelOptions(Map<String, dynamic>? config) {

--- a/packages/genkit_openai/lib/src/chat.dart
+++ b/packages/genkit_openai/lib/src/chat.dart
@@ -143,7 +143,8 @@ Verbosity? toVerbosity(String? value) {
   final verbosity = Verbosity.fromJson(value);
   if (verbosity == Verbosity.unknown) {
     throw GenkitException(
-      'Unknown verbosity "$value".',
+      'Unknown verbosity "$value". Known levels: '
+      '${Verbosity.values.where((v) => v != Verbosity.unknown).map((v) => v.toJson()).join(', ')}.',
       status: StatusCodes.INVALID_ARGUMENT,
     );
   }

--- a/packages/genkit_openai/lib/src/chat.g.dart
+++ b/packages/genkit_openai/lib/src/chat.g.dart
@@ -41,6 +41,8 @@ base class OpenAIChatOptions {
     String? user,
     bool? jsonMode,
     String? visualDetailLevel,
+    String? reasoningEffort,
+    String? verbosity,
   }) {
     _json = {
       'version': ?version,
@@ -54,6 +56,8 @@ base class OpenAIChatOptions {
       'user': ?user,
       'jsonMode': ?jsonMode,
       'visualDetailLevel': ?visualDetailLevel,
+      'reasoningEffort': ?reasoningEffort,
+      'verbosity': ?verbosity,
     };
   }
 
@@ -217,6 +221,52 @@ base class OpenAIChatOptions {
     }
   }
 
+  /// How hard a reasoning model should think before answering.
+  ///
+  /// Accepted by the o-series and the GPT-5 family; a model that does not
+  /// reason rejects the parameter outright. Which levels a given model takes
+  /// moves with the generation — `minimal` arrived with GPT-5, `none`
+  /// replaced it in GPT-5.1, `xhigh` came later still — so the full
+  /// vocabulary is offered here and OpenAI has the last word on the value.
+  String? get reasoningEffort {
+    return _json['reasoningEffort'] as String?;
+  }
+
+  /// How hard a reasoning model should think before answering.
+  ///
+  /// Accepted by the o-series and the GPT-5 family; a model that does not
+  /// reason rejects the parameter outright. Which levels a given model takes
+  /// moves with the generation — `minimal` arrived with GPT-5, `none`
+  /// replaced it in GPT-5.1, `xhigh` came later still — so the full
+  /// vocabulary is offered here and OpenAI has the last word on the value.
+  set reasoningEffort(String? value) {
+    if (value == null) {
+      _json.remove('reasoningEffort');
+    } else {
+      _json['reasoningEffort'] = value;
+    }
+  }
+
+  /// How much the model should say in its answer.
+  ///
+  /// A GPT-5-family parameter, and unrelated to [reasoningEffort]: this
+  /// shortens or lengthens the reply, not the thinking behind it.
+  String? get verbosity {
+    return _json['verbosity'] as String?;
+  }
+
+  /// How much the model should say in its answer.
+  ///
+  /// A GPT-5-family parameter, and unrelated to [reasoningEffort]: this
+  /// shortens or lengthens the reply, not the thinking behind it.
+  set verbosity(String? value) {
+    if (value == null) {
+      _json.remove('verbosity');
+    } else {
+      _json['verbosity'] = value;
+    }
+  }
+
   @override
   String toString() {
     return _json.toString();
@@ -256,6 +306,18 @@ base class _OpenAIChatOptionsTypeFactory
             'visualDetailLevel': $Schema.string(
               enumValues: ['auto', 'low', 'high'],
             ),
+            'reasoningEffort': $Schema.string(
+              enumValues: [
+                'none',
+                'minimal',
+                'low',
+                'medium',
+                'high',
+                'xhigh',
+                'max',
+              ],
+            ),
+            'verbosity': $Schema.string(enumValues: ['low', 'medium', 'high']),
           },
         )
         .value,

--- a/packages/genkit_openai/lib/src/chat.g.dart
+++ b/packages/genkit_openai/lib/src/chat.g.dart
@@ -224,10 +224,16 @@ base class OpenAIChatOptions {
   /// How hard a reasoning model should think before answering.
   ///
   /// Accepted by the o-series and the GPT-5 family; a model that does not
-  /// reason rejects the parameter outright. Which levels a given model takes
-  /// moves with the generation — `minimal` arrived with GPT-5, `none`
-  /// replaced it in GPT-5.1, `xhigh` came later still — so the full
-  /// vocabulary is offered here and OpenAI has the last word on the value.
+  /// reason rejects the parameter outright. Which of these levels a given
+  /// model takes moves with the generation — `minimal` arrived with GPT-5,
+  /// `none` replaced it in GPT-5.1, `xhigh` came later still — so every level
+  /// is offered to every reasoning model and OpenAI decides whether the pair
+  /// makes sense.
+  ///
+  /// The set itself is closed, and not by choice: `openai_dart` models
+  /// `reasoning_effort` as an enum, so a level newer than the SDK cannot be
+  /// put on the wire as anything but `unknown`. A level OpenAI ships after
+  /// this release needs an `openai_dart` bump to reach it.
   String? get reasoningEffort {
     return _json['reasoningEffort'] as String?;
   }
@@ -235,10 +241,16 @@ base class OpenAIChatOptions {
   /// How hard a reasoning model should think before answering.
   ///
   /// Accepted by the o-series and the GPT-5 family; a model that does not
-  /// reason rejects the parameter outright. Which levels a given model takes
-  /// moves with the generation — `minimal` arrived with GPT-5, `none`
-  /// replaced it in GPT-5.1, `xhigh` came later still — so the full
-  /// vocabulary is offered here and OpenAI has the last word on the value.
+  /// reason rejects the parameter outright. Which of these levels a given
+  /// model takes moves with the generation — `minimal` arrived with GPT-5,
+  /// `none` replaced it in GPT-5.1, `xhigh` came later still — so every level
+  /// is offered to every reasoning model and OpenAI decides whether the pair
+  /// makes sense.
+  ///
+  /// The set itself is closed, and not by choice: `openai_dart` models
+  /// `reasoning_effort` as an enum, so a level newer than the SDK cannot be
+  /// put on the wire as anything but `unknown`. A level OpenAI ships after
+  /// this release needs an `openai_dart` bump to reach it.
   set reasoningEffort(String? value) {
     if (value == null) {
       _json.remove('reasoningEffort');

--- a/packages/genkit_openai/lib/src/converters.dart
+++ b/packages/genkit_openai/lib/src/converters.dart
@@ -245,6 +245,12 @@ abstract final class GenkitConverter {
   static Message fromOpenAIAssistantMessage(sdk.AssistantMessage msg) {
     final parts = <Part>[];
 
+    // Reasoning comes before the answer it produced, so it leads the content.
+    final reasoning = reasoningTextOf(msg.reasoningContent, msg.reasoning);
+    if (reasoning != null) {
+      parts.add(ReasoningPart(reasoning: reasoning));
+    }
+
     // Handle refusal
     if (msg.refusal != null && msg.refusal!.isNotEmpty) {
       parts.add(TextPart(text: '[Refusal] ${msg.refusal}'));
@@ -274,6 +280,24 @@ abstract final class GenkitConverter {
     }
 
     return Message(role: Role.model, content: parts);
+  }
+
+  /// The reasoning text carried by an assistant message or a stream delta.
+  ///
+  /// Two spellings reach this plugin and neither is OpenAI's: `reasoning` is
+  /// what OpenRouter emits, `reasoning_content` what DeepSeek R1 and vLLM do.
+  /// OpenAI's own models never return their chain of thought on the chat API
+  /// at all - they bill it as reasoning tokens and keep it - so this is
+  /// entirely a compatible-backend path.
+  ///
+  /// Both are read because a gateway in front of several providers passes
+  /// through whichever its upstream used. When both are present they are the
+  /// same text under two names, so the first wins rather than being joined.
+  static String? reasoningTextOf(String? reasoningContent, String? reasoning) {
+    for (final candidate in [reasoningContent, reasoning]) {
+      if (candidate != null && candidate.isNotEmpty) return candidate;
+    }
+    return null;
   }
 
   /// Map OpenAI finish reason to Genkit FinishReason

--- a/packages/genkit_openai/lib/src/known_models.dart
+++ b/packages/genkit_openai/lib/src/known_models.dart
@@ -176,45 +176,66 @@ enum OpenAIModelStage {
 enum KnownOpenAIModel {
   // GPT-5.6, the current frontier family. No dated snapshots yet; the bare
   // `gpt-5.6` alias routes to sol and resolves dynamically.
-  gpt56Sol('gpt-5.6-sol', 'OpenAI GPT-5.6 Sol', multimodalSupports),
-  gpt56Terra('gpt-5.6-terra', 'OpenAI GPT-5.6 Terra', multimodalSupports),
-  gpt56Luna('gpt-5.6-luna', 'OpenAI GPT-5.6 Luna', multimodalSupports),
+  gpt56Sol(
+    'gpt-5.6-sol',
+    'OpenAI GPT-5.6 Sol',
+    multimodalSupports,
+    reasons: true,
+  ),
+  gpt56Terra(
+    'gpt-5.6-terra',
+    'OpenAI GPT-5.6 Terra',
+    multimodalSupports,
+    reasons: true,
+  ),
+  gpt56Luna(
+    'gpt-5.6-luna',
+    'OpenAI GPT-5.6 Luna',
+    multimodalSupports,
+    reasons: true,
+  ),
 
   gpt55(
     'gpt-5.5',
     'OpenAI GPT-5.5',
     multimodalSupports,
     snapshots: ['gpt-5.5-2026-04-23'],
+    reasons: true,
   ),
   gpt54(
     'gpt-5.4',
     'OpenAI GPT-5.4',
     multimodalSupports,
     snapshots: ['gpt-5.4-2026-03-05'],
+    reasons: true,
   ),
   gpt54Mini(
     'gpt-5.4-mini',
     'OpenAI GPT-5.4-mini',
     multimodalSupports,
     snapshots: ['gpt-5.4-mini-2026-03-17'],
+    reasons: true,
   ),
   gpt54Nano(
     'gpt-5.4-nano',
     'OpenAI GPT-5.4-nano',
     multimodalSupports,
     snapshots: ['gpt-5.4-nano-2026-03-17'],
+    reasons: true,
   ),
   gpt52(
     'gpt-5.2',
     'OpenAI GPT-5.2',
     multimodalSupports,
     snapshots: ['gpt-5.2-2025-12-11'],
+    reasons: true,
   ),
   gpt51(
     'gpt-5.1',
     'OpenAI GPT-5.1',
     multimodalSupports,
     snapshots: ['gpt-5.1-2025-11-13'],
+    reasons: true,
   ),
 
   // GPT-5. The dated snapshots shut down 2026-12-11; the aliases stay.
@@ -223,18 +244,21 @@ enum KnownOpenAIModel {
     'OpenAI GPT-5',
     multimodalSupports,
     snapshots: ['gpt-5-2025-08-07'],
+    reasons: true,
   ),
   gpt5Mini(
     'gpt-5-mini',
     'OpenAI GPT-5-mini',
     multimodalSupports,
     snapshots: ['gpt-5-mini-2025-08-07'],
+    reasons: true,
   ),
   gpt5Nano(
     'gpt-5-nano',
     'OpenAI GPT-5-nano',
     multimodalSupports,
     snapshots: ['gpt-5-nano-2025-08-07'],
+    reasons: true,
   ),
   // The ChatGPT-tuned GPT-5 snapshot: no function calling.
   gpt5ChatLatest(
@@ -299,13 +323,20 @@ enum KnownOpenAIModel {
 
   // Reasoning models. o1, o3-mini, and o4-mini shut down 2026-10-23;
   // o3-2025-04-16 shuts down 2026-12-11.
-  o3('o3', 'OpenAI o3', reasoningSupports, snapshots: ['o3-2025-04-16']),
+  o3(
+    'o3',
+    'OpenAI o3',
+    reasoningSupports,
+    snapshots: ['o3-2025-04-16'],
+    reasons: true,
+  ),
   o4Mini(
     'o4-mini',
     'OpenAI o4-mini',
     reasoningSupports,
     snapshots: ['o4-mini-2025-04-16'],
     stage: OpenAIModelStage.legacy,
+    reasons: true,
   ),
   o3Mini(
     'o3-mini',
@@ -313,6 +344,7 @@ enum KnownOpenAIModel {
     reasoningTextOnlySupports,
     snapshots: ['o3-mini-2025-01-31'],
     stage: OpenAIModelStage.legacy,
+    reasons: true,
   ),
   o1(
     'o1',
@@ -320,9 +352,11 @@ enum KnownOpenAIModel {
     reasoningSupports,
     snapshots: ['o1-2024-12-17'],
     stage: OpenAIModelStage.legacy,
+    reasons: true,
   ),
-  // o1-mini and o1-preview never had function calling on the chat API. Both
-  // are retired; curated so the names still resolve honestly.
+  // o1-mini and o1-preview never had function calling on the chat API, and
+  // predate `reasoning_effort` - they reason, but the level is not settable.
+  // Both are retired; curated so the names still resolve honestly.
   o1Mini(
     'o1-mini',
     'OpenAI o1-mini',
@@ -407,6 +441,7 @@ enum KnownOpenAIModel {
     this.supports, {
     this.snapshots = const [],
     this.stage = OpenAIModelStage.stable,
+    this.reasons = false,
   });
 
   /// Bare model name (no plugin prefix).
@@ -424,6 +459,20 @@ enum KnownOpenAIModel {
   /// Lifecycle stage, which decides whether the plugin registers this model
   /// as an action as well as how it describes it.
   final OpenAIModelStage stage;
+
+  /// Whether the model thinks before answering, and so accepts
+  /// `reasoning_effort`.
+  ///
+  /// A model that does not reason rejects the parameter outright, which is
+  /// the whole reason this is curated: setting an effort once in a shared
+  /// config and then switching models is an easy mistake, and a 400 naming
+  /// only the parameter does not say which of the two is wrong.
+  ///
+  /// Deliberately a flag and not a list of levels. Which levels a model takes
+  /// moves with the generation, and enumerating that per entry would be
+  /// guessing at values OpenAI can change under us; the value itself is left
+  /// for the API to judge.
+  final bool reasons;
 
   /// Every name that resolves to this model: the alias followed by its dated
   /// snapshots, newest first. Surfaced as `ModelInfo.versions`.

--- a/packages/genkit_openai/lib/src/openai_plugin.dart
+++ b/packages/genkit_openai/lib/src/openai_plugin.dart
@@ -277,6 +277,15 @@ class OpenAIPlugin extends GenkitPlugin {
       fn: (req, ctx) async {
         final modelRequest = req!;
         final options = chat.parseChatModelOptions(modelRequest.config);
+        // `version` overrides the resolved action's id, so it - not
+        // [modelName] - is the model that will answer, and the model the
+        // catalog has to be asked about.
+        final wireModel = options.version ?? modelName;
+        if (baseUrl == null) {
+          // Same rule the embedders follow: the catalog describes OpenAI's
+          // models, so it only judges requests bound for OpenAI's own host.
+          _requireReasoningSupport(wireModel, options.reasoningEffort);
+        }
 
         final resolvedConfig = await _resolveClientConfig();
         final client = sdk.OpenAIClient.withApiKey(
@@ -299,7 +308,7 @@ class OpenAIPlugin extends GenkitPlugin {
             modelRequest.output?.schema,
           );
           final request = sdk.ChatCompletionCreateRequest(
-            model: options.version ?? modelName,
+            model: wireModel,
             messages: GenkitConverter.toOpenAIMessages(
               modelRequest.messages,
               options.visualDetailLevel,
@@ -315,6 +324,8 @@ class OpenAIPlugin extends GenkitPlugin {
             seed: options.seed,
             user: options.user,
             responseFormat: isJsonMode ? responseFormat : null,
+            reasoningEffort: chat.toReasoningEffort(options.reasoningEffort),
+            verbosity: chat.toVerbosity(options.verbosity),
           );
           if (ctx.streamingRequested) {
             return await _handleStreaming(client, request, ctx);
@@ -350,6 +361,33 @@ class OpenAIPlugin extends GenkitPlugin {
     );
   }
 
+  /// Rejects a `reasoningEffort` aimed at a model that does not reason.
+  ///
+  /// OpenAI answers one with `Unsupported parameter: 'reasoning_effort'`,
+  /// which names the parameter but not the model - and the model is the half
+  /// that is usually wrong, since an effort is typically set once in a shared
+  /// config and then inherited by whatever model the call picks.
+  ///
+  /// Only curated models are judged. An uncurated name has no claim to judge
+  /// against, and a model released after this version of the plugin must not
+  /// be refused a parameter it may well accept.
+  ///
+  /// `verbosity` gets no equivalent guard, and its 400 is just as terse. It is
+  /// a GPT-5-family parameter, but the catalog carries no flag saying so, and
+  /// adding one would mean asserting per entry something less well documented
+  /// than which models reason. Left to the API rather than guessed at.
+  void _requireReasoningSupport(String modelName, String? reasoningEffort) {
+    if (reasoningEffort == null) return;
+    final curated = knownOpenAIModelFor(modelName);
+    if (curated == null || curated.reasons) return;
+
+    throw GenkitException(
+      '${curated.id} does not accept reasoningEffort; it is not a reasoning '
+      'model.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
+
   /// Handle streaming response
   Future<ModelResponse> _handleStreaming(
     sdk.OpenAIClient client,
@@ -365,6 +403,23 @@ class OpenAIPlugin extends GenkitPlugin {
     try {
       await for (final chunk in stream) {
         accumulator.add(chunk);
+
+        // Reasoning streams ahead of the answer, so it is forwarded as it
+        // arrives rather than held back until the final message - watching a
+        // reasoning model think is most of why its stream is worth reading.
+        final delta = chunk.choices?.firstOrNull?.delta;
+        final reasoningDelta = GenkitConverter.reasoningTextOf(
+          delta?.reasoningContent,
+          delta?.reasoning,
+        );
+        if (reasoningDelta != null) {
+          ctx.sendChunk(
+            ModelResponseChunk(
+              index: 0,
+              content: [ReasoningPart(reasoning: reasoningDelta)],
+            ),
+          );
+        }
 
         final textDelta = chunk.textDelta;
         if (textDelta != null) {

--- a/packages/genkit_openai/test/integration_test.dart
+++ b/packages/genkit_openai/test/integration_test.dart
@@ -335,6 +335,90 @@ void main() {
       expect(response.text.toLowerCase(), contains('hello'));
     }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
 
+    test('reasoning effort reaches a reasoning model', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      // The mocks prove the parameter reaches the wire; only OpenAI can say
+      // whether it accepts the level for this model.
+      final response = await ai.generate(
+        model: OpenAIModels.o4Mini,
+        prompt: 'What is 17 * 23? Answer with the number only.',
+        config: OpenAIChatOptions(reasoningEffort: 'low'),
+      );
+
+      expect(response.text, contains('391'));
+      // Reasoning models bill their thinking separately, so a low effort
+      // still shows up in the usage breakdown.
+      expect(response.usage?.outputTokens, greaterThan(0));
+
+      await ai.shutdown();
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('verbosity reaches the GPT-5 family', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      final response = await ai.generate(
+        model: OpenAIModels.gpt5Mini,
+        prompt: 'Name the capital of France.',
+        config: OpenAIChatOptions(verbosity: 'low', reasoningEffort: 'low'),
+      );
+
+      expect(response.text.toLowerCase(), contains('paris'));
+
+      await ai.shutdown();
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
+    test('a model that does not reason rejects an effort', () async {
+      if (apiKey == null || apiKey.isEmpty) {
+        fail(
+          'OPENAI_API_KEY environment variable must be set to run integration tests',
+        );
+      }
+
+      final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+
+      // The plugin refuses this before the request goes out. The live value
+      // of the test is the other half: that OpenAI would have refused it too,
+      // so the local check is not inventing a restriction.
+      final local = await ai.generate(
+        model: OpenAIModels.gpt4o,
+        prompt: 'hi',
+        config: OpenAIChatOptions(reasoningEffort: 'high'),
+      );
+      expect(local.finishReason, FinishReason.failed);
+      expect(local.error?.status, StatusCodes.INVALID_ARGUMENT.name);
+
+      // The same request with the guard bypassed. Naming OpenAI's own host as
+      // a baseUrl is the documented way to opt out of the catalog's judgement,
+      // so this reaches the API and OpenAI answers for itself.
+      final direct = Genkit(
+        plugins: [openAI(apiKey: apiKey, baseUrl: 'https://api.openai.com/v1')],
+      );
+      final remote = await direct.generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'hi',
+        config: OpenAIChatOptions(reasoningEffort: 'high'),
+      );
+
+      expect(remote.finishReason, FinishReason.failed);
+      expect(remote.error?.message, contains('reasoning_effort'));
+
+      await direct.shutdown();
+      await ai.shutdown();
+    }, skip: apiKey == null || apiKey.isEmpty ? 'OPENAI_API_KEY not set' : null);
+
     test('discovery enriches the curated catalog', () async {
       if (apiKey == null || apiKey.isEmpty) {
         fail(

--- a/packages/genkit_openai/test/known_models_test.dart
+++ b/packages/genkit_openai/test/known_models_test.dart
@@ -45,6 +45,46 @@ void main() {
       );
     });
 
+    test(
+      'every o-series model with settable effort is marked as reasoning',
+      () {
+        // Catches an o-series entry added without `reasons`, which would then
+        // be refused a parameter it accepts. The preview pair is excluded: they
+        // reason, but predate `reasoning_effort`.
+        for (final model in KnownOpenAIModel.values) {
+          if (model.supports != reasoningSupports &&
+              model.supports != reasoningTextOnlySupports) {
+            continue;
+          }
+          expect(model.reasons, isTrue, reason: model.id);
+        }
+      },
+    );
+
+    test('the GPT-5 family reasons, bar the ChatGPT-tuned snapshot', () {
+      for (final model in KnownOpenAIModel.values) {
+        if (!model.id.startsWith('gpt-5')) continue;
+        expect(
+          model.reasons,
+          model.id != 'gpt-5-chat-latest',
+          reason: model.id,
+        );
+      }
+    });
+
+    test('no model that predates reasoning claims to reason', () {
+      for (final id in [
+        'gpt-4o',
+        'gpt-4.1',
+        'gpt-4-turbo',
+        'gpt-3.5-turbo',
+        'o1-mini',
+        'o1-preview',
+      ]) {
+        expect(knownOpenAIModelFor(id)!.reasons, isFalse, reason: id);
+      }
+    });
+
     test('no two entries claim the same name', () {
       final seen = <String, String>{};
       for (final model in KnownOpenAIModel.values) {

--- a/packages/genkit_openai/test/openai_plugin_reasoning_test.dart
+++ b/packages/genkit_openai/test/openai_plugin_reasoning_test.dart
@@ -1,0 +1,340 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Answers chat completions with an optional reasoning payload, recording the
+/// request bodies the plugin sent.
+MockClient reasoningClient(
+  List<Map<String, dynamic>> capturedBodies, {
+  String? reasoningContent,
+  String? reasoning,
+  List<String>? sseFrames,
+}) {
+  return MockClient((request) async {
+    if (!request.url.path.endsWith('/chat/completions')) {
+      return http.Response('not found', 404);
+    }
+    capturedBodies.add(
+      (jsonDecode(request.body) as Map).cast<String, dynamic>(),
+    );
+
+    if (sseFrames != null) {
+      final body = sseFrames.map((f) => 'data: $f\n\n').join();
+      return http.Response(
+        '${body}data: [DONE]\n\n',
+        200,
+        headers: {'content-type': 'text/event-stream'},
+      );
+    }
+
+    return http.Response(
+      jsonEncode({
+        'id': 'chatcmpl-test',
+        'object': 'chat.completion',
+        'created': 0,
+        'model': 'o4-mini',
+        'choices': [
+          {
+            'index': 0,
+            'message': {
+              'role': 'assistant',
+              'content': 'the answer',
+              'reasoning_content': ?reasoningContent,
+              'reasoning': ?reasoning,
+            },
+            'finish_reason': 'stop',
+          },
+        ],
+      }),
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  });
+}
+
+/// Matches the failed response `generate()` returns for a request error.
+///
+/// The action layer still throws; `ai.generate()` reports the failure on the
+/// response instead (see #413), so a rejected `reasoningEffort` lands here.
+Matcher failsWith(StatusCodes status, {String? message}) =>
+    isA<GenerateResponse>()
+        .having((r) => r.finishReason, 'finishReason', FinishReason.failed)
+        .having((r) => r.error?.status, 'error.status', status.name)
+        .having(
+          (r) => r.error?.message ?? '',
+          'error.message',
+          message == null ? anything : contains(message),
+        );
+
+/// The reasoning text a response carries, or null when it carries none.
+String? reasoningOf(GenerateResponseHelper<dynamic> response) => response
+    .message
+    ?.content
+    .firstWhere((p) => p.isReasoning, orElse: () => TextPart(text: ''))
+    .reasoning;
+
+Genkit genkitWith(http.Client client, {String? baseUrl}) {
+  final ai = Genkit(
+    plugins: [openAI(apiKey: 'test-key', baseUrl: baseUrl, httpClient: client)],
+  );
+  addTearDown(ai.shutdown);
+  return ai;
+}
+
+void main() {
+  group('reasoning effort on the wire', () {
+    test('reaches the request for a reasoning model', () async {
+      final captured = <Map<String, dynamic>>[];
+      await genkitWith(reasoningClient(captured)).generate(
+        model: openAI.model('o4-mini'),
+        prompt: 'think',
+        config: OpenAIChatOptions(reasoningEffort: 'high'),
+      );
+
+      expect(captured.single['reasoning_effort'], 'high');
+    });
+
+    test('reaches the request for the GPT-5 family', () async {
+      final captured = <Map<String, dynamic>>[];
+      await genkitWith(reasoningClient(captured)).generate(
+        model: OpenAIModels.gpt5Mini,
+        prompt: 'think',
+        config: OpenAIChatOptions(reasoningEffort: 'minimal'),
+      );
+
+      expect(captured.single['reasoning_effort'], 'minimal');
+    });
+
+    test('every level the API knows is sendable', () async {
+      // The vocabulary moves per model generation, so the plugin forwards it
+      // rather than judging it - `none` arrived with GPT-5.1, `xhigh` later.
+      for (final effort in ['none', 'low', 'medium', 'high', 'xhigh', 'max']) {
+        final captured = <Map<String, dynamic>>[];
+        await genkitWith(reasoningClient(captured)).generate(
+          model: OpenAIModels.gpt56Sol,
+          prompt: 'think',
+          config: OpenAIChatOptions(reasoningEffort: effort),
+        );
+
+        expect(captured.single['reasoning_effort'], effort);
+      }
+    });
+
+    test('is omitted when unset', () async {
+      final captured = <Map<String, dynamic>>[];
+      await genkitWith(
+        reasoningClient(captured),
+      ).generate(model: openAI.model('o4-mini'), prompt: 'hi');
+
+      expect(captured.single, isNot(contains('reasoning_effort')));
+      expect(captured.single, isNot(contains('verbosity')));
+    });
+
+    test('verbosity reaches the request', () async {
+      final captured = <Map<String, dynamic>>[];
+      await genkitWith(reasoningClient(captured)).generate(
+        model: OpenAIModels.gpt5,
+        prompt: 'hi',
+        config: OpenAIChatOptions(verbosity: 'low'),
+      );
+
+      expect(captured.single['verbosity'], 'low');
+    });
+  });
+
+  group('reasoning effort validation', () {
+    test('a model that does not reason is named, not the parameter', () async {
+      final captured = <Map<String, dynamic>>[];
+
+      await expectLater(
+        genkitWith(reasoningClient(captured)).generate(
+          model: OpenAIModels.gpt4o,
+          prompt: 'hi',
+          config: OpenAIChatOptions(reasoningEffort: 'high'),
+        ),
+        completion(failsWith(StatusCodes.INVALID_ARGUMENT, message: 'gpt-4o')),
+      );
+      expect(captured, isEmpty, reason: 'rejected before any request');
+    });
+
+    test('o1-mini predates the parameter and is rejected', () async {
+      await expectLater(
+        genkitWith(reasoningClient([])).generate(
+          model: openAI.model('o1-mini'),
+          prompt: 'hi',
+          config: OpenAIChatOptions(reasoningEffort: 'low'),
+        ),
+        completion(failsWith(StatusCodes.INVALID_ARGUMENT, message: 'o1-mini')),
+      );
+    });
+
+    test('an uncurated model is left to OpenAI to judge', () async {
+      final captured = <Map<String, dynamic>>[];
+      await genkitWith(reasoningClient(captured)).generate(
+        model: openAI.model('o7-preview'),
+        prompt: 'hi',
+        config: OpenAIChatOptions(reasoningEffort: 'max'),
+      );
+
+      expect(captured.single['reasoning_effort'], 'max');
+    });
+
+    test('version is the model judged, not the action id', () async {
+      // `version` overrides the model that answers, so it is the one the
+      // catalog has to be asked about - both ways round.
+      final captured = <Map<String, dynamic>>[];
+
+      await expectLater(
+        genkitWith(reasoningClient(captured)).generate(
+          model: OpenAIModels.o4Mini,
+          prompt: 'hi',
+          config: OpenAIChatOptions(version: 'gpt-4o', reasoningEffort: 'high'),
+        ),
+        completion(failsWith(StatusCodes.INVALID_ARGUMENT, message: 'gpt-4o')),
+      );
+      expect(captured, isEmpty);
+
+      // And the reverse: a reasoning `version` behind a non-reasoning action
+      // is allowed through, because that is the model that will answer.
+      await genkitWith(reasoningClient(captured)).generate(
+        model: OpenAIModels.gpt4o,
+        prompt: 'hi',
+        config: OpenAIChatOptions(version: 'o3', reasoningEffort: 'high'),
+      );
+
+      expect(captured.single['model'], 'o3');
+      expect(captured.single['reasoning_effort'], 'high');
+    });
+
+    test('a compat host judges its own models', () async {
+      // gpt-4o behind a gateway may be a fine-tune or a rename; the catalog
+      // describes OpenAI's deployment, not that host's.
+      final captured = <Map<String, dynamic>>[];
+      await genkitWith(
+        reasoningClient(captured),
+        baseUrl: 'https://openrouter.ai/api/v1',
+      ).generate(
+        model: openAI.model('gpt-4o'),
+        prompt: 'hi',
+        config: OpenAIChatOptions(reasoningEffort: 'high'),
+      );
+
+      expect(captured.single['reasoning_effort'], 'high');
+    });
+
+    test('an unknown level is the caller\'s mistake', () async {
+      await expectLater(
+        genkitWith(reasoningClient([])).generate(
+          model: openAI.model('o4-mini'),
+          prompt: 'hi',
+          config: OpenAIChatOptions(reasoningEffort: 'extreme'),
+        ),
+        completion(
+          failsWith(StatusCodes.INVALID_ARGUMENT, message: 'Known levels'),
+        ),
+      );
+    });
+  });
+
+  group('reasoning in the response', () {
+    test('reasoning_content becomes a ReasoningPart', () async {
+      final response = await genkitWith(
+        reasoningClient([], reasoningContent: 'step one, step two'),
+      ).generate(model: openAI.model('deepseek-reasoner'), prompt: 'hi');
+
+      expect(reasoningOf(response), 'step one, step two');
+      expect(response.text, 'the answer');
+    });
+
+    test('reasoning is read too, for the gateways that use it', () async {
+      final response = await genkitWith(
+        reasoningClient([], reasoning: 'thinking out loud'),
+      ).generate(model: openAI.model('some-router-model'), prompt: 'hi');
+
+      expect(reasoningOf(response), 'thinking out loud');
+    });
+
+    test('reasoning leads the content, ahead of the answer', () async {
+      final response = await genkitWith(
+        reasoningClient([], reasoningContent: 'because'),
+      ).generate(model: openAI.model('deepseek-reasoner'), prompt: 'hi');
+
+      expect(response.message!.content.first.isReasoning, isTrue);
+      expect(response.message!.content.last.isText, isTrue);
+    });
+
+    test('a response without reasoning carries no ReasoningPart', () async {
+      final response = await genkitWith(
+        reasoningClient([]),
+      ).generate(model: openAI.model('gpt-4o'), prompt: 'hi');
+
+      expect(response.message!.content.any((p) => p.isReasoning), isFalse);
+    });
+  });
+
+  group('reasoning while streaming', () {
+    test('deltas are forwarded as they arrive', () async {
+      final frames = [
+        jsonEncode({
+          'id': 'c',
+          'object': 'chat.completion.chunk',
+          'created': 0,
+          'model': 'deepseek-reasoner',
+          'choices': [
+            {
+              'index': 0,
+              'delta': {'reasoning_content': 'first thought'},
+            },
+          ],
+        }),
+        jsonEncode({
+          'id': 'c',
+          'object': 'chat.completion.chunk',
+          'created': 0,
+          'model': 'deepseek-reasoner',
+          'choices': [
+            {
+              'index': 0,
+              'delta': {'content': 'the answer'},
+              'finish_reason': 'stop',
+            },
+          ],
+        }),
+      ];
+
+      final chunks = <List<Part>>[];
+      final stream = genkitWith(
+        reasoningClient([], sseFrames: frames),
+      ).generateStream(model: openAI.model('deepseek-reasoner'), prompt: 'hi');
+      await for (final chunk in stream) {
+        chunks.add(chunk.content);
+      }
+      final response = await stream.onResult;
+
+      // The thought arrives before the answer, not bundled in after it.
+      expect(chunks.first.first.isReasoning, isTrue);
+      expect(chunks.first.first.reasoning, 'first thought');
+      expect(chunks.last.first.isText, isTrue);
+      expect(reasoningOf(response), 'first thought');
+      expect(response.text, 'the answer');
+    });
+  });
+}


### PR DESCRIPTION
Adds `reasoningEffort` and `verbosity` to `OpenAIChatOptions` and wires both into the request.

Which levels a model takes moves with the generation — `minimal` came with GPT-5, `none` replaced it in GPT-5.1, `xhigh` later — so every level is offered to every reasoning model and OpenAI decides whether the pair makes sense. The set itself is fixed by `openai_dart`, which models the parameter as an enum; a level OpenAI ships after this release needs an SDK bump to reach.

What is curated is a `reasons` flag on `KnownOpenAIModel`. Sending an effort to `gpt-4o` is rejected before the request goes out, naming the model — OpenAI's own 400 says `Unsupported parameter: 'reasoning_effort'`, which doesn't tell you which half is wrong, and an effort set once in a shared config and then inherited by whatever model the call picks is the realistic way to hit it. The check follows `version` when set, since that is the model that actually answers. Skipped behind a custom `baseUrl`, same rule the rest of the catalog follows.

Also the response side, which the issue thread asked to bundle: `reasoning_content` and `reasoning` now become a `ReasoningPart` ahead of the answer, and stream as deltas instead of only landing in the final message. Worth knowing this is entirely a compat-backend path — OpenAI bills reasoning tokens and never returns the text; DeepSeek R1 and vLLM send one spelling, OpenRouter the other, and both are read.

`verbosity` gets no catalog gate. It is a GPT-5-family parameter, but nothing in the catalog says so, and asserting it per entry would be guessing at something less well documented than which models reason.

Closes #239.
