### PR TITLE
ci: pin GitHub action commit SHAs and set explicit permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,9 @@
 
 name: Commit Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
@@ -25,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -1,5 +1,8 @@
 name: Dart CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -16,10 +19,10 @@ jobs:
         sdk: ['3.10', dev]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Dart SDK
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:
           sdk: ${{ matrix.sdk }}
 
@@ -47,21 +50,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Dart SDK
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:
           sdk: '3.10'
 
       - name: Set up Java (required by the Firestore emulator)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@de7274f081f381c8f8158605e0321c36c376e2e6 # v6.0.1
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -1,5 +1,8 @@
 name: Docs CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -13,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Dart SDK
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:
           sdk: 'stable'
 

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,5 +1,8 @@
 name: Flutter CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -14,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: 'stable'
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,8 @@
 name: Format
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -10,9 +13,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
@@ -21,7 +24,7 @@ jobs:
 
       # Using Flutter here because we need to run `flutter pub upgrade` in some packages.
       # This is a bit annoying, but it's the easiest way to handle the mixed nature of the workspace.
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: 'stable'
           cache: true

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,5 +1,8 @@
 name: License Compliance
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]
@@ -8,9 +11,9 @@ jobs:
   check-license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Check License Headers
-        uses: genkit-ai/repo-workflows/license-checker@main
+        uses: genkit-ai/repo-workflows/license-checker@8f5bdcf7affaa49e3adeea46bff05e52736568ce # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,5 +1,8 @@
 name: Version bump
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -23,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GENKIT_RELEASER_GITHUB_TOKEN }}
           fetch-depth: 0 # Required for git describe and git log
 
       - name: Set up Dart SDK
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:
           sdk: stable
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -42,15 +42,19 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Run version bump script
+        env:
+          INPUT_RC: ${{ inputs.rc }}
+          INPUT_GRADUATE: ${{ inputs.graduate }}
+          INPUT_DRY_RUN: ${{ inputs.dry-run }}
         run: |
           args=()
-          if [ -n "${{ inputs.rc }}" ]; then
-            args+=("--rc" "${{ inputs.rc }}")
+          if [ -n "$INPUT_RC" ]; then
+            args+=("--rc" "$INPUT_RC")
           fi
-          if [ "${{ inputs.graduate }}" = "true" ]; then
+          if [ "$INPUT_GRADUATE" = "true" ]; then
             args+=("--graduate")
           fi
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
+          if [ "$INPUT_DRY_RUN" = "true" ]; then
             args+=("--dry-run")
           fi
           dart run tools/version.dart "${args[@]}"


### PR DESCRIPTION
Upgrade all GitHub Actions across workflows to their latest stable releases, pin them to full 40-character commit SHAs, and add explicit top-level permissions blocks to satisfy zizmor security checks.

- Upgrade `actions/checkout` to `v7.0.1` (`3d3c42e5aac5ba805825da76410c181273ba90b1`)
- Upgrade `dart-lang/setup-dart` to `v1.8.1` (`6afc89df92d6eb3834022f73cd65adc8cdfcb92d`)
- Upgrade `actions/setup-java` to `v6.0.1` (`de7274f081f381c8f8158605e0321c36c376e2e6`)
- Upgrade `actions/setup-node` to `v7.0.0` (`820762786026740c76f36085b0efc47a31fe5020`)
- Upgrade `actions/cache` to `v6.1.0` (`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`)
- Upgrade `subosito/flutter-action` to `v2.23.0` (`1a449444c387b1966244ae4d4f8c696479add0b2`)
- Pin `genkit-ai/repo-workflows/license-checker` to latest `main` commit SHA (`8f5bdcf7affaa49e3adeea46bff05e52736568ce`)
- Add explicit top-level permissions (`contents: read` or `contents: write`) to all 7 workflow files